### PR TITLE
Supervise Colima process groups

### DIFF
--- a/cmd/workcell-hostutil/main.go
+++ b/cmd/workcell-hostutil/main.go
@@ -519,6 +519,9 @@ func parseColimaInvocationArgs(args []string) (int, launcher.HostColimaInvocatio
 	if err != nil {
 		return 0, launcher.HostColimaInvocation{}, nil, fmt.Errorf("parse timeout seconds: %w", err)
 	}
+	if timeoutSeconds > launcher.MaxColimaTimeoutSeconds {
+		return 0, launcher.HostColimaInvocation{}, nil, fmt.Errorf("timeout seconds must not exceed %d", launcher.MaxColimaTimeoutSeconds)
+	}
 	rest := args[1:]
 	inv := launcher.HostColimaInvocation{
 		ColimaBin:  os.Getenv("HOST_COLIMA_BIN"),

--- a/cmd/workcell-hostutil/main_test.go
+++ b/cmd/workcell-hostutil/main_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -552,6 +553,151 @@ func TestHelperInputLimit(t *testing.T) {
 		}
 	}
 }
+
+func TestParseColimaInvocationCapsTimeout(t *testing.T) {
+	seconds, _, _, err := parseColimaInvocationArgs([]string{"86400", "--", "start"})
+	if err != nil || seconds != 86400 {
+		t.Fatalf("parse exact timeout = %d, %v", seconds, err)
+	}
+	if _, _, _, err := parseColimaInvocationArgs([]string{"86401", "--", "start"}); err == nil {
+		t.Fatal("parseColimaInvocationArgs accepted more than 24 hours")
+	}
+}
+
+func TestManagedColimaSignalSourceRejectsMutants(t *testing.T) {
+	workcell := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "workcell"))
+	invariants := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "verify-invariants.sh"))
+	supervisor := mustReadTestFile(t, filepath.Join("..", "..", "internal", "host", "launcher", "process_group_supervisor.go"))
+	if err := validateManagedColimaSignalSource(workcell, invariants, supervisor); err != nil {
+		t.Fatal(err)
+	}
+	mutants := map[string]string{
+		"shell recursive kill": workcell + "\nterminate_process_tree_by_pid() { :; }\n",
+		"direct shell start":   strings.Replace(workcell, "run_host_colima_with_timeout \"${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}\" start", "run_host_colima start", 1),
+		"missing start gate":   strings.Replace(workcell, "    case \"${start_status}\" in\n      130 | 143)\n        return \"${start_status}\"\n        ;;\n    esac", "", 1),
+		"missing delete gate":  strings.Replace(workcell, "  case \"${delete_status}\" in\n    130 | 143)\n      return \"${delete_status}\"\n      ;;\n  esac", "", 1),
+		"missing retry gate":   strings.Replace(workcell, "        case \"${build_status}\" in\n          130 | 143)\n            return \"${build_status}\"\n            ;;\n        esac", "", 1),
+		"missing build gate":   strings.Replace(workcell, "    case \"${build_status}\" in\n      130 | 143)\n        return \"${build_status}\"\n        ;;\n    esac", "", 1),
+		"normalized refresh":   strings.Replace(workcell, "refresh_managed_profile \"Refreshing managed Colima profile ${COLIMA_PROFILE} after Colima start timed out.\" || return $?", "refresh_managed_profile \"Refreshing managed Colima profile ${COLIMA_PROFILE} after Colima start timed out.\" || return 2", 1),
+	}
+	for name, mutant := range mutants {
+		t.Run(name, func(t *testing.T) {
+			if mutant == workcell {
+				t.Fatal("mutant did not change source")
+			}
+			if err := validateManagedColimaSignalSource(mutant, invariants, supervisor); err == nil {
+				t.Fatal("mutant passed source validation")
+			}
+			if strings.HasPrefix(name, "missing ") || name == "normalized refresh" {
+				runManagedColimaSignalFixture(t, mutant, true)
+			}
+		})
+	}
+}
+
+func validateManagedColimaSignalSource(workcell, invariants, supervisor string) error {
+	for _, required := range []string{
+		"run_host_colima_with_timeout \"${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}\" start",
+		"case \"${start_status}\" in\n      130 | 143)\n        return \"${start_status}\"",
+		"case \"${delete_status}\" in\n    130 | 143)\n      return \"${delete_status}\"",
+		"case \"${build_status}\" in\n          130 | 143)\n            return \"${build_status}\"",
+		"case \"${build_status}\" in\n      130 | 143)\n        return \"${build_status}\"",
+		"run_runtime_image_build_with_retries \"${BUILD_SOURCE_DATE_EPOCH}\" || BUILD_STATUS=$?\n  if [[ \"${BUILD_STATUS}\" -ne 0 ]]; then\n    restore_runtime_egress\n    exit \"${BUILD_STATUS}\"",
+		"make(chan error, 1)", "Setpgid = true", "syscall.SIGTERM", "syscall.SIGKILL",
+	} {
+		if !strings.Contains(workcell+supervisor, required) {
+			return fmt.Errorf("managed Colima source lacks %q", required)
+		}
+	}
+	if strings.Contains(workcell+invariants, "kill_process_tree_by_pid") || strings.Contains(workcell+invariants, "terminate_process_tree_by_pid") {
+		return fmt.Errorf("recursive shell process killer remains")
+	}
+	returns, exits := 0, 0
+	for _, line := range strings.Split(workcell, "\n") {
+		if !strings.Contains(line, "refresh_managed_profile \"") {
+			continue
+		}
+		if strings.HasSuffix(line, " || return $?") {
+			returns++
+		} else if strings.HasSuffix(line, " || exit $?") {
+			exits++
+		} else {
+			return fmt.Errorf("refresh call does not preserve status: %s", line)
+		}
+	}
+	if returns != 5 || exits != 4 || strings.Count(workcell, "start_managed_profile || build_status=$?") != 2 {
+		return fmt.Errorf("managed status sinks = %d returns, %d exits", returns, exits)
+	}
+	return nil
+}
+
+func TestManagedColimaSignalCallerOutcomes(t *testing.T) {
+	runManagedColimaSignalFixture(t, mustReadTestFile(t, filepath.Join("..", "..", "scripts", "workcell")), false)
+}
+
+func runManagedColimaSignalFixture(t *testing.T, workcell string, wantFailure bool) {
+	t.Helper()
+	functions := "set -euo pipefail\n"
+	for _, name := range []string{"refresh_managed_profile", "start_managed_profile", "run_runtime_image_build_with_retries"} {
+		functions += extractBashFunction(t, workcell, name) + "\n"
+	}
+	script := functions + managedColimaSignalFixture
+	cmd := exec.Command("/bin/bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"WORKCELL_REFRESH_FUNCTION="+extractBashFunction(t, workcell, "refresh_managed_profile"),
+		"WORKCELL_START_FUNCTION="+extractBashFunction(t, workcell, "start_managed_profile"),
+	)
+	output, err := cmd.CombinedOutput()
+	if wantFailure == (err == nil) {
+		t.Fatalf("signal fixture err = %v, output = %q", err, output)
+	}
+}
+
+func extractBashFunction(t *testing.T, source, name string) string {
+	t.Helper()
+	start := strings.Index(source, "\n"+name+"() {\n")
+	if start < 0 {
+		t.Fatalf("function %s not found", name)
+	}
+	block := source[start+1:]
+	end := strings.Index(block, "\n}\n")
+	if end < 0 {
+		t.Fatalf("function %s has no end", name)
+	}
+	return block[:end+2]
+}
+
+const managedColimaSignalFixture = `
+COLIMA_PROFILE=p; REAL_HOME=/tmp; WORKSPACE=/tmp/w; PROFILE_WORKSPACE_ROOT=/tmp/w
+COLIMA_CPU=1; COLIMA_MEMORY=1; COLIMA_DISK=1; TARGET_BACKEND=colima; NETWORK_POLICY=disabled; BOOTSTRAP_ENDPOINTS=""; SOURCE_DATE_EPOCH=1; IMAGE_TAG=i; ROOT_DIR=/tmp
+prepare_colima_staging_cache_roots(){ :; }; maybe_reap_stale_profile_processes(){ :; }; reap_stale_profile_processes(){ REAP=$((REAP+1)); [[ "${REAP_FAIL_AT:-0}" -ne "${REAP}" ]]; }
+colima_start_hit_recoverable_docker_boot_race(){ return 0; }; resolve_codex_release_url(){ :; }; resolve_copilot_release_url(){ :; }; validate_colima_profile(){ :; }
+validate_runtime_security_posture(){ :; }; record_validated_profile_state(){ :; }; begin_runtime_builder(){ BUILDX_BUILDER=b; }; create_runtime_builder(){ :; }
+cleanup_runtime_builder(){ CLEAN=$((CLEAN+1)); }; buildx_cmd(){ :; }; remember_profile_runtime_image_for_refresh(){ :; }; stash_profile_audit_log(){ :; }
+remove_profile_state_dirs(){ REMOVE=$((REMOVE+1)); }; profile_process_pids(){ [[ "${RESIDUE:-}" == pid ]] && echo 1; }; profile_state_dirs_exist(){ [[ "${RESIDUE:-}" == state ]]; }
+assert(){ [[ "$1" == "$2" ]] || { printf 'assert:%s != %s\n' "$1" "$2" >&2; exit 97; }; }
+for SIGNAL in 130 143; do
+  eval "${WORKCELL_START_FUNCTION}"
+  RUN=0; REFRESH=0; REAP=0; PROFILE_RUNNING=0
+  run_command_with_debug_log(){ RUN=$((RUN+1)); return "${SIGNAL}"; }; refresh_managed_profile(){ REFRESH=$((REFRESH+1)); :; }
+  status=0; start_managed_profile || status=$?; assert "${status},${RUN},${REFRESH}" "${SIGNAL},1,0"
+  RUN=0; REFRESH=0; run_command_with_debug_log(){ RUN=$((RUN+1)); return 124; }; refresh_managed_profile(){ REFRESH=$((REFRESH+1)); return "${SIGNAL}"; }
+  status=0; start_managed_profile || status=$?; assert "${status},${RUN},${REFRESH}" "${SIGNAL},1,1"
+  BUILD=0; CLEAN=0; SLEEP=0; REFRESH=0; run_command_with_debug_log(){ BUILD=$((BUILD+1)); return "${SIGNAL}"; }; sleep(){ SLEEP=$((SLEEP+1)); }
+  status=0; run_runtime_image_build_with_retries 1 || status=$?; assert "${status},${BUILD},${CLEAN},${SLEEP},${REFRESH}" "${SIGNAL},1,1,0,0"
+  BUILD=0; CLEAN=0; SLEEP=0; REFRESH=0; START=0; run_command_with_debug_log(){ BUILD=$((BUILD+1)); return 37; }
+  refresh_managed_profile(){ REFRESH=$((REFRESH+1)); :; }; start_managed_profile(){ START=$((START+1)); return "${SIGNAL}"; }
+  status=0; run_runtime_image_build_with_retries 1 || status=$?; assert "${status},${BUILD},${CLEAN},${SLEEP},${REFRESH},${START}" "${SIGNAL},1,1,1,1,1"
+  eval "${WORKCELL_REFRESH_FUNCTION}"
+  REAP=0; REMOVE=0; DELETE=0; RESIDUE=""; PROFILE_WAS_REFRESHED=0; run_host_colima_with_timeout(){ DELETE=$((DELETE+1)); return "${SIGNAL}"; }
+  status=0; refresh_managed_profile x || status=$?; assert "${status},${DELETE},${REAP},${REMOVE},${PROFILE_WAS_REFRESHED}" "${SIGNAL},1,1,0,0"
+done
+run_host_colima_with_timeout(){ :; }
+for MODE in first second pid state; do
+  REAP=0; REMOVE=0; RESIDUE=""; REAP_FAIL_AT=0; [[ "${MODE}" == first ]] && REAP_FAIL_AT=1; [[ "${MODE}" == second ]] && REAP_FAIL_AT=2; [[ "${MODE}" == pid ]] && RESIDUE=pid; [[ "${MODE}" == state ]] && RESIDUE=state
+  status=0; refresh_managed_profile x || status=$?; assert "${status}" 2
+done
+`
 
 func TestHostInputSourceContractRejectsMutants(t *testing.T) {
 	workcell := mustReadTestFile(t, filepath.Join("..", "..", "scripts", "workcell"))

--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -201,6 +201,24 @@ The launcher publishes a profile status only after the inventory producer and pa
 Workcell accepts only an absolute path for the selected Colima executable.
 Runtime DNS resolution uses a five-second deadline. The resolver cancels the lookup context when resolution finishes.
 
+### Colima timeout controls
+
+A positive managed Colima start or delete timeout cannot exceed 24 hours.
+For a positive timeout, the host utility starts Colima in a dedicated process group.
+The host utility handles `SIGINT` and `SIGTERM` that it receives directly.
+
+Cancellation sends `SIGTERM` when the process group exists. The host utility then polls for group absence.
+It sends `SIGKILL` if the group remains. It polls again and fails if the group remains.
+
+After successful deadline cleanup, the host utility returns status `124`.
+After successful signal cleanup, it returns status `130` for `SIGINT` and `143` for `SIGTERM`.
+Cancellation before process start returns the matching status without group cleanup.
+The host utility preserves ordinary exit statuses and unrelated signal statuses.
+It reports start, input/output, and cleanup errors.
+
+The launcher stops managed start and image-build retries after status `130` or `143`.
+A profile refresh preserves these statuses from its managed delete.
+
 The publication function is a deliberate host-side exception. It can receive
 the ambient operator publication and signing environment. The Tier 1 runtime
 does not receive this ambient state. Reviewed injection can stage selected

--- a/internal/host/launcher/colima.go
+++ b/internal/host/launcher/colima.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -18,7 +19,10 @@ import (
 // ColimaTimeoutExitCode mirrors GNU coreutils `timeout`'s exit code for a
 // process that was killed because its deadline elapsed.  Bash callers
 // rely on this value to distinguish a timeout from a colima failure.
-const ColimaTimeoutExitCode = 124
+const (
+	ColimaTimeoutExitCode   = 124
+	MaxColimaTimeoutSeconds = 24 * 60 * 60
+)
 
 // HostColimaInvocation captures the environment used to invoke a
 // trusted host `colima` binary on behalf of scripts/workcell.  The
@@ -60,10 +64,13 @@ func RunHostColima(inv HostColimaInvocation) (int, error) {
 
 // RunHostColimaWithTimeout invokes the trusted colima binary with a
 // deadline.  When timeoutSeconds is zero or negative the call falls
-// through to RunHostColima with no timeout.  On timeout the function
-// returns ColimaTimeoutExitCode (124) after killing the colima process
-// group, matching the bash run_host_colima_with_timeout helper.
+// through to RunHostColima with no timeout.  On timeout, SIGINT, or
+// SIGTERM the function returns 124, 130, or 143 respectively.  If the
+// process starts, it first terminates and proves its group absent.
 func RunHostColimaWithTimeout(timeoutSeconds int, inv HostColimaInvocation) (int, error) {
+	if timeoutSeconds > MaxColimaTimeoutSeconds {
+		return 0, fmt.Errorf("RunHostColimaWithTimeout: timeout must not exceed %d seconds", MaxColimaTimeoutSeconds)
+	}
 	if len(inv.Args) == 0 {
 		return 0, nil
 	}
@@ -74,27 +81,51 @@ func RunHostColimaWithTimeout(timeoutSeconds int, inv HostColimaInvocation) (int
 		return 0, fmt.Errorf("RunHostColimaWithTimeout: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
+	deadlineCtx, cancelDeadline := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
+	defer cancelDeadline()
+	ctx, stopSignals := colimaSignalContext(deadlineCtx)
+	defer stopSignals()
+	return runHostColimaWithContext(ctx, inv)
+}
 
+type colimaSignalCancellation struct {
+	signal os.Signal
+}
+
+func (c *colimaSignalCancellation) Error() string {
+	return fmt.Sprintf("received %s", c.signal)
+}
+
+func colimaSignalContext(parent context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancelCause(parent)
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case received := <-signals:
+			cancel(&colimaSignalCancellation{signal: received})
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, func() {
+		signal.Stop(signals)
+		cancel(context.Canceled)
+		<-done
+	}
+}
+
+func runHostColimaWithContext(ctx context.Context, inv HostColimaInvocation) (int, error) {
 	cmd, err := newColimaCommand(ctx, inv)
 	if err != nil {
 		return 0, err
 	}
-	// Place the child in its own process group so we can deliver
-	// SIGKILL to the whole tree on timeout (mirroring the bash
-	// helper's kill_process_tree_by_pid behaviour).
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return killColimaProcessGroup(cmd)
+	result := defaultProcessGroupSupervisor().run(ctx, cmd)
+	if result.cleanupRan || result.preStartCanceled {
+		return colimaCancellationResult(result.runErr, result.cleanupErr, result.cause)
 	}
-	cmd.WaitDelay = 5 * time.Second
-
-	code, runErr := runColimaCommand(cmd)
-	if ctx.Err() == context.DeadlineExceeded {
-		return ColimaTimeoutExitCode, nil
-	}
-	return code, runErr
+	return colimaRunResult(result.runErr)
 }
 
 // ValidateColimaStatusOutput checks that the textual output of
@@ -167,7 +198,10 @@ func colimaChildEnv(inv HostColimaInvocation) []string {
 }
 
 func runColimaCommand(cmd *exec.Cmd) (int, error) {
-	err := cmd.Run()
+	return colimaRunResult(cmd.Run())
+}
+
+func colimaRunResult(err error) (int, error) {
 	if err == nil {
 		return 0, nil
 	}
@@ -176,6 +210,49 @@ func runColimaCommand(cmd *exec.Cmd) (int, error) {
 		return colimaExitCode(exitErr), nil
 	}
 	return 0, fmt.Errorf("colima invocation failed: %w", err)
+}
+
+func colimaCancellationResult(runErr, cleanupErr, cause error) (int, error) {
+	if cleanupErr != nil {
+		cleanupErr = fmt.Errorf("colima process-group cleanup failed: %w", cleanupErr)
+		causeErr := fmt.Errorf("colima cancellation cause: %w", cause)
+		if runErr != nil {
+			return 0, errors.Join(fmt.Errorf("colima invocation failed: %w", runErr), cleanupErr, causeErr)
+		}
+		return 0, errors.Join(cleanupErr, causeErr)
+	}
+	if expectedColimaCancellationError(runErr) {
+		return colimaCancellationExitCode(cause)
+	}
+	return colimaRunResult(runErr)
+}
+
+func colimaCancellationExitCode(cause error) (int, error) {
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return ColimaTimeoutExitCode, nil
+	}
+	var signalCause *colimaSignalCancellation
+	if errors.As(cause, &signalCause) {
+		switch signalCause.signal {
+		case os.Interrupt:
+			return 128 + int(syscall.SIGINT), nil
+		case syscall.SIGTERM:
+			return 128 + int(syscall.SIGTERM), nil
+		}
+	}
+	return 0, fmt.Errorf("colima cancellation has unexpected cause: %w", cause)
+}
+
+func expectedColimaCancellationError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && (status.Signal() == syscall.SIGTERM || status.Signal() == syscall.SIGKILL)
 }
 
 func colimaExitCode(exitErr *exec.ExitError) int {
@@ -194,20 +271,6 @@ func validateColimaBinary(path string) error {
 	}
 	if !filepath.IsAbs(path) {
 		return errors.New("colima binary path must be absolute")
-	}
-	return nil
-}
-
-func killColimaProcessGroup(cmd *exec.Cmd) error {
-	if cmd == nil || cmd.Process == nil {
-		return nil
-	}
-	pid := cmd.Process.Pid
-	// Negative pid targets the whole process group.  Ignore the
-	// "no such process" error that arises if the child already exited
-	// between the deadline firing and our kill call.
-	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
-		return err
 	}
 	return nil
 }

--- a/internal/host/launcher/colima_test.go
+++ b/internal/host/launcher/colima_test.go
@@ -4,9 +4,14 @@
 package launcher
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -197,16 +202,36 @@ func TestRunHostColimaWithTimeoutNoTimeoutDelegates(t *testing.T) {
 	fake := writeFakeColima(t, dir, `#!/bin/sh
 exit 11
 `)
-	code, err := RunHostColimaWithTimeout(0, HostColimaInvocation{
-		ColimaBin: fake,
-		RealHome:  dir,
+	for _, timeout := range []int{0, -1} {
+		code, err := RunHostColimaWithTimeout(timeout, HostColimaInvocation{
+			ColimaBin: fake,
+			RealHome:  dir,
+			Args:      []string{"list"},
+		})
+		if err != nil {
+			t.Fatalf("RunHostColimaWithTimeout(%d) err = %v", timeout, err)
+		}
+		if code != 11 {
+			t.Fatalf("RunHostColimaWithTimeout(%d) code = %d, want 11", timeout, code)
+		}
+	}
+}
+
+func TestRunHostColimaWithTimeoutCapsPositiveTimeout(t *testing.T) {
+	t.Parallel()
+	code, err := RunHostColimaWithTimeout(86400, HostColimaInvocation{
+		ColimaBin: "/usr/bin/true",
 		Args:      []string{"list"},
 	})
-	if err != nil {
-		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
+	if err != nil || code != 0 {
+		t.Fatalf("RunHostColimaWithTimeout(86400) = %d, %v", code, err)
 	}
-	if code != 11 {
-		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 11", code)
+	_, err = RunHostColimaWithTimeout(86401, HostColimaInvocation{
+		ColimaBin: "/usr/bin/true",
+		Args:      []string{"list"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must not exceed 86400 seconds") {
+		t.Fatalf("RunHostColimaWithTimeout(86401) err = %v", err)
 	}
 }
 
@@ -215,26 +240,257 @@ func TestRunHostColimaWithTimeoutKillsRunawayChild(t *testing.T) {
 		t.Skip("relies on POSIX /bin/sh helpers")
 	}
 	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
-	dir := t.TempDir()
-	fake := writeFakeColima(t, dir, `#!/bin/sh
-# Sleep well past the test deadline to force the timeout path.
-sleep 30
-exit 0
+	for _, tc := range []struct {
+		name   string
+		setup  string
+		minRun time.Duration
+		maxRun time.Duration
+	}{
+		{"TERM-responsive", ":", 0, 4 * time.Second},
+		{"TERM-resistant", "trap '' TERM", 4750 * time.Millisecond, 10 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			marker := filepath.Join(dir, "processes")
+			groupID := registerProcessGroupCleanup(t, marker)
+			fake := writeFakeColima(t, dir, "#!/bin/sh\n"+tc.setup+`
+sh -c "`+tc.setup+`; while :; do sleep 1; done" &
+child=$!
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+printf '%s %s\n' "$pgid" "$child" >"$2"
+wait "$child"
 `)
-	start := time.Now()
-	code, err := RunHostColimaWithTimeout(1, HostColimaInvocation{
-		ColimaBin: fake,
-		RealHome:  dir,
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(context.Canceled)
+			go cancelWhenProcessMarkerReady(ctx, func() { cancel(context.DeadlineExceeded) }, marker)
+			start := time.Now()
+			code, err := runHostColimaWithContext(ctx, HostColimaInvocation{
+				ColimaBin: fake,
+				RealHome:  dir,
+				Args:      []string{"start", marker},
+			})
+			if err != nil || code != ColimaTimeoutExitCode {
+				t.Fatalf("runHostColimaWithContext() = %d, %v", code, err)
+			}
+			if elapsed := time.Since(start); elapsed < tc.minRun || elapsed > tc.maxRun {
+				t.Fatalf("process-group cleanup completed in %s", elapsed)
+			}
+			fields := strings.Fields(string(mustReadFile(t, marker)))
+			if len(fields) != 2 {
+				t.Fatalf("process marker = %q", fields)
+			}
+			parsedGroupID, err := strconv.Atoi(fields[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			*groupID = parsedGroupID
+			if err := syscall.Kill(-*groupID, 0); !errors.Is(err, syscall.ESRCH) {
+				t.Fatalf("process group %d still exists: %v", *groupID, err)
+			}
+			*groupID = -1
+		})
+	}
+}
+
+func TestRunHostColimaWithTimeoutHandlesDirectHelperSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX process-group and signal semantics")
+	}
+	if os.Getenv("WORKCELL_COLIMA_SIGNAL_HELPER") == "1" {
+		code, err := RunHostColimaWithTimeout(30, HostColimaInvocation{
+			ColimaBin: os.Getenv("WORKCELL_COLIMA_SIGNAL_BIN"),
+			RealHome:  os.Getenv("WORKCELL_COLIMA_SIGNAL_HOME"),
+			Args: []string{
+				"start",
+				os.Getenv("WORKCELL_COLIMA_SIGNAL_PROCESS_MARKER"),
+				os.Getenv("WORKCELL_COLIMA_SIGNAL_TERM_MARKER"),
+			},
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(125)
+		}
+		os.Exit(code)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		signal   os.Signal
+		wantCode int
+	}{
+		{"SIGINT", os.Interrupt, 128 + int(syscall.SIGINT)},
+		{"SIGTERM", syscall.SIGTERM, 128 + int(syscall.SIGTERM)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			processMarker := filepath.Join(dir, "processes")
+			termMarker := filepath.Join(dir, "term")
+			fake := writeFakeColima(t, dir, `#!/bin/sh
+trap 'printf "TERM\n" >"$3"; while :; do sleep 1; done' TERM
+sh -c 'trap "" TERM; while :; do sleep 1; done' &
+child=$!
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+printf '%s %s\n' "$pgid" "$child" >"$2"
+while kill -0 "$child" 2>/dev/null; do
+  wait "$child" || true
+done
+`)
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRunHostColimaWithTimeoutHandlesDirectHelperSignals$")
+			cmd.Env = append(os.Environ(),
+				"WORKCELL_COLIMA_SIGNAL_HELPER=1",
+				"WORKCELL_COLIMA_SIGNAL_BIN="+fake,
+				"WORKCELL_COLIMA_SIGNAL_HOME="+dir,
+				"WORKCELL_COLIMA_SIGNAL_PROCESS_MARKER="+processMarker,
+				"WORKCELL_COLIMA_SIGNAL_TERM_MARKER="+termMarker,
+			)
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			waited := false
+			groupID := registerProcessGroupCleanup(t, processMarker)
+			t.Cleanup(func() {
+				if !waited {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+				}
+			})
+
+			fields := pollProcessMarker(processMarker, 5*time.Second)
+			if len(fields) != 2 {
+				t.Fatalf("process marker %s was not ready", processMarker)
+			}
+			var err error
+			*groupID, err = strconv.Atoi(fields[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			startedCleanup := time.Now()
+			if err := cmd.Process.Signal(tc.signal); err != nil {
+				t.Fatal(err)
+			}
+			err = cmd.Wait()
+			waited = true
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != tc.wantCode {
+				t.Fatalf("signal helper wait = %v, want status %d", err, tc.wantCode)
+			}
+			if elapsed := time.Since(startedCleanup); elapsed < 4750*time.Millisecond || elapsed > 10*time.Second {
+				t.Fatalf("signal cleanup completed in %s", elapsed)
+			}
+			if got := strings.TrimSpace(string(mustReadFile(t, termMarker))); got != "TERM" {
+				t.Fatalf("TERM marker = %q, want TERM", got)
+			}
+			if err := syscall.Kill(-*groupID, 0); !errors.Is(err, syscall.ESRCH) {
+				t.Fatalf("process group %d still exists: %v", *groupID, err)
+			}
+			*groupID = -1
+		})
+	}
+}
+
+func TestRunHostColimaWithContextPreservesPreStartCancellationCause(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		newContext func() (context.Context, context.CancelFunc)
+		wantCode   int
+	}{
+		{
+			"deadline",
+			func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Unix(1, 0))
+			},
+			ColimaTimeoutExitCode,
+		},
+		{
+			"SIGINT",
+			func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancelCause(context.Background())
+				cancel(&colimaSignalCancellation{signal: os.Interrupt})
+				return ctx, func() { cancel(context.Canceled) }
+			},
+			128 + int(syscall.SIGINT),
+		},
+		{
+			"SIGTERM",
+			func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancelCause(context.Background())
+				cancel(&colimaSignalCancellation{signal: syscall.SIGTERM})
+				return ctx, func() { cancel(context.Canceled) }
+			},
+			128 + int(syscall.SIGTERM),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.newContext()
+			defer cancel()
+			code, err := runHostColimaWithContext(ctx, HostColimaInvocation{
+				ColimaBin: "/usr/bin/true",
+				Args:      []string{"start"},
+			})
+			if err != nil || code != tc.wantCode {
+				t.Fatalf("runHostColimaWithContext() = %d, %v, want %d", code, err, tc.wantCode)
+			}
+		})
+	}
+
+	code, err := runHostColimaWithContext(context.Background(), HostColimaInvocation{
+		ColimaBin: "/workcell-missing-colima-binary",
 		Args:      []string{"start"},
 	})
-	if err != nil {
-		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
+	if code != 0 || err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unrelated start error = %d, %v", code, err)
 	}
-	if code != ColimaTimeoutExitCode {
-		t.Fatalf("RunHostColimaWithTimeout() code = %d, want %d", code, ColimaTimeoutExitCode)
-	}
-	if elapsed := time.Since(start); elapsed > 10*time.Second {
-		t.Fatalf("RunHostColimaWithTimeout() took %s, expected to honour 1s deadline", elapsed)
+}
+
+func TestColimaCancellationResultPreservesOutcomes(t *testing.T) {
+	termErr := processSignalError(t, syscall.SIGTERM)
+	killErr := processSignalError(t, syscall.SIGKILL)
+	interruptErr := processSignalError(t, syscall.SIGINT)
+	exitErr := exec.Command("/bin/sh", "-c", "exit 7").Run()
+	exit124Err := exec.Command("/bin/sh", "-c", "exit 124").Run()
+	ioErr := errors.New("write failed")
+	cleanupErr := errors.New("group remains")
+	interruptCause := &colimaSignalCancellation{signal: os.Interrupt}
+	for _, tc := range []struct {
+		name       string
+		runErr     error
+		cleanupErr error
+		cause      error
+		wantCode   int
+		wantErrors []error
+		wantSignal bool
+	}{
+		{"nil after deadline", nil, nil, context.DeadlineExceeded, 124, nil, false},
+		{"deadline error", context.DeadlineExceeded, nil, context.DeadlineExceeded, 124, nil, false},
+		{"TERM after deadline", termErr, nil, context.DeadlineExceeded, 124, nil, false},
+		{"context canceled after SIGINT", context.Canceled, nil, interruptCause, 130, nil, false},
+		{"KILL after SIGINT", killErr, nil, interruptCause, 130, nil, false},
+		{"TERM after SIGTERM", termErr, nil, &colimaSignalCancellation{signal: syscall.SIGTERM}, 143, nil, false},
+		{"ordinary exit 7", exitErr, nil, interruptCause, 7, nil, false},
+		{"ordinary exit 124", exit124Err, nil, interruptCause, 124, nil, false},
+		{"unrelated SIGINT", interruptErr, nil, context.DeadlineExceeded, 128 + int(syscall.SIGINT), nil, false},
+		{"I/O error", ioErr, nil, context.DeadlineExceeded, 0, []error{ioErr}, false},
+		{"cleanup after SIGINT", termErr, cleanupErr, interruptCause, 0, []error{termErr, cleanupErr, interruptCause}, true},
+		{"cleanup after deadline", termErr, cleanupErr, context.DeadlineExceeded, 0, []error{termErr, cleanupErr, context.DeadlineExceeded}, false},
+		{"unknown cause", termErr, nil, context.Canceled, 0, []error{context.Canceled}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := colimaCancellationResult(tc.runErr, tc.cleanupErr, tc.cause)
+			if code != tc.wantCode || (len(tc.wantErrors) == 0 && err != nil) {
+				t.Fatalf("colimaCancellationResult() = %d, %v", code, err)
+			}
+			for _, wantErr := range tc.wantErrors {
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("colimaCancellationResult() err = %v, want %v", err, wantErr)
+				}
+			}
+			if tc.wantSignal {
+				var signalCause *colimaSignalCancellation
+				if !errors.As(err, &signalCause) || signalCause.signal != os.Interrupt {
+					t.Fatalf("colimaCancellationResult() err = %v, want SIGINT cause", err)
+				}
+			}
+		})
 	}
 }
 
@@ -258,6 +514,19 @@ exit 0
 	if code != 0 {
 		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 0", code)
 	}
+	runaway := writeFakeColima(t, dir, "#!/bin/sh\nsleep 30\n")
+	start := time.Now()
+	code, err = RunHostColimaWithTimeout(1, HostColimaInvocation{
+		ColimaBin: runaway,
+		RealHome:  dir,
+		Args:      []string{"start"},
+	})
+	if err != nil || code != ColimaTimeoutExitCode {
+		t.Fatalf("RunHostColimaWithTimeout(runaway) = %d, %v", code, err)
+	}
+	if elapsed := time.Since(start); elapsed < 750*time.Millisecond || elapsed > 10*time.Second {
+		t.Fatalf("one-second timeout completed in %s", elapsed)
+	}
 }
 
 func writeFakeColima(t *testing.T, dir, script string) string {
@@ -270,4 +539,78 @@ func writeFakeColima(t *testing.T, dir, script string) string {
 		t.Fatalf("chmod fake colima: %v", err)
 	}
 	return path
+}
+
+func processSignalError(t *testing.T, signal syscall.Signal) error {
+	t.Helper()
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Process.Signal(signal); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.Wait()
+	if err == nil {
+		t.Fatalf("signal %s produced no error", signal)
+	}
+	return err
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func pollProcessMarker(path string, limit time.Duration) []string {
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil {
+			if fields := strings.Fields(string(data)); len(fields) == 2 {
+				return fields
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil
+}
+
+func registerProcessGroupCleanup(t *testing.T, marker string) *int {
+	t.Helper()
+	groupID := new(int)
+	t.Cleanup(func() {
+		if *groupID < 0 {
+			return
+		}
+		if *groupID == 0 {
+			if fields := pollProcessMarker(marker, 5*time.Second); len(fields) == 2 {
+				*groupID, _ = strconv.Atoi(fields[0])
+			}
+		}
+		if *groupID <= 0 {
+			return
+		}
+		if err := syscall.Kill(-*groupID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			t.Errorf("cleanup process group %d: %v", *groupID, err)
+		}
+		absent, err := waitForProcessGroupExit(*groupID, 5*time.Second)
+		if err != nil || !absent {
+			t.Errorf("cleanup did not prove process group %d absent: %v", *groupID, err)
+		}
+		*groupID = -1
+	})
+	return groupID
+}
+
+func cancelWhenProcessMarkerReady(ctx context.Context, cancel func(), path string) {
+	for ctx.Err() == nil {
+		if fields := pollProcessMarker(path, 25*time.Millisecond); len(fields) == 2 {
+			cancel()
+			return
+		}
+	}
 }

--- a/internal/host/launcher/process_group_supervisor.go
+++ b/internal/host/launcher/process_group_supervisor.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const (
+	processGroupTerminationGrace = 5 * time.Second
+	processGroupProofLimit       = 5 * time.Second
+	processGroupPollInterval     = 25 * time.Millisecond
+)
+
+type processGroupRunResult struct {
+	runErr           error
+	cleanupErr       error
+	cause            error
+	cleanupRan       bool
+	preStartCanceled bool
+}
+
+type processGroupSupervisor struct {
+	signalGroup func(int, syscall.Signal) error
+	waitAbsent  func(int, time.Duration) (bool, error)
+	termGrace   time.Duration
+	proofLimit  time.Duration
+}
+
+func defaultProcessGroupSupervisor() processGroupSupervisor {
+	return processGroupSupervisor{
+		signalGroup: signalProcessGroup,
+		waitAbsent:  waitForProcessGroupExit,
+		termGrace:   processGroupTerminationGrace,
+		proofLimit:  processGroupProofLimit,
+	}
+}
+
+func (s processGroupSupervisor) run(ctx context.Context, cmd *exec.Cmd) processGroupRunResult {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cleanupResult := make(chan error, 1)
+	cmd.Cancel = func() error {
+		err := s.terminate(cmd)
+		cleanupResult <- err
+		return err
+	}
+
+	runErr := cmd.Run()
+	result := processGroupRunResult{
+		runErr:           runErr,
+		cause:            context.Cause(ctx),
+		preStartCanceled: cmd.Process == nil && ctx.Err() != nil && errors.Is(runErr, ctx.Err()),
+	}
+	select {
+	case cleanupErr := <-cleanupResult:
+		result.cleanupErr = cleanupErr
+		result.cleanupRan = true
+	default:
+	}
+	return result
+}
+
+func (s processGroupSupervisor) terminate(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	groupID := cmd.Process.Pid
+	if err := s.signalGroup(groupID, syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal process group %d with SIGTERM: %w", groupID, err)
+	}
+	absent, err := s.waitAbsent(groupID, s.termGrace)
+	if err != nil {
+		return fmt.Errorf("poll process group %d after SIGTERM: %w", groupID, err)
+	}
+	if absent {
+		return nil
+	}
+	if err := s.signalGroup(groupID, syscall.SIGKILL); err != nil {
+		return fmt.Errorf("signal process group %d with SIGKILL: %w", groupID, err)
+	}
+	absent, err = s.waitAbsent(groupID, s.proofLimit)
+	if err != nil {
+		return fmt.Errorf("poll process group %d after SIGKILL: %w", groupID, err)
+	}
+	if !absent {
+		return fmt.Errorf("process group %d remains after SIGKILL", groupID)
+	}
+	return nil
+}
+
+func signalProcessGroup(groupID int, signal syscall.Signal) error {
+	if err := syscall.Kill(-groupID, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}
+
+func waitForProcessGroupExit(groupID int, limit time.Duration) (bool, error) {
+	return waitForProcessGroupExitWithProbe(groupID, limit, syscall.Kill, time.Now, time.Sleep)
+}
+
+func waitForProcessGroupExitWithProbe(
+	groupID int,
+	limit time.Duration,
+	probe func(int, syscall.Signal) error,
+	now func() time.Time,
+	sleep func(time.Duration),
+) (bool, error) {
+	deadline := now().Add(limit)
+	for {
+		err := probe(-groupID, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return true, nil
+		}
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			return false, err
+		}
+		if !now().Before(deadline) {
+			return false, nil
+		}
+		sleep(processGroupPollInterval)
+	}
+}

--- a/internal/host/launcher/process_group_supervisor_test.go
+++ b/internal/host/launcher/process_group_supervisor_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestProcessGroupSupervisorRunRetainsCancellationResult(t *testing.T) {
+	cause := errors.New("cancel fixture")
+	cleanupErr := errors.New("cleanup fixture")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	marker := filepath.Join(t.TempDir(), "ready")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `printf ready >"$1"; sleep 30`, "fixture", marker)
+	s := defaultProcessGroupSupervisor()
+	s.signalGroup = func(groupID int, signal syscall.Signal) error {
+		if err := signalProcessGroup(groupID, signal); err != nil {
+			return err
+		}
+		return cleanupErr
+	}
+	go func() {
+		for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
+			if _, err := os.Stat(marker); err == nil {
+				cancel(cause)
+				return
+			}
+		}
+		cancel(cause)
+	}()
+	result := s.run(ctx, cmd)
+	if !result.cleanupRan || result.preStartCanceled || !errors.Is(result.cleanupErr, cleanupErr) ||
+		!errors.Is(result.cause, cause) || result.runErr == nil {
+		t.Fatalf("run result = %+v", result)
+	}
+
+	preCtx, preCancel := context.WithCancelCause(context.Background())
+	preCancel(cause)
+	preResult := defaultProcessGroupSupervisor().run(preCtx, exec.CommandContext(preCtx, "/usr/bin/true"))
+	if !preResult.preStartCanceled || preResult.cleanupRan || !errors.Is(preResult.cause, cause) {
+		t.Fatalf("pre-start run result = %+v", preResult)
+	}
+}
+
+func TestProcessGroupSupervisorTerminate(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("fixture failure")
+	for _, tc := range []struct {
+		name       string
+		waits      []bool
+		signalFail int
+		waitFail   int
+		wantSignal []syscall.Signal
+		wantErr    error
+		wantText   string
+	}{
+		{name: "TERM is sufficient", waits: []bool{true}, wantSignal: []syscall.Signal{syscall.SIGTERM}},
+		{name: "escalates to KILL", waits: []bool{false, true}, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}},
+		{name: "TERM fails", signalFail: 1, wantSignal: []syscall.Signal{syscall.SIGTERM}, wantErr: sentinel},
+		{name: "TERM poll fails", waitFail: 1, wantSignal: []syscall.Signal{syscall.SIGTERM}, wantErr: sentinel},
+		{name: "KILL fails", waits: []bool{false}, signalFail: 2, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantErr: sentinel},
+		{name: "KILL poll fails", waits: []bool{false}, waitFail: 2, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantErr: sentinel},
+		{name: "group survives KILL", waits: []bool{false, false}, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantText: "remains after SIGKILL"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var signals []syscall.Signal
+			waitCall := 0
+			s := processGroupSupervisor{
+				signalGroup: func(_ int, signal syscall.Signal) error {
+					signals = append(signals, signal)
+					if len(signals) == tc.signalFail {
+						return sentinel
+					}
+					return nil
+				},
+				waitAbsent: func(_ int, _ time.Duration) (bool, error) {
+					waitCall++
+					if waitCall == tc.waitFail {
+						return false, sentinel
+					}
+					if waitCall <= len(tc.waits) {
+						return tc.waits[waitCall-1], nil
+					}
+					return false, nil
+				},
+				termGrace:  time.Second,
+				proofLimit: time.Second,
+			}
+			err := s.terminate(&exec.Cmd{Process: &os.Process{Pid: 4242}})
+			if !reflect.DeepEqual(signals, tc.wantSignal) {
+				t.Fatalf("signals = %v, want %v", signals, tc.wantSignal)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantText != "" && (err == nil || !strings.Contains(err.Error(), tc.wantText)) {
+				t.Fatalf("error = %v, want %q", err, tc.wantText)
+			}
+			if tc.wantErr == nil && tc.wantText == "" && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestWaitForProcessGroupExitTreatsEPERMAsPresent(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1, 0)
+	absent, err := waitForProcessGroupExitWithProbe(
+		42,
+		0,
+		func(pid int, signal syscall.Signal) error {
+			if pid != -42 || signal != 0 {
+				t.Fatalf("probe = (%d, %d)", pid, signal)
+			}
+			return syscall.EPERM
+		},
+		func() time.Time { return now },
+		func(time.Duration) { t.Fatal("unexpected sleep") },
+	)
+	if err != nil || absent {
+		t.Fatalf("waitForProcessGroupExitWithProbe() = %v, %v, want present", absent, err)
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "3ad0354f6b3506c15851e75edcb0885512e8440b7eee311c5dfbd69d744ef170"
+      "sha256": "b212cd612abf755e854a88d1e0280f812f6d7394228c7a5dd197619c9f0c3893"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -2766,10 +2766,6 @@ go_verify_citools workcell-managed-profile-staging "${ROOT_DIR}" || exit 1
 WORKCELL_COLIMA_TIMEOUT_HARNESS="${BARRIER_VERIFY_ROOT}/workcell-colima-timeout-harness.sh"
 {
   printf 'set -euo pipefail\n'
-  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" kill_process_tree_by_pid
-  printf '\n'
-  extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" terminate_process_tree_by_pid
-  printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/scripts/lib/launcher/go-hostutil.sh" run_go_hostutil_preserve_exit
   printf '\n'
   extract_top_level_bash_function "${ROOT_DIR}/scripts/workcell" run_host_colima_with_timeout

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -685,34 +685,6 @@ run_host_colima() {
   )
 }
 
-kill_process_tree_by_pid() {
-  local target_pid="$1"
-  local child_pid=""
-
-  [[ -n "${target_pid}" ]] || return 0
-  while IFS= read -r child_pid; do
-    [[ -n "${child_pid}" ]] || continue
-    kill_process_tree_by_pid "${child_pid}"
-  done < <(pgrep -P "${target_pid}" 2>/dev/null || true)
-  kill "${target_pid}" >/dev/null 2>&1 || true
-}
-
-terminate_process_tree_by_pid() {
-  local target_pid="$1"
-  local deadline=0
-
-  [[ -n "${target_pid}" ]] || return 0
-  kill_process_tree_by_pid "${target_pid}"
-  deadline=$((SECONDS + 5))
-  while kill -0 "${target_pid}" >/dev/null 2>&1; do
-    if ((SECONDS >= deadline)); then
-      kill -9 "${target_pid}" >/dev/null 2>&1 || true
-      break
-    fi
-    sleep 1
-  done
-}
-
 run_host_colima_with_timeout() {
   local timeout_seconds="$1"
   shift
@@ -820,23 +792,29 @@ maybe_reap_stale_profile_processes() {
 
 refresh_managed_profile() {
   local message="$1"
+  local delete_status=0
 
   echo "${message}" >&2
   PROFILE_VALIDATED=0
   remember_profile_runtime_image_for_refresh "${COLIMA_PROFILE}"
   stash_profile_audit_log "${COLIMA_PROFILE}"
-  reap_stale_profile_processes "${COLIMA_PROFILE}" || return $?
+  reap_stale_profile_processes "${COLIMA_PROFILE}" || return 2
   run_host_colima_with_timeout "${WORKCELL_COLIMA_DELETE_TIMEOUT_SECONDS:-30}" \
-    delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || true
-  reap_stale_profile_processes "${COLIMA_PROFILE}" || return $?
+    delete --profile "${COLIMA_PROFILE}" --force >/dev/null 2>&1 || delete_status=$?
+  case "${delete_status}" in
+    130 | 143)
+      return "${delete_status}"
+      ;;
+  esac
+  reap_stale_profile_processes "${COLIMA_PROFILE}" || return 2
   remove_profile_state_dirs "${COLIMA_PROFILE}"
   if profile_process_pids "${COLIMA_PROFILE}" | grep -q .; then
     echo "Failed to fully tear down managed Colima profile ${COLIMA_PROFILE} during refresh." >&2
-    return 1
+    return 2
   fi
   if profile_state_dirs_exist "${COLIMA_PROFILE}"; then
     echo "Failed to remove managed Colima profile state for ${COLIMA_PROFILE} during refresh." >&2
-    return 1
+    return 2
   fi
   PROFILE_WAS_REFRESHED=1
   PROFILE_PREEXISTED=0
@@ -6389,14 +6367,11 @@ run_command_with_debug_log() {
   local heartbeat_pid=""
   local spinner_pid=""
   local spinner_enabled=0
-  local tail_pid=""
   local start_seconds=0
   local pid=""
   local status=0
-  local timed_out=0
-  local timeout_seconds=0
+  local managed_timeout_status=124
   local heartbeat_interval_seconds=30
-  local next_heartbeat=0
   local failed_capture_path=""
 
   format_elapsed_compact() {
@@ -6524,58 +6499,8 @@ run_command_with_debug_log() {
       fi
     fi
   fi
-  case "${label}" in
-    colima-start)
-      timeout_seconds="${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}"
-      ;;
-  esac
   maybe_print_progress_update start "0s"
-  if ((timeout_seconds > 0)); then
-    "$@" >"${log_path}" 2>&1 &
-    pid=$!
-    if [[ "${spinner_enabled}" -eq 1 ]]; then
-      start_progress_spinner "${pid}"
-    elif [[ "${LOG_LEVEL}" != "debug" ]]; then
-      next_heartbeat=$((SECONDS + heartbeat_interval_seconds))
-    fi
-    if [[ "${LOG_LEVEL}" == "debug" ]]; then
-      tail -n +1 -f "${log_path}" >&2 &
-      tail_pid=$!
-    fi
-    while kill -0 "${pid}" >/dev/null 2>&1; do
-      sleep 1
-      if ! kill -0 "${pid}" >/dev/null 2>&1; then
-        break
-      fi
-      if [[ "${spinner_enabled}" -eq 0 ]] && [[ "${LOG_LEVEL}" != "debug" ]] && ((SECONDS >= next_heartbeat)); then
-        maybe_print_progress_update heartbeat "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
-        next_heartbeat=$((SECONDS + heartbeat_interval_seconds))
-      fi
-      if ((SECONDS - start_seconds >= timeout_seconds)); then
-        timed_out=1
-        terminate_process_tree_by_pid "${pid}"
-        break
-      fi
-    done
-    if wait "${pid}"; then
-      :
-    else
-      status=$?
-    fi
-    if ((timed_out == 1)); then
-      status=124
-    fi
-    stop_progress_spinner
-    if [[ -n "${tail_pid}" ]]; then
-      kill "${tail_pid}" >/dev/null 2>&1 || true
-      wait "${tail_pid}" 2>/dev/null || true
-    fi
-    if [[ -n "${DEBUG_LOG_PATH}" ]] && [[ -f "${log_path}" ]]; then
-      if debug_log_path="$(revalidate_recorded_host_output_path "${DEBUG_LOG_PATH}")"; then
-        cat "${log_path}" >>"${debug_log_path}"
-      fi
-    fi
-  elif [[ "${LOG_LEVEL}" == "debug" ]]; then
+  if [[ "${LOG_LEVEL}" == "debug" ]]; then
     set +e
     "$@" 2>&1 | tee "${log_path}" >&2
     debug_pipe_status=("${PIPESTATUS[@]}")
@@ -6621,7 +6546,7 @@ run_command_with_debug_log() {
   if [[ "${status}" -eq 0 ]]; then
     maybe_print_progress_update success "$(format_elapsed_compact "$((SECONDS - start_seconds))")"
   else
-    if ((timed_out == 1)); then
+    if [[ "${label}" == "colima-start" ]] && [[ "${status}" -eq "${managed_timeout_status}" ]]; then
       echo "Workcell timed out waiting for managed Colima profile ${COLIMA_PROFILE} to start ($(format_elapsed_compact "$((SECONDS - start_seconds))"))." >&2
     fi
     echo "Workcell ${label} failed." >&2
@@ -6776,11 +6701,11 @@ run_runtime_image_build_with_retries() {
       echo "Retrying the runtime image build for profile ${COLIMA_PROFILE} (attempt ${attempt}/${max_attempts})." >&2
       case "${TARGET_BACKEND}" in
         colima)
-          refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after a failed runtime image build." || return 2
+          refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after a failed runtime image build." || return $?
           start_managed_profile || build_status=$?
           if [[ "${build_status}" -eq 0 ]] &&
             ! validate_colima_profile "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT:-${WORKSPACE}}"; then
-            refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after a failed runtime image build." || return 2
+            refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after a failed runtime image build." || return $?
             start_managed_profile || build_status=$?
             if [[ "${build_status}" -eq 0 ]] &&
               ! validate_colima_profile "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT:-${WORKSPACE}}"; then
@@ -6796,6 +6721,11 @@ run_runtime_image_build_with_retries() {
           ;;
       esac
       if [[ "${build_status}" -ne 0 ]]; then
+        case "${build_status}" in
+          130 | 143)
+            return "${build_status}"
+            ;;
+        esac
         if [[ "${attempt}" -ge "${max_attempts}" ]]; then
           return "${build_status}"
         fi
@@ -6838,6 +6768,11 @@ run_runtime_image_build_with_retries() {
     if ! cleanup_runtime_builder; then
       return 2
     fi
+    case "${build_status}" in
+      130 | 143)
+        return "${build_status}"
+        ;;
+    esac
     if [[ "${build_status}" -eq 0 ]]; then
       return 0
     fi
@@ -7025,7 +6960,7 @@ start_managed_profile() {
   while :; do
     maybe_reap_stale_profile_processes "${COLIMA_PROFILE}" || return 2
     if run_command_with_debug_log colima-start \
-      run_host_colima start \
+      run_host_colima_with_timeout "${WORKCELL_COLIMA_START_TIMEOUT_SECONDS:-180}" start \
       --profile "${COLIMA_PROFILE}" \
       --vm-type vz \
       --mount "${workspace_mount}:w" \
@@ -7045,14 +6980,19 @@ start_managed_profile() {
       PROFILE_RUNNING=1
       return 0
     fi
+    case "${start_status}" in
+      130 | 143)
+        return "${start_status}"
+        ;;
+    esac
     if [[ "${start_status}" -eq 124 ]] && [[ "${attempt}" -ge "${max_attempts}" ]]; then
-      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after repeated startup timeouts." || return 2
+      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after repeated startup timeouts." || return $?
       return 124
     fi
     if [[ "${start_status}" -ne 124 ]] && [[ "${attempt}" -lt "${max_attempts}" ]] &&
       colima_start_hit_recoverable_docker_boot_race; then
       reap_stale_profile_processes "${COLIMA_PROFILE}" || return 2
-      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after Colima failed during Docker startup." || return 2
+      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after Colima failed during Docker startup." || return $?
       echo "Retrying managed Colima profile ${COLIMA_PROFILE} after a Docker startup race (attempt $((attempt + 1))/${max_attempts})." >&2
       attempt=$((attempt + 1))
       continue
@@ -7061,7 +7001,7 @@ start_managed_profile() {
       return "${start_status}"
     fi
     reap_stale_profile_processes "${COLIMA_PROFILE}" || return 2
-    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after Colima start timed out." || return 2
+    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} after Colima start timed out." || return $?
     echo "Retrying managed Colima profile ${COLIMA_PROFILE} after a startup timeout (attempt $((attempt + 1))/${max_attempts})." >&2
     attempt=$((attempt + 1))
   done
@@ -9190,15 +9130,15 @@ if [[ "${TARGET_BACKEND}" == "colima" ]] && [[ "${PROFILE_PREEXISTED}" -eq 1 ]];
   profile_status=""
   if [[ ! -f "${profile_config_path}" ]] ||
     ! validate_colima_profile_config "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT}" "${COLIMA_CPU}" "${COLIMA_MEMORY}" "${COLIMA_DISK}"; then
-    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} to apply the requested reviewed VM resources." || exit 2
+    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} to apply the requested reviewed VM resources." || exit $?
   elif [[ ! -f "${lima_config_path}" ]] ||
     ! validate_colima_runtime_mounts "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT}"; then
-    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} to discard stale runtime mounts." || exit 2
+    refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} to discard stale runtime mounts." || exit $?
   else
     profile_status="$(colima_profile_status "${COLIMA_PROFILE}" || true)"
     if [[ "${profile_status}" == "Running" ]] &&
       ! validate_colima_runtime_workspace_view "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT}"; then
-      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents." || exit 2
+      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} because the running VM is not exposing the expected workspace contents." || exit $?
     fi
   fi
 fi
@@ -9215,7 +9155,7 @@ if [[ "${TARGET_BACKEND}" == "colima" ]]; then
   start_managed_profile
   if ! validate_colima_profile "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT}"; then
     if [[ "${PROFILE_PREEXISTED}" -eq 1 ]] && [[ "${PROFILE_WAS_REFRESHED}" -eq 0 ]]; then
-      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view." || exit 2
+      refresh_managed_profile "Refreshing managed Colima profile ${COLIMA_PROFILE} because the started VM did not expose the expected workspace view." || exit $?
       start_managed_profile
       validate_colima_profile "${COLIMA_PROFILE}" "${PROFILE_WORKSPACE_ROOT}" || exit 2
     else


### PR DESCRIPTION
## Summary

- Run Colima commands in a dedicated process group.
- Stop the complete process group after a timeout or operator signal.
- Preserve exit status 124, 130, and 143 at shell retry boundaries.
- Update the launcher contract and control-plane manifest.

## Validation

- Fresh `./scripts/pre-merge.sh --profile pr-parity` passed.
- Evidence binds base `e7425e01`, head `0c32dd2f`, tree `d126026d`, and a clean worktree.
- Focused tests and race tests passed.
- Live Darwin process-group proof passed with a TERM-resistant child.
- Final six-role review was clean.

## Scope

- This PR contains F-013 B1 only.
- It changes 10 paths and 1,098 lines.
- It has no binary files.

## Checklist

- [x] The commit signature is valid.
- [x] The source review is clean.
- [x] Fresh PR parity passed.
- [x] Live certification evidence passed.
- [x] Residue cleanup passed.