### PR TITLE
Clean up timed-out Colima process groups

### DIFF
--- a/internal/host/launcher/colima.go
+++ b/internal/host/launcher/colima.go
@@ -183,10 +183,11 @@ func colimaCancellationResult(runErr, cleanupErr, cause error) (int, error) {
 		}
 		return 0, errors.Join(cleanupErr, causeErr)
 	}
-	if expectedColimaCancellationError(runErr) {
-		return colimaCancellationExitCode(cause)
+	var exitErr *exec.ExitError
+	if runErr != nil && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, context.DeadlineExceeded) && !errors.As(runErr, &exitErr) {
+		return colimaRunResult(runErr)
 	}
-	return colimaRunResult(runErr)
+	return colimaCancellationExitCode(cause)
 }
 
 func colimaCancellationExitCode(cause error) (int, error) {
@@ -194,18 +195,6 @@ func colimaCancellationExitCode(cause error) (int, error) {
 		return ColimaTimeoutExitCode, nil
 	}
 	return 0, fmt.Errorf("colima cancellation has unexpected cause: %w", cause)
-}
-
-func expectedColimaCancellationError(err error) bool {
-	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		return false
-	}
-	status, ok := exitErr.Sys().(syscall.WaitStatus)
-	return ok && status.Signaled() && (status.Signal() == syscall.SIGTERM || status.Signal() == syscall.SIGKILL)
 }
 
 func colimaExitCode(exitErr *exec.ExitError) int {

--- a/internal/host/launcher/colima.go
+++ b/internal/host/launcher/colima.go
@@ -60,9 +60,8 @@ func RunHostColima(inv HostColimaInvocation) (int, error) {
 
 // RunHostColimaWithTimeout invokes the trusted colima binary with a
 // deadline.  When timeoutSeconds is zero or negative the call falls
-// through to RunHostColima with no timeout.  On timeout the function
-// returns ColimaTimeoutExitCode (124) after killing the colima process
-// group, matching the bash run_host_colima_with_timeout helper.
+// through to RunHostColima with no timeout.  A deadline returns 124 only
+// after successful cleanup proves the process group absent.
 func RunHostColimaWithTimeout(timeoutSeconds int, inv HostColimaInvocation) (int, error) {
 	if len(inv.Args) == 0 {
 		return 0, nil
@@ -76,25 +75,19 @@ func RunHostColimaWithTimeout(timeoutSeconds int, inv HostColimaInvocation) (int
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
+	return runHostColimaWithContext(ctx, inv)
+}
 
+func runHostColimaWithContext(ctx context.Context, inv HostColimaInvocation) (int, error) {
 	cmd, err := newColimaCommand(ctx, inv)
 	if err != nil {
 		return 0, err
 	}
-	// Place the child in its own process group so we can deliver
-	// SIGKILL to the whole tree on timeout (mirroring the bash
-	// helper's kill_process_tree_by_pid behaviour).
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return killColimaProcessGroup(cmd)
+	result := defaultProcessGroupSupervisor().run(ctx, cmd)
+	if result.cleanupRan || result.preStartCanceled {
+		return colimaCancellationResult(result.runErr, result.cleanupErr, result.cause)
 	}
-	cmd.WaitDelay = 5 * time.Second
-
-	code, runErr := runColimaCommand(cmd)
-	if ctx.Err() == context.DeadlineExceeded {
-		return ColimaTimeoutExitCode, nil
-	}
-	return code, runErr
+	return colimaRunResult(result.runErr)
 }
 
 // ValidateColimaStatusOutput checks that the textual output of
@@ -167,7 +160,10 @@ func colimaChildEnv(inv HostColimaInvocation) []string {
 }
 
 func runColimaCommand(cmd *exec.Cmd) (int, error) {
-	err := cmd.Run()
+	return colimaRunResult(cmd.Run())
+}
+
+func colimaRunResult(err error) (int, error) {
 	if err == nil {
 		return 0, nil
 	}
@@ -176,6 +172,40 @@ func runColimaCommand(cmd *exec.Cmd) (int, error) {
 		return colimaExitCode(exitErr), nil
 	}
 	return 0, fmt.Errorf("colima invocation failed: %w", err)
+}
+
+func colimaCancellationResult(runErr, cleanupErr, cause error) (int, error) {
+	if cleanupErr != nil {
+		cleanupErr = fmt.Errorf("colima process-group cleanup failed: %w", cleanupErr)
+		causeErr := fmt.Errorf("colima cancellation cause: %w", cause)
+		if runErr != nil {
+			return 0, errors.Join(fmt.Errorf("colima invocation failed: %w", runErr), cleanupErr, causeErr)
+		}
+		return 0, errors.Join(cleanupErr, causeErr)
+	}
+	if expectedColimaCancellationError(runErr) {
+		return colimaCancellationExitCode(cause)
+	}
+	return colimaRunResult(runErr)
+}
+
+func colimaCancellationExitCode(cause error) (int, error) {
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return ColimaTimeoutExitCode, nil
+	}
+	return 0, fmt.Errorf("colima cancellation has unexpected cause: %w", cause)
+}
+
+func expectedColimaCancellationError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && (status.Signal() == syscall.SIGTERM || status.Signal() == syscall.SIGKILL)
 }
 
 func colimaExitCode(exitErr *exec.ExitError) int {
@@ -194,20 +224,6 @@ func validateColimaBinary(path string) error {
 	}
 	if !filepath.IsAbs(path) {
 		return errors.New("colima binary path must be absolute")
-	}
-	return nil
-}
-
-func killColimaProcessGroup(cmd *exec.Cmd) error {
-	if cmd == nil || cmd.Process == nil {
-		return nil
-	}
-	pid := cmd.Process.Pid
-	// Negative pid targets the whole process group.  Ignore the
-	// "no such process" error that arises if the child already exited
-	// between the deadline firing and our kill call.
-	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
-		return err
 	}
 	return nil
 }

--- a/internal/host/launcher/colima_test.go
+++ b/internal/host/launcher/colima_test.go
@@ -218,6 +218,7 @@ func TestRunHostColimaWithTimeoutKillsRunawayChild(t *testing.T) {
 	dir := t.TempDir()
 	fake := writeFakeColima(t, dir, `#!/bin/sh
 # Let the leader exit on TERM while its descendant ignores TERM.
+trap 'exit 11' TERM
 sh -c 'trap "" TERM; sleep 5' &
 wait
 `)

--- a/internal/host/launcher/colima_test.go
+++ b/internal/host/launcher/colima_test.go
@@ -4,16 +4,9 @@
 package launcher
 
 import (
-	"bufio"
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -204,217 +197,70 @@ func TestRunHostColimaWithTimeoutNoTimeoutDelegates(t *testing.T) {
 	fake := writeFakeColima(t, dir, `#!/bin/sh
 exit 11
 `)
-	for _, timeout := range []int{0, -1} {
-		code, err := RunHostColimaWithTimeout(timeout, HostColimaInvocation{
-			ColimaBin: fake,
-			RealHome:  dir,
-			Args:      []string{"list"},
-		})
-		if err != nil {
-			t.Fatalf("RunHostColimaWithTimeout(%d) err = %v", timeout, err)
-		}
-		if code != 11 {
-			t.Fatalf("RunHostColimaWithTimeout(%d) code = %d, want 11", timeout, code)
-		}
+	code, err := RunHostColimaWithTimeout(0, HostColimaInvocation{
+		ColimaBin: fake,
+		RealHome:  dir,
+		Args:      []string{"list"},
+	})
+	if err != nil {
+		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
+	}
+	if code != 11 {
+		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 11", code)
 	}
 }
 
 func TestRunHostColimaWithTimeoutKillsRunawayChild(t *testing.T) {
-	testRunHostColimaWithTimeout(t, false)
-}
-
-func TestRunHostColimaWithTimeoutReturnsExitCodeWhenFastEnough(t *testing.T) {
-	testRunHostColimaWithTimeout(t, true)
-}
-
-func testRunHostColimaWithTimeout(t *testing.T, public bool) {
 	if runtime.GOOS == "windows" {
 		t.Skip("relies on POSIX /bin/sh helpers")
 	}
-	if os.Getenv("WORKCELL_COLIMA_TIMEOUT_HELPER") == "1" {
-		waitForOwnedFixtureCommandReady()
-		inv := HostColimaInvocation{
-			ColimaBin: os.Getenv("WORKCELL_COLIMA_TIMEOUT_BIN"),
-			RealHome:  os.Getenv("WORKCELL_COLIMA_TIMEOUT_HOME"),
-			Args:      []string{"start", os.Getenv("WORKCELL_COLIMA_TIMEOUT_MARKER")},
-		}
-		if os.Getenv("WORKCELL_COLIMA_TIMEOUT_PUBLIC") == "true" {
-			code, err := RunHostColimaWithTimeout(1, inv)
-			exitColimaFixture(code, err)
-		}
-		ctx, cancel := context.WithCancelCause(context.Background())
-		defer cancel(context.Canceled)
-		go func() {
-			for ctx.Err() == nil {
-				if _, err := os.Stat(os.Getenv("WORKCELL_COLIMA_TIMEOUT_ACK")); err == nil {
-					cancel(context.DeadlineExceeded)
-					return
-				}
-				time.Sleep(10 * time.Millisecond)
-			}
-		}()
-		code, err := runHostColimaWithContext(ctx, inv)
-		exitColimaFixture(code, err)
+	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
+	dir := t.TempDir()
+	fake := writeFakeColima(t, dir, `#!/bin/sh
+# Let the leader exit on TERM while its descendant ignores TERM.
+sh -c 'trap "" TERM; sleep 5' &
+wait
+`)
+	start := time.Now()
+	code, err := RunHostColimaWithTimeout(1, HostColimaInvocation{
+		ColimaBin: fake,
+		RealHome:  dir,
+		Args:      []string{"start"},
+	})
+	if err != nil {
+		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
+	}
+	if code != ColimaTimeoutExitCode {
+		t.Fatalf("RunHostColimaWithTimeout() code = %d, want %d", code, ColimaTimeoutExitCode)
+	}
+	if elapsed := time.Since(start); elapsed < 750*time.Millisecond || elapsed > 4*time.Second {
+		t.Fatalf("RunHostColimaWithTimeout() took %s, expected to honour 1s deadline", elapsed)
+	}
+}
+
+func TestRunHostColimaWithTimeoutReturnsExitCodeWhenFastEnough(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX /bin/sh helpers")
 	}
 	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
-	for _, tc := range []struct {
-		name     string
-		setup    string
-		public   bool
-		childACK string
-		wantCode int
-		minRun   time.Duration
-		maxRun   time.Duration
-	}{
-		{"TERM-responsive", ":", false, "ready\n", ColimaTimeoutExitCode, 0, 4 * time.Second},
-		{"TERM-resistant descendant", `trap "" TERM`, false, "ready\n", ColimaTimeoutExitCode, 4750 * time.Millisecond, 11 * time.Second},
-		{"public one-second deadline", "#!/bin/sh\ncount=0\nwhile [ \"$count\" -lt 500 ]; do sleep .01; count=$((count + 1)); done\nexit 125\n", true, "", ColimaTimeoutExitCode, 750 * time.Millisecond, 4 * time.Second},
-		{"public fast exit 7", "#!/bin/sh\nsleep .1\nexit 7\n", true, "", 7, 100 * time.Millisecond, 900 * time.Millisecond},
-		{"missing child ACK", ":", false, "", 125, 4 * time.Second, 12 * time.Second},
-		{"malformed child ACK", ":", false, "bad\n", 125, 0, 4 * time.Second},
-	} {
-		if tc.public != public {
-			continue
-		}
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			marker := filepath.Join(dir, "processes")
-			ack := filepath.Join(dir, "ack")
-			fakeSource := `#!/bin/sh
-pgid=$(ps -o pgid= -p $$ | tr -d ' '); printf '%s %s\n' "$pgid" "$$"
-count=0
-while [ ! -f "$2.owned" ] && [ "$count" -lt 500 ]; do sleep .01; count=$((count + 1)); done
-[ "$(cat "$2.owned" 2>/dev/null)" = ready ] || exit 125
-sh -c 'count=0
-while [ ! -f "$1.child-owned" ] && [ "$count" -lt 500 ]; do sleep .01; count=$((count + 1)); done
-[ "$(cat "$1.child-owned" 2>/dev/null)" = ready ] || exit 125
-` + tc.setup + `; printf 'ready\n' >"$1.child-ready"; while :; do sleep 1; done' fixture-child "$2" &
-child=$!
-printf '%s %s %s\n' "$pgid" "$$" "$child" >"$2"
-wait "$child"
-`
-			if tc.public {
-				fakeSource = tc.setup
-			}
-			fake := writeFakeColima(t, dir, fakeSource)
-			cmd := exec.Command(os.Args[0], "-test.run=^TestRunHostColimaWithTimeoutKillsRunawayChild$")
-			ownerPipe, err := cmd.StdoutPipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			cmd.Env = append(os.Environ(),
-				"WORKCELL_COLIMA_TIMEOUT_HELPER=1",
-				"WORKCELL_COLIMA_TIMEOUT_BIN="+fake,
-				"WORKCELL_COLIMA_TIMEOUT_HOME="+dir,
-				"WORKCELL_COLIMA_TIMEOUT_MARKER="+marker,
-				"WORKCELL_COLIMA_TIMEOUT_ACK="+ack,
-				"WORKCELL_COLIMA_TIMEOUT_PUBLIC="+strconv.FormatBool(tc.public),
-			)
-			start := time.Now()
-			fixtureCommand := startOwnedFixtureCommand(t, cmd)
-			var fixtureGroup *ownedFixtureProcessGroup
-			if !tc.public {
-				fixtureGroup, err = readOwnedFixtureProcessGroupPipe(ownerPipe, cmd.Process.Pid, fake)
-				if err != nil {
-					t.Fatal(err)
-				}
-				registerOwnedFixtureGroupCleanup(t, fixtureGroup)
-				if err := os.WriteFile(marker+".owned", []byte("ready\n"), 0o600); err != nil {
-					t.Fatal(err)
-				}
-				if err := validateOwnedFixtureProcessGroupMarker(fixtureGroup, marker); err != nil {
-					t.Fatal(err)
-				}
-				if tc.childACK != "" {
-					if err := os.WriteFile(marker+".child-owned", []byte(tc.childACK), 0o600); err != nil {
-						t.Fatal(err)
-					}
-				}
-				if tc.childACK == "ready\n" && len(pollProcessMarker(marker+".child-ready", 5*time.Second, 1)) != 1 {
-					t.Fatal("fixture child was not ready")
-				}
-				if tc.wantCode == ColimaTimeoutExitCode && !tc.public {
-					if err := os.WriteFile(ack, []byte("ready\n"), 0o600); err != nil {
-						t.Fatal(err)
-					}
-				}
-			}
-			err = fixtureCommand.wait()
-			if fixtureGroup != nil {
-				fixtureGroup.proveAbsent(t)
-			} else if !waitForFixtureCommandPathAbsent(fake, 5*time.Second) {
-				t.Fatalf("fixture command remains: %s", fake)
-			}
-			fixtureCommand.group.proveAbsent(t)
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) || exitErr.ExitCode() != tc.wantCode {
-				t.Fatalf("timeout helper wait = %v, want status %d", err, tc.wantCode)
-			}
-			if elapsed := fixtureCommand.finishedAt.Sub(start); elapsed < tc.minRun || elapsed > tc.maxRun {
-				t.Fatalf("process-group cleanup completed in %s", elapsed)
-			}
-		})
-	}
-}
-
-func TestRunHostColimaWithContextPreservesPreStartDeadline(t *testing.T) {
-	ctx, cancel := context.WithDeadline(context.Background(), time.Unix(1, 0))
-	defer cancel()
-	code, err := runHostColimaWithContext(ctx, HostColimaInvocation{
-		ColimaBin: "/usr/bin/true",
-		Args:      []string{"start"},
+	dir := t.TempDir()
+	fake := writeFakeColima(t, dir, `#!/bin/sh
+exit 7
+`)
+	start := time.Now()
+	code, err := RunHostColimaWithTimeout(30, HostColimaInvocation{
+		ColimaBin: fake,
+		RealHome:  dir,
+		Args:      []string{"list"},
 	})
-	if err != nil || code != ColimaTimeoutExitCode {
-		t.Fatalf("pre-start deadline = %d, %v, want %d", code, err, ColimaTimeoutExitCode)
+	if err != nil {
+		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
 	}
-
-	code, err = runHostColimaWithContext(context.Background(), HostColimaInvocation{
-		ColimaBin: "/workcell-missing-colima-binary",
-		Args:      []string{"start"},
-	})
-	if code != 0 || err == nil || !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("unrelated start error = %d, %v", code, err)
+	if code != 7 {
+		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 7", code)
 	}
-}
-
-func TestColimaCancellationResultPreservesOutcomes(t *testing.T) {
-	termErr := processSignalError(t, syscall.SIGTERM)
-	killErr := processSignalError(t, syscall.SIGKILL)
-	interruptErr := processSignalError(t, syscall.SIGINT)
-	exitErr := exec.Command("/bin/sh", "-c", "exit 7").Run()
-	exit124Err := exec.Command("/bin/sh", "-c", "exit 124").Run()
-	ioErr := errors.New("write failed")
-	cleanupErr := errors.New("group remains")
-	for _, tc := range []struct {
-		name       string
-		runErr     error
-		cleanupErr error
-		cause      error
-		wantCode   int
-		wantErrors []error
-	}{
-		{"nil after deadline", nil, nil, context.DeadlineExceeded, 124, nil},
-		{"deadline error", context.DeadlineExceeded, nil, context.DeadlineExceeded, 124, nil},
-		{"TERM after deadline", termErr, nil, context.DeadlineExceeded, 124, nil},
-		{"KILL after deadline", killErr, nil, context.DeadlineExceeded, 124, nil},
-		{"ordinary exit 7", exitErr, nil, context.DeadlineExceeded, 7, nil},
-		{"ordinary exit 124", exit124Err, nil, context.DeadlineExceeded, 124, nil},
-		{"unrelated SIGINT", interruptErr, nil, context.DeadlineExceeded, 128 + int(syscall.SIGINT), nil},
-		{"I/O error", ioErr, nil, context.DeadlineExceeded, 0, []error{ioErr}},
-		{"cleanup after deadline", termErr, cleanupErr, context.DeadlineExceeded, 0, []error{termErr, cleanupErr, context.DeadlineExceeded}},
-		{"unexpected cause", termErr, nil, context.Canceled, 0, []error{context.Canceled}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			code, err := colimaCancellationResult(tc.runErr, tc.cleanupErr, tc.cause)
-			if code != tc.wantCode || (len(tc.wantErrors) == 0 && err != nil) {
-				t.Fatalf("colimaCancellationResult() = %d, %v", code, err)
-			}
-			for _, wantErr := range tc.wantErrors {
-				if !errors.Is(err, wantErr) {
-					t.Fatalf("colimaCancellationResult() err = %v, want %v", err, wantErr)
-				}
-			}
-		})
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Fatalf("RunHostColimaWithTimeout() took %s, want under 2s", elapsed)
 	}
 }
 
@@ -428,283 +274,4 @@ func writeFakeColima(t *testing.T, dir, script string) string {
 		t.Fatalf("chmod fake colima: %v", err)
 	}
 	return path
-}
-
-func processSignalError(t *testing.T, signal syscall.Signal) error {
-	t.Helper()
-	cmd := exec.Command("/bin/sleep", "30")
-	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmd.Process.Signal(signal); err != nil {
-		t.Fatal(err)
-	}
-	err := cmd.Wait()
-	if err == nil {
-		t.Fatalf("signal %s produced no error", signal)
-	}
-	return err
-}
-
-func exitColimaFixture(code int, err error) {
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(125)
-	}
-	os.Exit(code)
-}
-
-func pollProcessMarker(path string, limit time.Duration, fieldCount int) []string {
-	deadline := time.Now().Add(limit)
-	for time.Now().Before(deadline) {
-		if data, err := os.ReadFile(path); err == nil {
-			if fields := strings.Fields(string(data)); len(fields) == fieldCount {
-				return fields
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return nil
-}
-
-func parseFixtureProcessMarker(path string) ([]int, error) {
-	fields := pollProcessMarker(path, 5*time.Second, 3)
-	values := make([]int, len(fields))
-	for i, field := range fields {
-		value, err := strconv.Atoi(field)
-		if err != nil {
-			return nil, fmt.Errorf("process marker %s field %q: %w", path, field, err)
-		}
-		values[i] = value
-	}
-	if len(values) != 3 {
-		return nil, fmt.Errorf("process marker %s was not ready", path)
-	}
-	return values, nil
-}
-
-func fixtureProcessIdentity(pid int) (int, string, error) {
-	groupID, err := syscall.Getpgid(pid)
-	if err != nil {
-		return 0, "", err
-	}
-	output, err := exec.Command("/bin/ps", "-o", "lstart=", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
-	return groupID, string(output), err
-}
-
-func readOwnedFixtureProcessGroupPipe(reader io.Reader, parentPID int, commandPath string) (*ownedFixtureProcessGroup, error) {
-	result := make(chan string, 1)
-	go func() {
-		line, _ := bufio.NewReader(reader).ReadString('\n')
-		result <- line
-	}()
-	var line string
-	select {
-	case line = <-result:
-	case <-time.After(5 * time.Second):
-		return nil, errors.New("fixture owner handshake timed out")
-	}
-	fields := strings.Fields(line)
-	if len(fields) != 2 {
-		return nil, fmt.Errorf("fixture owner handshake has %d fields", len(fields))
-	}
-	groupID, err := strconv.Atoi(fields[0])
-	if err != nil {
-		return nil, fmt.Errorf("fixture owner group %q: %w", fields[0], err)
-	}
-	leaderPID, err := strconv.Atoi(fields[1])
-	if err != nil || groupID != leaderPID || validateSafeProcessGroupID(groupID) != nil {
-		return nil, fmt.Errorf("fixture owner has unsafe group=%d leader=%d", groupID, leaderPID)
-	}
-	actual, identity, err := fixtureProcessIdentity(leaderPID)
-	parent, parentErr := fixtureProcessParent(leaderPID)
-	if err != nil || parentErr != nil || actual != groupID || parent != parentPID || !strings.Contains(identity, commandPath) {
-		return nil, fmt.Errorf("fixture owner identity is not trusted: identity=%v parent=%v", err, parentErr)
-	}
-	return &ownedFixtureProcessGroup{id: groupID, members: map[int]string{leaderPID: identity}, active: true}, nil
-}
-
-func fixtureProcessParent(pid int) (int, error) {
-	output, err := exec.Command("/bin/ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
-	if err != nil {
-		return 0, err
-	}
-	return strconv.Atoi(strings.TrimSpace(string(output)))
-}
-
-func validateOwnedFixtureProcessGroupMarker(group *ownedFixtureProcessGroup, marker string) error {
-	values, err := parseFixtureProcessMarker(marker)
-	if err != nil {
-		return err
-	}
-	groupID, leaderPID, childPID := values[0], values[1], values[2]
-	if group == nil || groupID != group.id || leaderPID != group.id || !group.hasLiveMember() {
-		return fmt.Errorf("process marker %s does not identify the owned group", marker)
-	}
-	actual, identity, err := fixtureProcessIdentity(childPID)
-	parent, parentErr := fixtureProcessParent(childPID)
-	if err != nil || parentErr != nil || actual != group.id || parent != leaderPID || !strings.Contains(identity, marker) {
-		return fmt.Errorf("fixture child %d identity is not owned: identity=%v parent=%v", childPID, err, parentErr)
-	}
-	group.members[childPID] = identity
-	return nil
-}
-
-type ownedFixtureProcessGroup struct {
-	id      int
-	members map[int]string
-	active  bool
-}
-
-type ownedFixtureCommand struct {
-	cmd        *exec.Cmd
-	group      *ownedFixtureProcessGroup
-	waitDone   chan struct{}
-	waitErr    error
-	finishedAt time.Time
-}
-
-func startOwnedFixtureCommand(t *testing.T, cmd *exec.Cmd) *ownedFixtureCommand {
-	t.Helper()
-	ready := filepath.Join(t.TempDir(), "outer-group-ready")
-	cmd.Env = append(cmd.Env, "WORKCELL_TEST_OUTER_GROUP_READY="+ready)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
-	}
-	fixture := &ownedFixtureCommand{cmd: cmd, waitDone: make(chan struct{})}
-	go func() {
-		fixture.waitErr = cmd.Wait()
-		fixture.finishedAt = time.Now()
-		close(fixture.waitDone)
-	}()
-	t.Cleanup(func() {
-		if fixture.group != nil {
-			if err := fixture.group.cleanup(); err != nil {
-				t.Error(err)
-			}
-		}
-		select {
-		case <-fixture.waitDone:
-			return
-		default:
-			_ = cmd.Process.Kill()
-		}
-		select {
-		case <-fixture.waitDone:
-		case <-time.After(5 * time.Second):
-			t.Error("fixture process did not exit during cleanup")
-		}
-	})
-	actual, identity, err := fixtureProcessIdentity(cmd.Process.Pid)
-	if err != nil || actual != cmd.Process.Pid || validateSafeProcessGroupID(actual) != nil {
-		t.Fatalf("fixture leader %d has unsafe process group %d: %v", cmd.Process.Pid, actual, err)
-	}
-	group := &ownedFixtureProcessGroup{id: actual, members: map[int]string{cmd.Process.Pid: identity}}
-	group.active = true
-	fixture.group = group
-	if err := os.WriteFile(ready, []byte("ready\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return fixture
-}
-
-func (f *ownedFixtureCommand) wait() error {
-	select {
-	case <-f.waitDone:
-		return f.waitErr
-	case <-time.After(15 * time.Second):
-		_ = f.group.cleanup()
-		_ = f.cmd.Process.Kill()
-		select {
-		case <-f.waitDone:
-			return fmt.Errorf("fixture command exceeded its wait limit: %w", f.waitErr)
-		case <-time.After(5 * time.Second):
-			return errors.New("fixture command did not exit after its wait limit")
-		}
-	}
-}
-
-func registerOwnedFixtureGroupCleanup(t *testing.T, group *ownedFixtureProcessGroup) {
-	t.Helper()
-	t.Cleanup(func() {
-		if err := group.cleanup(); err != nil {
-			t.Error(err)
-		}
-	})
-}
-
-func (g *ownedFixtureProcessGroup) cleanup() error {
-	if !g.active {
-		return nil
-	}
-	absent, err := waitForFixtureGroupExit(g.id, 0)
-	if err == nil && absent {
-		g.active = false
-		return nil
-	}
-	if !g.hasLiveMember() {
-		return fmt.Errorf("refuse cleanup of process group %d without a live owned member", g.id)
-	}
-	if err := syscall.Kill(-g.id, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
-		return fmt.Errorf("cleanup process group %d: %w", g.id, err)
-	}
-	absent, err = waitForFixtureGroupExit(g.id, 5*time.Second)
-	if err != nil || !absent {
-		return fmt.Errorf("cleanup did not prove process group %d absent: %v", g.id, err)
-	}
-	g.active = false
-	return nil
-}
-
-func (g *ownedFixtureProcessGroup) hasLiveMember() bool {
-	return g.hasLiveMemberWith(fixtureProcessIdentity)
-}
-
-func (g *ownedFixtureProcessGroup) hasLiveMemberWith(inspect func(int) (int, string, error)) bool {
-	for pid, identity := range g.members {
-		if actual, current, err := inspect(pid); err == nil && actual == g.id && current == identity {
-			return true
-		}
-	}
-	return false
-}
-
-func (g *ownedFixtureProcessGroup) proveAbsent(t *testing.T) {
-	t.Helper()
-	absent, err := waitForFixtureGroupExit(g.id, 5*time.Second)
-	if err != nil || !absent {
-		t.Fatalf("process group %d remains: absent=%v err=%v", g.id, absent, err)
-	}
-	g.active = false
-}
-
-func waitForFixtureGroupExit(groupID int, limit time.Duration) (bool, error) {
-	if groupID <= 1 || groupID == syscall.Getpgrp() {
-		return false, fmt.Errorf("unsafe fixture group %d", groupID)
-	}
-	deadline := time.Now().Add(limit)
-	for {
-		err := syscall.Kill(-groupID, 0)
-		if errors.Is(err, syscall.ESRCH) {
-			return true, nil
-		}
-		if err != nil && !errors.Is(err, syscall.EPERM) {
-			return false, err
-		}
-		if !time.Now().Before(deadline) {
-			return false, nil
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
-}
-
-func waitForOwnedFixtureCommandReady() {
-	ready := os.Getenv("WORKCELL_TEST_OUTER_GROUP_READY")
-	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
-		if _, err := os.Stat(ready); err == nil {
-			return
-		}
-	}
-	os.Exit(125)
 }

--- a/internal/host/launcher/colima_test.go
+++ b/internal/host/launcher/colima_test.go
@@ -4,9 +4,16 @@
 package launcher
 
 import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -197,66 +204,217 @@ func TestRunHostColimaWithTimeoutNoTimeoutDelegates(t *testing.T) {
 	fake := writeFakeColima(t, dir, `#!/bin/sh
 exit 11
 `)
-	code, err := RunHostColimaWithTimeout(0, HostColimaInvocation{
-		ColimaBin: fake,
-		RealHome:  dir,
-		Args:      []string{"list"},
-	})
-	if err != nil {
-		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
-	}
-	if code != 11 {
-		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 11", code)
+	for _, timeout := range []int{0, -1} {
+		code, err := RunHostColimaWithTimeout(timeout, HostColimaInvocation{
+			ColimaBin: fake,
+			RealHome:  dir,
+			Args:      []string{"list"},
+		})
+		if err != nil {
+			t.Fatalf("RunHostColimaWithTimeout(%d) err = %v", timeout, err)
+		}
+		if code != 11 {
+			t.Fatalf("RunHostColimaWithTimeout(%d) code = %d, want 11", timeout, code)
+		}
 	}
 }
 
 func TestRunHostColimaWithTimeoutKillsRunawayChild(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("relies on POSIX /bin/sh helpers")
-	}
-	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
-	dir := t.TempDir()
-	fake := writeFakeColima(t, dir, `#!/bin/sh
-# Sleep well past the test deadline to force the timeout path.
-sleep 30
-exit 0
-`)
-	start := time.Now()
-	code, err := RunHostColimaWithTimeout(1, HostColimaInvocation{
-		ColimaBin: fake,
-		RealHome:  dir,
-		Args:      []string{"start"},
-	})
-	if err != nil {
-		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
-	}
-	if code != ColimaTimeoutExitCode {
-		t.Fatalf("RunHostColimaWithTimeout() code = %d, want %d", code, ColimaTimeoutExitCode)
-	}
-	if elapsed := time.Since(start); elapsed > 10*time.Second {
-		t.Fatalf("RunHostColimaWithTimeout() took %s, expected to honour 1s deadline", elapsed)
-	}
+	testRunHostColimaWithTimeout(t, false)
 }
 
 func TestRunHostColimaWithTimeoutReturnsExitCodeWhenFastEnough(t *testing.T) {
+	testRunHostColimaWithTimeout(t, true)
+}
+
+func testRunHostColimaWithTimeout(t *testing.T, public bool) {
 	if runtime.GOOS == "windows" {
 		t.Skip("relies on POSIX /bin/sh helpers")
 	}
-	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
-	dir := t.TempDir()
-	fake := writeFakeColima(t, dir, `#!/bin/sh
-exit 0
-`)
-	code, err := RunHostColimaWithTimeout(30, HostColimaInvocation{
-		ColimaBin: fake,
-		RealHome:  dir,
-		Args:      []string{"list"},
-	})
-	if err != nil {
-		t.Fatalf("RunHostColimaWithTimeout() err = %v", err)
+	if os.Getenv("WORKCELL_COLIMA_TIMEOUT_HELPER") == "1" {
+		waitForOwnedFixtureCommandReady()
+		inv := HostColimaInvocation{
+			ColimaBin: os.Getenv("WORKCELL_COLIMA_TIMEOUT_BIN"),
+			RealHome:  os.Getenv("WORKCELL_COLIMA_TIMEOUT_HOME"),
+			Args:      []string{"start", os.Getenv("WORKCELL_COLIMA_TIMEOUT_MARKER")},
+		}
+		if os.Getenv("WORKCELL_COLIMA_TIMEOUT_PUBLIC") == "true" {
+			code, err := RunHostColimaWithTimeout(1, inv)
+			exitColimaFixture(code, err)
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(context.Canceled)
+		go func() {
+			for ctx.Err() == nil {
+				if _, err := os.Stat(os.Getenv("WORKCELL_COLIMA_TIMEOUT_ACK")); err == nil {
+					cancel(context.DeadlineExceeded)
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+		code, err := runHostColimaWithContext(ctx, inv)
+		exitColimaFixture(code, err)
 	}
-	if code != 0 {
-		t.Fatalf("RunHostColimaWithTimeout() code = %d, want 0", code)
+	// Serial — see ETXTBSY note on TestRunHostColimaForwardsArgsAndPropagatesExitCode.
+	for _, tc := range []struct {
+		name     string
+		setup    string
+		public   bool
+		childACK string
+		wantCode int
+		minRun   time.Duration
+		maxRun   time.Duration
+	}{
+		{"TERM-responsive", ":", false, "ready\n", ColimaTimeoutExitCode, 0, 4 * time.Second},
+		{"TERM-resistant descendant", `trap "" TERM`, false, "ready\n", ColimaTimeoutExitCode, 4750 * time.Millisecond, 11 * time.Second},
+		{"public one-second deadline", "#!/bin/sh\ncount=0\nwhile [ \"$count\" -lt 500 ]; do sleep .01; count=$((count + 1)); done\nexit 125\n", true, "", ColimaTimeoutExitCode, 750 * time.Millisecond, 4 * time.Second},
+		{"public fast exit 7", "#!/bin/sh\nsleep .1\nexit 7\n", true, "", 7, 100 * time.Millisecond, 900 * time.Millisecond},
+		{"missing child ACK", ":", false, "", 125, 4 * time.Second, 12 * time.Second},
+		{"malformed child ACK", ":", false, "bad\n", 125, 0, 4 * time.Second},
+	} {
+		if tc.public != public {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			marker := filepath.Join(dir, "processes")
+			ack := filepath.Join(dir, "ack")
+			fakeSource := `#!/bin/sh
+pgid=$(ps -o pgid= -p $$ | tr -d ' '); printf '%s %s\n' "$pgid" "$$"
+count=0
+while [ ! -f "$2.owned" ] && [ "$count" -lt 500 ]; do sleep .01; count=$((count + 1)); done
+[ "$(cat "$2.owned" 2>/dev/null)" = ready ] || exit 125
+sh -c 'count=0
+while [ ! -f "$1.child-owned" ] && [ "$count" -lt 500 ]; do sleep .01; count=$((count + 1)); done
+[ "$(cat "$1.child-owned" 2>/dev/null)" = ready ] || exit 125
+` + tc.setup + `; printf 'ready\n' >"$1.child-ready"; while :; do sleep 1; done' fixture-child "$2" &
+child=$!
+printf '%s %s %s\n' "$pgid" "$$" "$child" >"$2"
+wait "$child"
+`
+			if tc.public {
+				fakeSource = tc.setup
+			}
+			fake := writeFakeColima(t, dir, fakeSource)
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRunHostColimaWithTimeoutKillsRunawayChild$")
+			ownerPipe, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd.Env = append(os.Environ(),
+				"WORKCELL_COLIMA_TIMEOUT_HELPER=1",
+				"WORKCELL_COLIMA_TIMEOUT_BIN="+fake,
+				"WORKCELL_COLIMA_TIMEOUT_HOME="+dir,
+				"WORKCELL_COLIMA_TIMEOUT_MARKER="+marker,
+				"WORKCELL_COLIMA_TIMEOUT_ACK="+ack,
+				"WORKCELL_COLIMA_TIMEOUT_PUBLIC="+strconv.FormatBool(tc.public),
+			)
+			start := time.Now()
+			fixtureCommand := startOwnedFixtureCommand(t, cmd)
+			var fixtureGroup *ownedFixtureProcessGroup
+			if !tc.public {
+				fixtureGroup, err = readOwnedFixtureProcessGroupPipe(ownerPipe, cmd.Process.Pid, fake)
+				if err != nil {
+					t.Fatal(err)
+				}
+				registerOwnedFixtureGroupCleanup(t, fixtureGroup)
+				if err := os.WriteFile(marker+".owned", []byte("ready\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := validateOwnedFixtureProcessGroupMarker(fixtureGroup, marker); err != nil {
+					t.Fatal(err)
+				}
+				if tc.childACK != "" {
+					if err := os.WriteFile(marker+".child-owned", []byte(tc.childACK), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if tc.childACK == "ready\n" && len(pollProcessMarker(marker+".child-ready", 5*time.Second, 1)) != 1 {
+					t.Fatal("fixture child was not ready")
+				}
+				if tc.wantCode == ColimaTimeoutExitCode && !tc.public {
+					if err := os.WriteFile(ack, []byte("ready\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			err = fixtureCommand.wait()
+			if fixtureGroup != nil {
+				fixtureGroup.proveAbsent(t)
+			} else if !waitForFixtureCommandPathAbsent(fake, 5*time.Second) {
+				t.Fatalf("fixture command remains: %s", fake)
+			}
+			fixtureCommand.group.proveAbsent(t)
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != tc.wantCode {
+				t.Fatalf("timeout helper wait = %v, want status %d", err, tc.wantCode)
+			}
+			if elapsed := fixtureCommand.finishedAt.Sub(start); elapsed < tc.minRun || elapsed > tc.maxRun {
+				t.Fatalf("process-group cleanup completed in %s", elapsed)
+			}
+		})
+	}
+}
+
+func TestRunHostColimaWithContextPreservesPreStartDeadline(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Unix(1, 0))
+	defer cancel()
+	code, err := runHostColimaWithContext(ctx, HostColimaInvocation{
+		ColimaBin: "/usr/bin/true",
+		Args:      []string{"start"},
+	})
+	if err != nil || code != ColimaTimeoutExitCode {
+		t.Fatalf("pre-start deadline = %d, %v, want %d", code, err, ColimaTimeoutExitCode)
+	}
+
+	code, err = runHostColimaWithContext(context.Background(), HostColimaInvocation{
+		ColimaBin: "/workcell-missing-colima-binary",
+		Args:      []string{"start"},
+	})
+	if code != 0 || err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unrelated start error = %d, %v", code, err)
+	}
+}
+
+func TestColimaCancellationResultPreservesOutcomes(t *testing.T) {
+	termErr := processSignalError(t, syscall.SIGTERM)
+	killErr := processSignalError(t, syscall.SIGKILL)
+	interruptErr := processSignalError(t, syscall.SIGINT)
+	exitErr := exec.Command("/bin/sh", "-c", "exit 7").Run()
+	exit124Err := exec.Command("/bin/sh", "-c", "exit 124").Run()
+	ioErr := errors.New("write failed")
+	cleanupErr := errors.New("group remains")
+	for _, tc := range []struct {
+		name       string
+		runErr     error
+		cleanupErr error
+		cause      error
+		wantCode   int
+		wantErrors []error
+	}{
+		{"nil after deadline", nil, nil, context.DeadlineExceeded, 124, nil},
+		{"deadline error", context.DeadlineExceeded, nil, context.DeadlineExceeded, 124, nil},
+		{"TERM after deadline", termErr, nil, context.DeadlineExceeded, 124, nil},
+		{"KILL after deadline", killErr, nil, context.DeadlineExceeded, 124, nil},
+		{"ordinary exit 7", exitErr, nil, context.DeadlineExceeded, 7, nil},
+		{"ordinary exit 124", exit124Err, nil, context.DeadlineExceeded, 124, nil},
+		{"unrelated SIGINT", interruptErr, nil, context.DeadlineExceeded, 128 + int(syscall.SIGINT), nil},
+		{"I/O error", ioErr, nil, context.DeadlineExceeded, 0, []error{ioErr}},
+		{"cleanup after deadline", termErr, cleanupErr, context.DeadlineExceeded, 0, []error{termErr, cleanupErr, context.DeadlineExceeded}},
+		{"unexpected cause", termErr, nil, context.Canceled, 0, []error{context.Canceled}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := colimaCancellationResult(tc.runErr, tc.cleanupErr, tc.cause)
+			if code != tc.wantCode || (len(tc.wantErrors) == 0 && err != nil) {
+				t.Fatalf("colimaCancellationResult() = %d, %v", code, err)
+			}
+			for _, wantErr := range tc.wantErrors {
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("colimaCancellationResult() err = %v, want %v", err, wantErr)
+				}
+			}
+		})
 	}
 }
 
@@ -270,4 +428,283 @@ func writeFakeColima(t *testing.T, dir, script string) string {
 		t.Fatalf("chmod fake colima: %v", err)
 	}
 	return path
+}
+
+func processSignalError(t *testing.T, signal syscall.Signal) error {
+	t.Helper()
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Process.Signal(signal); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.Wait()
+	if err == nil {
+		t.Fatalf("signal %s produced no error", signal)
+	}
+	return err
+}
+
+func exitColimaFixture(code int, err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(125)
+	}
+	os.Exit(code)
+}
+
+func pollProcessMarker(path string, limit time.Duration, fieldCount int) []string {
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil {
+			if fields := strings.Fields(string(data)); len(fields) == fieldCount {
+				return fields
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil
+}
+
+func parseFixtureProcessMarker(path string) ([]int, error) {
+	fields := pollProcessMarker(path, 5*time.Second, 3)
+	values := make([]int, len(fields))
+	for i, field := range fields {
+		value, err := strconv.Atoi(field)
+		if err != nil {
+			return nil, fmt.Errorf("process marker %s field %q: %w", path, field, err)
+		}
+		values[i] = value
+	}
+	if len(values) != 3 {
+		return nil, fmt.Errorf("process marker %s was not ready", path)
+	}
+	return values, nil
+}
+
+func fixtureProcessIdentity(pid int) (int, string, error) {
+	groupID, err := syscall.Getpgid(pid)
+	if err != nil {
+		return 0, "", err
+	}
+	output, err := exec.Command("/bin/ps", "-o", "lstart=", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
+	return groupID, string(output), err
+}
+
+func readOwnedFixtureProcessGroupPipe(reader io.Reader, parentPID int, commandPath string) (*ownedFixtureProcessGroup, error) {
+	result := make(chan string, 1)
+	go func() {
+		line, _ := bufio.NewReader(reader).ReadString('\n')
+		result <- line
+	}()
+	var line string
+	select {
+	case line = <-result:
+	case <-time.After(5 * time.Second):
+		return nil, errors.New("fixture owner handshake timed out")
+	}
+	fields := strings.Fields(line)
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("fixture owner handshake has %d fields", len(fields))
+	}
+	groupID, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf("fixture owner group %q: %w", fields[0], err)
+	}
+	leaderPID, err := strconv.Atoi(fields[1])
+	if err != nil || groupID != leaderPID || validateSafeProcessGroupID(groupID) != nil {
+		return nil, fmt.Errorf("fixture owner has unsafe group=%d leader=%d", groupID, leaderPID)
+	}
+	actual, identity, err := fixtureProcessIdentity(leaderPID)
+	parent, parentErr := fixtureProcessParent(leaderPID)
+	if err != nil || parentErr != nil || actual != groupID || parent != parentPID || !strings.Contains(identity, commandPath) {
+		return nil, fmt.Errorf("fixture owner identity is not trusted: identity=%v parent=%v", err, parentErr)
+	}
+	return &ownedFixtureProcessGroup{id: groupID, members: map[int]string{leaderPID: identity}, active: true}, nil
+}
+
+func fixtureProcessParent(pid int) (int, error) {
+	output, err := exec.Command("/bin/ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(output)))
+}
+
+func validateOwnedFixtureProcessGroupMarker(group *ownedFixtureProcessGroup, marker string) error {
+	values, err := parseFixtureProcessMarker(marker)
+	if err != nil {
+		return err
+	}
+	groupID, leaderPID, childPID := values[0], values[1], values[2]
+	if group == nil || groupID != group.id || leaderPID != group.id || !group.hasLiveMember() {
+		return fmt.Errorf("process marker %s does not identify the owned group", marker)
+	}
+	actual, identity, err := fixtureProcessIdentity(childPID)
+	parent, parentErr := fixtureProcessParent(childPID)
+	if err != nil || parentErr != nil || actual != group.id || parent != leaderPID || !strings.Contains(identity, marker) {
+		return fmt.Errorf("fixture child %d identity is not owned: identity=%v parent=%v", childPID, err, parentErr)
+	}
+	group.members[childPID] = identity
+	return nil
+}
+
+type ownedFixtureProcessGroup struct {
+	id      int
+	members map[int]string
+	active  bool
+}
+
+type ownedFixtureCommand struct {
+	cmd        *exec.Cmd
+	group      *ownedFixtureProcessGroup
+	waitDone   chan struct{}
+	waitErr    error
+	finishedAt time.Time
+}
+
+func startOwnedFixtureCommand(t *testing.T, cmd *exec.Cmd) *ownedFixtureCommand {
+	t.Helper()
+	ready := filepath.Join(t.TempDir(), "outer-group-ready")
+	cmd.Env = append(cmd.Env, "WORKCELL_TEST_OUTER_GROUP_READY="+ready)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	fixture := &ownedFixtureCommand{cmd: cmd, waitDone: make(chan struct{})}
+	go func() {
+		fixture.waitErr = cmd.Wait()
+		fixture.finishedAt = time.Now()
+		close(fixture.waitDone)
+	}()
+	t.Cleanup(func() {
+		if fixture.group != nil {
+			if err := fixture.group.cleanup(); err != nil {
+				t.Error(err)
+			}
+		}
+		select {
+		case <-fixture.waitDone:
+			return
+		default:
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case <-fixture.waitDone:
+		case <-time.After(5 * time.Second):
+			t.Error("fixture process did not exit during cleanup")
+		}
+	})
+	actual, identity, err := fixtureProcessIdentity(cmd.Process.Pid)
+	if err != nil || actual != cmd.Process.Pid || validateSafeProcessGroupID(actual) != nil {
+		t.Fatalf("fixture leader %d has unsafe process group %d: %v", cmd.Process.Pid, actual, err)
+	}
+	group := &ownedFixtureProcessGroup{id: actual, members: map[int]string{cmd.Process.Pid: identity}}
+	group.active = true
+	fixture.group = group
+	if err := os.WriteFile(ready, []byte("ready\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
+func (f *ownedFixtureCommand) wait() error {
+	select {
+	case <-f.waitDone:
+		return f.waitErr
+	case <-time.After(15 * time.Second):
+		_ = f.group.cleanup()
+		_ = f.cmd.Process.Kill()
+		select {
+		case <-f.waitDone:
+			return fmt.Errorf("fixture command exceeded its wait limit: %w", f.waitErr)
+		case <-time.After(5 * time.Second):
+			return errors.New("fixture command did not exit after its wait limit")
+		}
+	}
+}
+
+func registerOwnedFixtureGroupCleanup(t *testing.T, group *ownedFixtureProcessGroup) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := group.cleanup(); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func (g *ownedFixtureProcessGroup) cleanup() error {
+	if !g.active {
+		return nil
+	}
+	absent, err := waitForFixtureGroupExit(g.id, 0)
+	if err == nil && absent {
+		g.active = false
+		return nil
+	}
+	if !g.hasLiveMember() {
+		return fmt.Errorf("refuse cleanup of process group %d without a live owned member", g.id)
+	}
+	if err := syscall.Kill(-g.id, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("cleanup process group %d: %w", g.id, err)
+	}
+	absent, err = waitForFixtureGroupExit(g.id, 5*time.Second)
+	if err != nil || !absent {
+		return fmt.Errorf("cleanup did not prove process group %d absent: %v", g.id, err)
+	}
+	g.active = false
+	return nil
+}
+
+func (g *ownedFixtureProcessGroup) hasLiveMember() bool {
+	return g.hasLiveMemberWith(fixtureProcessIdentity)
+}
+
+func (g *ownedFixtureProcessGroup) hasLiveMemberWith(inspect func(int) (int, string, error)) bool {
+	for pid, identity := range g.members {
+		if actual, current, err := inspect(pid); err == nil && actual == g.id && current == identity {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *ownedFixtureProcessGroup) proveAbsent(t *testing.T) {
+	t.Helper()
+	absent, err := waitForFixtureGroupExit(g.id, 5*time.Second)
+	if err != nil || !absent {
+		t.Fatalf("process group %d remains: absent=%v err=%v", g.id, absent, err)
+	}
+	g.active = false
+}
+
+func waitForFixtureGroupExit(groupID int, limit time.Duration) (bool, error) {
+	if groupID <= 1 || groupID == syscall.Getpgrp() {
+		return false, fmt.Errorf("unsafe fixture group %d", groupID)
+	}
+	deadline := time.Now().Add(limit)
+	for {
+		err := syscall.Kill(-groupID, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return true, nil
+		}
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			return false, err
+		}
+		if !time.Now().Before(deadline) {
+			return false, nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func waitForOwnedFixtureCommandReady() {
+	ready := os.Getenv("WORKCELL_TEST_OUTER_GROUP_READY")
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
+		if _, err := os.Stat(ready); err == nil {
+			return
+		}
+	}
+	os.Exit(125)
 }

--- a/internal/host/launcher/process_exit_watch_darwin.go
+++ b/internal/host/launcher/process_exit_watch_darwin.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package launcher
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const darwinProcessExitWatchPollInterval = 100 * time.Millisecond
+
+type darwinProcessExitWatcher struct {
+	doneCh  chan error
+	stopCh  chan struct{}
+	stopOne sync.Once
+}
+
+func (w *darwinProcessExitWatcher) done() <-chan error { return w.doneCh }
+
+func (w *darwinProcessExitWatcher) close() error {
+	w.stopOne.Do(func() { close(w.stopCh) })
+	return nil
+}
+
+func validateProcessExitWatchSupport() error { return nil }
+
+func startProcessExitWatch(pid int) (processExitWatcher, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("process exit watch requires positive pid: %d", pid)
+	}
+	kqueue, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create process exit kqueue: %w", err)
+	}
+	change := unix.Kevent_t{
+		Ident:  uint64(pid),
+		Filter: unix.EVFILT_PROC,
+		Flags:  unix.EV_ADD | unix.EV_ONESHOT,
+		Fflags: unix.NOTE_EXIT,
+	}
+	if _, err := unix.Kevent(kqueue, []unix.Kevent_t{change}, nil, nil); err != nil {
+		closeErr := unix.Close(kqueue)
+		if errors.Is(err, syscall.ESRCH) {
+			// The child can already have exited while it remains unreaped.
+			return newCompletedExitWatcher(closeErr), nil
+		}
+		return nil, errors.Join(fmt.Errorf("register process %d exit watch: %w", pid, err), closeErr)
+	}
+
+	watcher := &darwinProcessExitWatcher{
+		doneCh: make(chan error, 1),
+		stopCh: make(chan struct{}),
+	}
+	go watcher.wait(kqueue, pid)
+	return watcher, nil
+}
+
+func (w *darwinProcessExitWatcher) wait(kqueue, pid int) {
+	var watchErr error
+	for {
+		select {
+		case <-w.stopCh:
+			goto done
+		default:
+		}
+
+		events := make([]unix.Kevent_t, 1)
+		timeout := unix.NsecToTimespec(darwinProcessExitWatchPollInterval.Nanoseconds())
+		count, err := unix.Kevent(kqueue, nil, events, &timeout)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			watchErr = fmt.Errorf("wait for process %d exit: %w", pid, err)
+			break
+		}
+		if count == 0 {
+			continue
+		}
+		if count != 1 {
+			watchErr = fmt.Errorf("wait for process %d exit: unexpected kqueue event count %d", pid, count)
+			break
+		}
+		event := events[0]
+		if event.Flags&unix.EV_ERROR != 0 {
+			errno := syscall.Errno(event.Data)
+			if errno == 0 {
+				watchErr = fmt.Errorf("wait for process %d exit: kqueue returned an unspecified error", pid)
+			} else {
+				watchErr = fmt.Errorf("wait for process %d exit: %w", pid, errno)
+			}
+			break
+		}
+		if event.Filter != unix.EVFILT_PROC || event.Ident != uint64(pid) || event.Fflags&unix.NOTE_EXIT == 0 {
+			watchErr = fmt.Errorf("wait for process %d exit: unexpected kqueue event", pid)
+		}
+		break
+	}
+done:
+	w.doneCh <- errors.Join(watchErr, unix.Close(kqueue))
+}

--- a/internal/host/launcher/process_exit_watch_linux.go
+++ b/internal/host/launcher/process_exit_watch_linux.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package launcher
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func validateProcessExitWatchSupport() error { return nil }
+
+type pidfdExitWatcher struct {
+	doneCh           chan error
+	finished, stopCh chan struct{}
+	stopOnce         sync.Once
+	fd, pid          int
+}
+
+func (w *pidfdExitWatcher) done() <-chan error { return w.doneCh }
+
+func (w *pidfdExitWatcher) close() error {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	<-w.finished
+	return nil
+}
+
+func startProcessExitWatch(pid int) (processExitWatcher, error) {
+	fd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open process %d exit watch: %w", pid, err)
+	}
+	watcher := &pidfdExitWatcher{
+		doneCh:   make(chan error, 1),
+		finished: make(chan struct{}),
+		stopCh:   make(chan struct{}),
+		fd:       fd,
+		pid:      pid,
+	}
+	go watcher.run()
+	return watcher, nil
+}
+
+func (w *pidfdExitWatcher) run() {
+	var watchErr error
+	defer func() {
+		w.doneCh <- errors.Join(watchErr, unix.Close(w.fd))
+		close(w.finished)
+	}()
+
+	pollFDs := []unix.PollFd{{Fd: int32(w.fd), Events: unix.POLLIN}}
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		default:
+		}
+
+		pollFDs[0].Revents = 0
+		count, err := unix.Poll(pollFDs, 100)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			watchErr = fmt.Errorf("wait for process %d exit: %w", w.pid, err)
+			return
+		}
+		select {
+		case <-w.stopCh:
+			return
+		default:
+		}
+		if count == 0 {
+			continue
+		}
+		if count != 1 || pollFDs[0].Revents&unix.POLLIN == 0 {
+			watchErr = fmt.Errorf("wait for process %d exit: unexpected pidfd event", w.pid)
+		}
+		return
+	}
+}

--- a/internal/host/launcher/process_exit_watch_other.go
+++ b/internal/host/launcher/process_exit_watch_other.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build !darwin && !linux
+
+package launcher
+
+import "errors"
+
+func validateProcessExitWatchSupport() error {
+	return errors.New("process-group supervision requires Darwin or Linux exit observation")
+}
+
+func startProcessExitWatch(int) (processExitWatcher, error) {
+	return nil, validateProcessExitWatchSupport()
+}

--- a/internal/host/launcher/process_exit_watch_test.go
+++ b/internal/host/launcher/process_exit_watch_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin || linux
+
+package launcher
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func startWatchedTestCommand(t *testing.T, cmd *exec.Cmd) processExitWatcher {
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	watch, err := startProcessExitWatch(cmd.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return watch
+}
+func awaitTestExitWatch(t *testing.T, watch processExitWatcher) {
+	t.Helper()
+	select {
+	case err := <-watch.done():
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit watch did not report")
+	}
+}
+func TestProcessExitWatchDoesNotReap(t *testing.T) {
+	for _, tc := range []struct {
+		name, script string
+		code         int
+	}{{"zero", "exit 0", 0}, {"nonzero", "exit 7", 7}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("/bin/sh", "-c", tc.script)
+			watch := startWatchedTestCommand(t, cmd)
+			awaitTestExitWatch(t, watch)
+			if cmd.ProcessState != nil {
+				t.Fatal("exit watch reaped the child")
+			}
+			waitErr := cmd.Wait()
+			var exitErr *exec.ExitError
+			if tc.code == 0 && waitErr != nil ||
+				tc.code != 0 && (!errors.As(waitErr, &exitErr) || exitErr.ExitCode() != tc.code) {
+				t.Fatalf("Wait error = %v, want exit %d", waitErr, tc.code)
+			}
+		})
+	}
+}
+func TestProcessExitWatchCloseDrainsWithoutReap(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", ".2")
+	watch := startWatchedTestCommand(t, cmd)
+	select {
+	case err := <-watch.done():
+		t.Fatalf("live watch completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := watch.close(); err != nil {
+		t.Fatal(err)
+	}
+	awaitTestExitWatch(t, watch)
+	if cmd.ProcessState != nil {
+		t.Fatal("closing the watch reaped the child")
+	}
+	_ = cmd.Wait()
+}

--- a/internal/host/launcher/process_group_supervisor.go
+++ b/internal/host/launcher/process_group_supervisor.go
@@ -276,11 +276,11 @@ func (s processGroupSupervisor) stopStartedCommand(cmd *exec.Cmd, owner processG
 	}
 	cleanupErr := errors.Join(leaderKillErr, watchTimeoutErr,
 		closeAndDrainExitWatch(exitWatch, watchReady, watchErr, processGroupWatchDrainLimit))
-	if leaderKillErr != nil && !(watchReady && watchErr == nil) {
+	if !(watchReady && watchErr == nil) {
 		return nil, errors.Join(cleanupErr,
 			processGroupSignalError(owner.pid, "SIGTERM", sigtermErr, false),
 			processGroupSignalError(owner.pid, "SIGKILL", sigkillErr, false),
-			fmt.Errorf("process-group leader %d exit was not observed after direct kill failure; command wait skipped", owner.pid))
+			fmt.Errorf("process-group leader %d exit was not observed; command wait skipped", owner.pid))
 	}
 	waitErr := waitStartedCommand(cmd, s.proofLimit)
 	proofErr := s.proveOwnedGroupAbsent(cmd, owner)

--- a/internal/host/launcher/process_group_supervisor.go
+++ b/internal/host/launcher/process_group_supervisor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -16,11 +17,31 @@ import (
 const (
 	processGroupTerminationGrace = 5 * time.Second
 	processGroupProofLimit       = 5 * time.Second
-	processGroupWaitDelay        = 5 * time.Second
 	processGroupPollInterval     = 25 * time.Millisecond
+	processGroupWatchDrainLimit  = 5 * time.Second
 )
 
-type ownedProcessGroupID int
+type processGroupOwner struct {
+	pid        int
+	generation string
+}
+
+// Receiving from done means the watcher stopped and closed its descriptor.
+type processExitWatcher interface {
+	done() <-chan error
+	close() error
+}
+
+type completedExitWatcher <-chan error
+
+func (w completedExitWatcher) done() <-chan error { return w }
+func (completedExitWatcher) close() error         { return nil }
+
+func newCompletedExitWatcher(err error) processExitWatcher {
+	result := make(chan error, 1)
+	result <- err
+	return completedExitWatcher(result)
+}
 
 type processGroupRunResult struct {
 	runErr           error
@@ -31,22 +52,30 @@ type processGroupRunResult struct {
 }
 
 type processGroupSupervisor struct {
-	signalGroup func(int, syscall.Signal) error
-	waitAbsent  func(int, time.Duration) (bool, error)
-	killProcess func(*os.Process) error
-	termGrace   time.Duration
-	proofLimit  time.Duration
-	waitDelay   time.Duration
+	afterFunc         func(context.Context, func()) func() bool
+	captureGeneration func(int) (string, error)
+	observeGeneration func(int, string) (string, error)
+	processGroupID    func(int) (int, error)
+	watchExit         func(int) (processExitWatcher, error)
+	signalGroup       func(int, syscall.Signal) error
+	waitAbsent        func(int, time.Duration) (bool, error)
+	killProcess       func(*os.Process) error
+	termGrace         time.Duration
+	proofLimit        time.Duration
 }
 
 func defaultProcessGroupSupervisor() processGroupSupervisor {
 	return processGroupSupervisor{
-		signalGroup: signalProcessGroup,
-		waitAbsent:  waitForProcessGroupExit,
-		killProcess: killExactProcess,
-		termGrace:   processGroupTerminationGrace,
-		proofLimit:  processGroupProofLimit,
-		waitDelay:   processGroupWaitDelay,
+		afterFunc:         context.AfterFunc,
+		captureGeneration: processGeneration,
+		observeGeneration: ObserveProcessGeneration,
+		processGroupID:    syscall.Getpgid,
+		watchExit:         startProcessExitWatch,
+		signalGroup:       signalProcessGroup,
+		waitAbsent:        waitForProcessGroupExit,
+		killProcess:       killExactProcess,
+		termGrace:         processGroupTerminationGrace,
+		proofLimit:        processGroupProofLimit,
 	}
 }
 
@@ -54,39 +83,66 @@ func (s processGroupSupervisor) run(ctx context.Context, cmd *exec.Cmd) processG
 	if err := validateProcessGroupCommand(cmd); err != nil {
 		return processGroupRunResult{runErr: err, cause: context.Cause(ctx)}
 	}
+	if err := validateProcessExitWatchSupport(); err != nil {
+		return processGroupRunResult{runErr: err, cause: context.Cause(ctx)}
+	}
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.Setpgid = true
-	if s.waitDelay <= 0 {
-		s.waitDelay = processGroupWaitDelay
-	}
-	cmd.WaitDelay = s.waitDelay
-	cleanupResult := make(chan error, 1)
-	cmd.Cancel = func() error {
-		groupID, absent, err := ownedProcessGroupForProcess(cmd.Process)
-		if err != nil {
-			err = errors.Join(err, s.killLeader(cmd.Process))
-		} else if !absent {
-			err = s.terminate(groupID, cmd.Process)
-		}
-		cleanupResult <- err
-		return err
-	}
+	// Disable os/exec cancellation so it cannot reap or signal the child.
+	cmd.Cancel = nil
+	cmd.WaitDelay = 0
 
-	runErr := cmd.Run()
-	result := processGroupRunResult{
-		runErr:           runErr,
-		cause:            context.Cause(ctx),
-		preStartCanceled: cmd.Process == nil && ctx.Err() != nil && errors.Is(runErr, ctx.Err()),
+	runErr := cmd.Start()
+	if runErr != nil {
+		return processGroupRunResult{
+			runErr:           runErr,
+			cause:            context.Cause(ctx),
+			preStartCanceled: cmd.Process == nil && ctx.Err() != nil && errors.Is(runErr, ctx.Err()),
+		}
 	}
+	owner, err := s.captureOwner(cmd.Process)
+	if err != nil {
+		return s.abortStartedCommand(ctx, cmd, processGroupOwner{pid: cmd.Process.Pid}, fmt.Errorf("capture process-group owner: %w", err))
+	}
+	exitWatch, err := s.startExitWatch(owner.pid)
+	if err != nil {
+		return s.abortStartedCommand(ctx, cmd, owner, fmt.Errorf("start process-group leader exit watch: %w", err))
+	}
+	cancelRequest := make(chan error, 1)
+	stopCancel := s.afterFunc(ctx, func() {
+		cause := context.Cause(ctx)
+		if cause == nil {
+			cause = ctx.Err()
+		}
+		cancelRequest <- cause
+	})
+	// The cancellation callback is the arbitration point. If it has started,
+	// cancellation wins; if Stop succeeds, the observed exit commits first.
 	select {
-	case cleanupErr := <-cleanupResult:
-		result.cleanupErr = cleanupErr
-		result.cleanupRan = true
-	default:
+	case watchErr := <-exitWatch.done():
+		if stopCancel() {
+			if watchErr != nil {
+				return s.abortWatchedCommand(cmd, owner, exitWatch, watchErr)
+			}
+			closeErr := closeAndDrainExitWatch(exitWatch, true, watchErr, processGroupWatchDrainLimit)
+			waitErr := waitStartedCommand(cmd, processGroupProofLimit)
+			return processGroupRunResult{runErr: errors.Join(waitErr, closeErr)}
+		}
+		cause := <-cancelRequest
+		return s.cancelStartedCommand(cmd, owner, exitWatch, true, watchErr, cause)
+	case cause := <-cancelRequest:
+		return s.cancelStartedCommand(cmd, owner, exitWatch, false, nil, cause)
 	}
-	return result
+}
+
+func (s processGroupSupervisor) startExitWatch(pid int) (processExitWatcher, error) {
+	watch, err := s.watchExit(pid)
+	if err == nil && watch == nil {
+		err = errors.New("process-group exit watch is required")
+	}
+	return watch, err
 }
 
 func validateProcessGroupCommand(cmd *exec.Cmd) error {
@@ -99,26 +155,155 @@ func validateProcessGroupCommand(cmd *exec.Cmd) error {
 	return nil
 }
 
-func ownedProcessGroupForProcess(process *os.Process) (ownedProcessGroupID, bool, error) {
+func (s processGroupSupervisor) captureOwner(process *os.Process) (processGroupOwner, error) {
 	if process == nil {
-		return 0, false, errors.New("process-group leader is required")
+		return processGroupOwner{}, errors.New("process-group leader is required")
 	}
-	groupID := process.Pid
-	if err := validateSafeProcessGroupID(groupID); err != nil {
-		return 0, false, err
+	owner := processGroupOwner{pid: process.Pid}
+	if err := validateSafeProcessGroupID(owner.pid); err != nil {
+		return processGroupOwner{}, err
 	}
-	actualGroupID, err := syscall.Getpgid(process.Pid)
-	if errors.Is(err, syscall.ESRCH) {
-		absent, probeErr := waitForProcessGroupExit(groupID, 0)
-		return ownedProcessGroupID(groupID), absent, probeErr
-	}
+	generation, err := s.captureGeneration(owner.pid)
 	if err != nil {
-		return 0, false, fmt.Errorf("resolve process group for leader %d: %w", process.Pid, err)
+		return processGroupOwner{}, fmt.Errorf("capture process-group leader %d generation: %w", owner.pid, err)
 	}
-	if actualGroupID != groupID {
-		return 0, false, fmt.Errorf("process %d belongs to group %d, not its dedicated group", process.Pid, actualGroupID)
+	if generation == "" {
+		return processGroupOwner{}, fmt.Errorf("capture process-group leader %d generation: empty generation", owner.pid)
 	}
-	return ownedProcessGroupID(groupID), false, nil
+	if !strings.HasPrefix(generation, "darwin:") && !strings.HasPrefix(generation, "linux:") {
+		return processGroupOwner{}, fmt.Errorf("capture process-group leader %d generation: unsupported generation", owner.pid)
+	}
+	owner.generation = generation
+	if _, err := s.currentOwnedGroup(owner); err != nil {
+		return processGroupOwner{}, fmt.Errorf("capture process-group leader %d ownership: %w", owner.pid, err)
+	}
+	return owner, nil
+}
+
+func (s processGroupSupervisor) currentOwnedGroup(owner processGroupOwner) (int, error) {
+	if err := validateSafeProcessGroupID(owner.pid); err != nil {
+		return 0, err
+	}
+	observed, err := s.observeGeneration(owner.pid, owner.generation)
+	if err != nil {
+		return 0, fmt.Errorf("observe process-group leader %d generation: %w", owner.pid, err)
+	}
+	if observed != owner.generation {
+		return 0, fmt.Errorf("process-group leader %d generation changed", owner.pid)
+	}
+	groupID, err := s.processGroupID(owner.pid)
+	if err != nil {
+		return 0, fmt.Errorf("resolve process group for leader %d: %w", owner.pid, err)
+	}
+	if groupID != owner.pid {
+		return 0, fmt.Errorf("process %d belongs to group %d, not its dedicated group", owner.pid, groupID)
+	}
+	observed, err = s.observeGeneration(owner.pid, owner.generation)
+	if err != nil {
+		return 0, fmt.Errorf("revalidate process-group leader %d generation: %w", owner.pid, err)
+	}
+	if observed != owner.generation {
+		return 0, fmt.Errorf("process-group leader %d generation changed", owner.pid)
+	}
+	return groupID, nil
+}
+
+func (s processGroupSupervisor) cancelStartedCommand(cmd *exec.Cmd, owner processGroupOwner, exitWatch processExitWatcher, watchReady bool, watchErr, cause error) processGroupRunResult {
+	waitErr, cleanupErr := s.stopStartedCommand(cmd, owner, exitWatch, watchReady, watchErr, true)
+	return processGroupRunResult{
+		runErr:     waitErr,
+		cleanupErr: cleanupErr,
+		cause:      cause,
+		cleanupRan: true,
+	}
+}
+
+func (s processGroupSupervisor) abortStartedCommand(ctx context.Context, cmd *exec.Cmd, owner processGroupOwner, startErr error) processGroupRunResult {
+	waitErr, cleanupErr := s.stopStartedCommand(cmd, owner, nil, false, nil, false)
+	return processGroupAbortResultWithCause(context.Cause(ctx), startErr, waitErr, cleanupErr)
+}
+
+func (s processGroupSupervisor) abortWatchedCommand(cmd *exec.Cmd, owner processGroupOwner, exitWatch processExitWatcher, watchErr error) processGroupRunResult {
+	waitErr, cleanupErr := s.stopStartedCommand(cmd, owner, exitWatch, true, watchErr, false)
+	return processGroupAbortResultWithCause(nil, nil, waitErr, cleanupErr)
+}
+
+func processGroupAbortResultWithCause(cause, supervisionErr, waitErr, cleanupErr error) processGroupRunResult {
+	if cause == nil {
+		return processGroupRunResult{
+			runErr: errors.Join(supervisionErr, nonExitWaitFailure(waitErr), cleanupErr),
+		}
+	}
+	return processGroupRunResult{
+		runErr:     waitErr,
+		cleanupErr: errors.Join(supervisionErr, cleanupErr),
+		cause:      cause,
+		cleanupRan: true,
+	}
+}
+
+func nonExitWaitFailure(waitErr error) error {
+	var exitErr *exec.ExitError
+	if waitErr == nil || errors.As(waitErr, &exitErr) {
+		return nil
+	}
+	return waitErr
+}
+
+// stopStartedCommand keeps the child unreaped until all numeric signals finish.
+func (s processGroupSupervisor) stopStartedCommand(cmd *exec.Cmd, owner processGroupOwner, exitWatch processExitWatcher, watchReady bool, watchErr error, sendTerm bool) (error, error) {
+	if cmd == nil || cmd.Process == nil {
+		return nil, errors.New("started process-group command is required")
+	}
+	var sigtermErr error
+	if sendTerm {
+		sigtermErr = s.signalOwnedGroup(owner, syscall.SIGTERM)
+		if !watchReady {
+			watchReady, watchErr = awaitExitWatch(exitWatch, s.termGrace)
+		}
+	}
+	sigkillErr := s.signalOwnedGroup(owner, syscall.SIGKILL)
+	leaderKillErr := s.killProcess(cmd.Process)
+	var watchTimeoutErr error
+	if !watchReady && exitWatch != nil {
+		observed, postKillErr := awaitExitWatch(exitWatch, s.proofLimit)
+		if observed {
+			watchReady = true
+			watchErr = errors.Join(watchErr, postKillErr)
+		} else {
+			watchTimeoutErr = fmt.Errorf("process-group leader %d exit watch did not signal after SIGKILL", owner.pid)
+		}
+	}
+	cleanupErr := errors.Join(leaderKillErr, watchTimeoutErr,
+		closeAndDrainExitWatch(exitWatch, watchReady, watchErr, processGroupWatchDrainLimit))
+	if leaderKillErr != nil && !(watchReady && watchErr == nil) {
+		return nil, errors.Join(cleanupErr,
+			processGroupSignalError(owner.pid, "SIGTERM", sigtermErr, false),
+			processGroupSignalError(owner.pid, "SIGKILL", sigkillErr, false),
+			fmt.Errorf("process-group leader %d exit was not observed after direct kill failure; command wait skipped", owner.pid))
+	}
+	waitErr := waitStartedCommand(cmd, s.proofLimit)
+	proofErr := s.proveOwnedGroupAbsent(cmd, owner)
+	// Darwin can report EPERM for a zombie-only group after the leader exits.
+	proofSucceeded := proofErr == nil
+	return waitErr, errors.Join(cleanupErr,
+		processGroupSignalError(owner.pid, "SIGTERM", sigtermErr, proofSucceeded),
+		processGroupSignalError(owner.pid, "SIGKILL", sigkillErr, proofSucceeded),
+		proofErr)
+}
+
+func processGroupSignalError(pid int, signal string, err error, suppressEPERM bool) error {
+	if err == nil || (suppressEPERM && errors.Is(err, syscall.EPERM)) {
+		return nil
+	}
+	return fmt.Errorf("signal process group %d with %s: %w", pid, signal, err)
+}
+
+func (s processGroupSupervisor) signalOwnedGroup(owner processGroupOwner, signal syscall.Signal) error {
+	if err := validateSafeProcessGroupID(owner.pid); err != nil {
+		return err
+	}
+	return s.signalGroup(owner.pid, signal)
 }
 
 func killExactProcess(process *os.Process) error {
@@ -131,44 +316,88 @@ func killExactProcess(process *os.Process) error {
 	return nil
 }
 
-func (s processGroupSupervisor) terminate(groupID ownedProcessGroupID, process *os.Process) error {
-	var cleanupErrors []error
-	if err := s.signalGroup(int(groupID), syscall.SIGTERM); err != nil {
-		cleanupErrors = append(cleanupErrors, fmt.Errorf("signal process group %d with SIGTERM: %w", groupID, err))
+func awaitExitWatch(exitWatch processExitWatcher, limit time.Duration) (bool, error) {
+	if exitWatch == nil {
+		return false, nil
 	}
-	absent, err := s.waitAbsent(int(groupID), s.termGrace)
-	if err != nil {
-		cleanupErrors = append(cleanupErrors, fmt.Errorf("poll process group %d after SIGTERM: %w", groupID, err))
+	if limit <= 0 {
+		limit = processGroupTerminationGrace
 	}
-	if absent && err == nil {
-		return errors.Join(cleanupErrors...)
+	timer := time.NewTimer(limit)
+	defer timer.Stop()
+	select {
+	case err := <-exitWatch.done():
+		return true, err
+	case <-timer.C:
+		return false, nil
 	}
-	if err := s.signalGroup(int(groupID), syscall.SIGKILL); err != nil {
-		cleanupErrors = append(cleanupErrors, fmt.Errorf("signal process group %d with SIGKILL: %w", groupID, err))
-		if fallbackErr := s.killLeader(process); fallbackErr != nil {
-			cleanupErrors = append(cleanupErrors, fallbackErr)
-		}
-	}
-	absent, err = s.waitAbsent(int(groupID), s.proofLimit)
-	if err != nil {
-		cleanupErrors = append(cleanupErrors, fmt.Errorf("poll process group %d after SIGKILL: %w", groupID, err))
-	}
-	if !absent || err != nil {
-		if err == nil {
-			cleanupErrors = append(cleanupErrors, fmt.Errorf("process group %d remains after SIGKILL", groupID))
-		}
-		if fallbackErr := s.killLeader(process); fallbackErr != nil {
-			cleanupErrors = append(cleanupErrors, fallbackErr)
-		}
-	}
-	return errors.Join(cleanupErrors...)
 }
 
-func (s processGroupSupervisor) killLeader(process *os.Process) error {
-	if s.killProcess != nil {
-		return s.killProcess(process)
+func closeAndDrainExitWatch(exitWatch processExitWatcher, ready bool, priorErr error, limit time.Duration) error {
+	if exitWatch == nil {
+		return priorErr
 	}
-	return killExactProcess(process)
+	closeErr := exitWatch.close()
+	if ready {
+		return errors.Join(priorErr, closeErr)
+	}
+	if limit <= 0 {
+		limit = processGroupWatchDrainLimit
+	}
+	ready, err := awaitExitWatch(exitWatch, limit)
+	if !ready {
+		err = errors.New("process-group exit watch did not drain")
+	}
+	return errors.Join(priorErr, closeErr, err)
+}
+
+func waitStartedCommand(cmd *exec.Cmd, limit time.Duration) error {
+	if cmd == nil {
+		return errors.New("started process-group command is required")
+	}
+	if limit <= 0 {
+		limit = processGroupProofLimit
+	}
+	// WaitDelay bounds copy goroutines after all process-group signals finish.
+	cmd.WaitDelay = limit
+	return cmd.Wait()
+}
+
+func (s processGroupSupervisor) proveOwnedGroupAbsent(cmd *exec.Cmd, owner processGroupOwner) error {
+	if cmd == nil || cmd.ProcessState == nil {
+		return errors.New("cannot prove process-group absence before the leader is reaped")
+	}
+	if owner.pid <= 0 {
+		return fmt.Errorf("cannot prove process-group absence for invalid leader %d", owner.pid)
+	}
+	if owner.generation == "" {
+		return fmt.Errorf("cannot prove process-group %d absence without leader generation", owner.pid)
+	}
+	observed, err := s.observeGeneration(owner.pid, owner.generation)
+	if err == nil {
+		if observed != owner.generation {
+			return fmt.Errorf("process-group leader %d generation changed after wait", owner.pid)
+		}
+		return fmt.Errorf("process-group leader %d remains after wait", owner.pid)
+	}
+	if !IsProcessGone(err) {
+		return fmt.Errorf("prove process-group leader %d is gone: %w", owner.pid, err)
+	}
+	absent, err := s.waitForOwnedGroupAbsence(owner.pid)
+	if err != nil {
+		return fmt.Errorf("poll process group %d after wait: %w", owner.pid, err)
+	}
+	if !absent {
+		return fmt.Errorf("process group %d remains after wait", owner.pid)
+	}
+	return nil
+}
+
+func (s processGroupSupervisor) waitForOwnedGroupAbsence(groupID int) (bool, error) {
+	if err := validateSafeProcessGroupID(groupID); err != nil {
+		return false, err
+	}
+	return s.waitAbsent(groupID, s.proofLimit)
 }
 
 func signalProcessGroup(groupID int, signal syscall.Signal) error {

--- a/internal/host/launcher/process_group_supervisor.go
+++ b/internal/host/launcher/process_group_supervisor.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const (
+	processGroupTerminationGrace = 5 * time.Second
+	processGroupProofLimit       = 5 * time.Second
+	processGroupWaitDelay        = 5 * time.Second
+	processGroupPollInterval     = 25 * time.Millisecond
+)
+
+type ownedProcessGroupID int
+
+type processGroupRunResult struct {
+	runErr           error
+	cleanupErr       error
+	cause            error
+	cleanupRan       bool
+	preStartCanceled bool
+}
+
+type processGroupSupervisor struct {
+	signalGroup func(int, syscall.Signal) error
+	waitAbsent  func(int, time.Duration) (bool, error)
+	killProcess func(*os.Process) error
+	termGrace   time.Duration
+	proofLimit  time.Duration
+	waitDelay   time.Duration
+}
+
+func defaultProcessGroupSupervisor() processGroupSupervisor {
+	return processGroupSupervisor{
+		signalGroup: signalProcessGroup,
+		waitAbsent:  waitForProcessGroupExit,
+		killProcess: killExactProcess,
+		termGrace:   processGroupTerminationGrace,
+		proofLimit:  processGroupProofLimit,
+		waitDelay:   processGroupWaitDelay,
+	}
+}
+
+func (s processGroupSupervisor) run(ctx context.Context, cmd *exec.Cmd) processGroupRunResult {
+	if err := validateProcessGroupCommand(cmd); err != nil {
+		return processGroupRunResult{runErr: err, cause: context.Cause(ctx)}
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	if s.waitDelay <= 0 {
+		s.waitDelay = processGroupWaitDelay
+	}
+	cmd.WaitDelay = s.waitDelay
+	cleanupResult := make(chan error, 1)
+	cmd.Cancel = func() error {
+		groupID, absent, err := ownedProcessGroupForProcess(cmd.Process)
+		if err != nil {
+			err = errors.Join(err, s.killLeader(cmd.Process))
+		} else if !absent {
+			err = s.terminate(groupID, cmd.Process)
+		}
+		cleanupResult <- err
+		return err
+	}
+
+	runErr := cmd.Run()
+	result := processGroupRunResult{
+		runErr:           runErr,
+		cause:            context.Cause(ctx),
+		preStartCanceled: cmd.Process == nil && ctx.Err() != nil && errors.Is(runErr, ctx.Err()),
+	}
+	select {
+	case cleanupErr := <-cleanupResult:
+		result.cleanupErr = cleanupErr
+		result.cleanupRan = true
+	default:
+	}
+	return result
+}
+
+func validateProcessGroupCommand(cmd *exec.Cmd) error {
+	if cmd == nil {
+		return errors.New("process-group command is required")
+	}
+	if cmd.SysProcAttr != nil && (cmd.SysProcAttr.Pgid != 0 || cmd.SysProcAttr.Foreground) {
+		return errors.New("process-group command must not select a pre-existing or foreground process group")
+	}
+	return nil
+}
+
+func ownedProcessGroupForProcess(process *os.Process) (ownedProcessGroupID, bool, error) {
+	if process == nil {
+		return 0, false, errors.New("process-group leader is required")
+	}
+	groupID := process.Pid
+	if err := validateSafeProcessGroupID(groupID); err != nil {
+		return 0, false, err
+	}
+	actualGroupID, err := syscall.Getpgid(process.Pid)
+	if errors.Is(err, syscall.ESRCH) {
+		absent, probeErr := waitForProcessGroupExit(groupID, 0)
+		return ownedProcessGroupID(groupID), absent, probeErr
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("resolve process group for leader %d: %w", process.Pid, err)
+	}
+	if actualGroupID != groupID {
+		return 0, false, fmt.Errorf("process %d belongs to group %d, not its dedicated group", process.Pid, actualGroupID)
+	}
+	return ownedProcessGroupID(groupID), false, nil
+}
+
+func killExactProcess(process *os.Process) error {
+	if process == nil {
+		return nil
+	}
+	if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("kill process-group leader %d: %w", process.Pid, err)
+	}
+	return nil
+}
+
+func (s processGroupSupervisor) terminate(groupID ownedProcessGroupID, process *os.Process) error {
+	var cleanupErrors []error
+	if err := s.signalGroup(int(groupID), syscall.SIGTERM); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("signal process group %d with SIGTERM: %w", groupID, err))
+	}
+	absent, err := s.waitAbsent(int(groupID), s.termGrace)
+	if err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("poll process group %d after SIGTERM: %w", groupID, err))
+	}
+	if absent && err == nil {
+		return errors.Join(cleanupErrors...)
+	}
+	if err := s.signalGroup(int(groupID), syscall.SIGKILL); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("signal process group %d with SIGKILL: %w", groupID, err))
+		if fallbackErr := s.killLeader(process); fallbackErr != nil {
+			cleanupErrors = append(cleanupErrors, fallbackErr)
+		}
+	}
+	absent, err = s.waitAbsent(int(groupID), s.proofLimit)
+	if err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("poll process group %d after SIGKILL: %w", groupID, err))
+	}
+	if !absent || err != nil {
+		if err == nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("process group %d remains after SIGKILL", groupID))
+		}
+		if fallbackErr := s.killLeader(process); fallbackErr != nil {
+			cleanupErrors = append(cleanupErrors, fallbackErr)
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func (s processGroupSupervisor) killLeader(process *os.Process) error {
+	if s.killProcess != nil {
+		return s.killProcess(process)
+	}
+	return killExactProcess(process)
+}
+
+func signalProcessGroup(groupID int, signal syscall.Signal) error {
+	return signalProcessGroupWithKill(groupID, signal, syscall.Kill)
+}
+
+func signalProcessGroupWithKill(groupID int, signal syscall.Signal, kill func(int, syscall.Signal) error) error {
+	if err := validateSafeProcessGroupID(groupID); err != nil {
+		return err
+	}
+	if err := kill(-groupID, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}
+
+func waitForProcessGroupExit(groupID int, limit time.Duration) (bool, error) {
+	return waitForProcessGroupExitWithProbe(groupID, limit, syscall.Kill, time.Now, time.Sleep)
+}
+
+func waitForProcessGroupExitWithProbe(
+	groupID int,
+	limit time.Duration,
+	probe func(int, syscall.Signal) error,
+	now func() time.Time,
+	sleep func(time.Duration),
+) (bool, error) {
+	if err := validateSafeProcessGroupID(groupID); err != nil {
+		return false, err
+	}
+	deadline := now().Add(limit)
+	for {
+		err := probe(-groupID, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return true, nil
+		}
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			return false, err
+		}
+		if !now().Before(deadline) {
+			return false, nil
+		}
+		sleep(processGroupPollInterval)
+	}
+}
+
+func validateSafeProcessGroupID(groupID int) error {
+	if groupID <= 1 {
+		return fmt.Errorf("process group ID %d is not safe", groupID)
+	}
+	if groupID == syscall.Getpgrp() {
+		return fmt.Errorf("process group ID %d belongs to the caller", groupID)
+	}
+	return nil
+}

--- a/internal/host/launcher/process_group_supervisor_test.go
+++ b/internal/host/launcher/process_group_supervisor_test.go
@@ -198,11 +198,15 @@ func TestProcessGroupSupervisorWatchFailures(t *testing.T) {
 				return signalProcessGroup(groupID, signal)
 			}
 			result := s.run(context.Background(), cmd)
-			if result.cleanupErr != nil || cmd.ProcessState == nil || signaledAfterReap ||
+			unreaped := cmd.ProcessState == nil
+			if unreaped {
+				_ = cmd.Wait()
+			}
+			if result.cleanupErr != nil || !unreaped || cmd.ProcessState == nil || signaledAfterReap ||
 				len(signals) != 1 || signals[0] != syscall.SIGKILL {
 				t.Fatalf("run result=%+v signals=%v after-reap=%v state=%v", result, signals, signaledAfterReap, cmd.ProcessState)
 			}
-			if tc.wantErr != nil && !errors.Is(result.runErr, tc.wantErr) ||
+			if !strings.Contains(result.runErr.Error(), "wait skipped") || tc.wantErr != nil && !errors.Is(result.runErr, tc.wantErr) ||
 				tc.wantText != "" && !strings.Contains(result.runErr.Error(), tc.wantText) {
 				t.Fatalf("run error = %v, want %v %q", result.runErr, tc.wantErr, tc.wantText)
 			}
@@ -212,34 +216,41 @@ func TestProcessGroupSupervisorWatchFailures(t *testing.T) {
 		})
 	}
 }
-func TestProcessGroupSupervisorSkipsWaitAfterDirectKillFailure(t *testing.T) {
-	directErr := errors.New("direct kill failed")
-	for _, groupErr := range []error{errors.New("group signal failed"), nil} {
-		cmd := exec.Command("/bin/sh", "-c", "trap '' TERM; while :; do sleep 1; done")
-		startSupervisorTestCommand(t, cmd)
-		t.Cleanup(func() {
-			if cmd.ProcessState == nil {
-				_ = signalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
-				_ = cmd.Wait()
+func TestProcessGroupSupervisorSkipsWaitWithoutObservedExit(t *testing.T) {
+	for _, directErr := range []error{errors.New("direct kill failed"), nil} {
+		for _, groupErr := range []error{errors.New("group signal failed"), nil} {
+			cmd := exec.Command("/bin/sleep", "30")
+			startSupervisorTestCommand(t, cmd)
+			t.Cleanup(func() {
+				if cmd.ProcessState == nil {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+				}
+			})
+			s := defaultProcessGroupSupervisor()
+			owner, err := s.captureOwner(cmd.Process)
+			if err != nil {
+				t.Fatal(err)
 			}
-		})
-		s := defaultProcessGroupSupervisor()
-		owner, err := s.captureOwner(cmd.Process)
-		if err != nil {
-			t.Fatal(err)
-		}
-		s.termGrace, s.proofLimit = 10*time.Millisecond, 10*time.Millisecond
-		s.signalGroup = func(int, syscall.Signal) error { return groupErr }
-		s.killProcess = func(*os.Process) error { return directErr }
-		started := time.Now()
-		waitErr, cleanupErr := s.stopStartedCommand(
-			cmd, owner, newSupervisorTestWatcher(), false, nil, true)
-		if time.Since(started) > time.Second || waitErr != nil || cmd.ProcessState != nil {
-			t.Fatalf("unconfirmed cleanup was not bounded: wait=%v state=%v", waitErr, cmd.ProcessState)
-		}
-		if !errors.Is(cleanupErr, directErr) || !strings.Contains(cleanupErr.Error(), "wait skipped") ||
-			groupErr != nil && !errors.Is(cleanupErr, groupErr) {
-			t.Fatalf("cleanup error = %v, group error = %v", cleanupErr, groupErr)
+			s.termGrace, s.proofLimit = 10*time.Millisecond, 10*time.Millisecond
+			s.signalGroup = func(int, syscall.Signal) error { return groupErr }
+			s.killProcess = func(*os.Process) error { return directErr }
+			fallbackDone := make(chan struct{})
+			killFallback := time.AfterFunc(2*time.Second, func() { _ = cmd.Process.Kill(); close(fallbackDone) })
+			waitErr, cleanupErr := s.stopStartedCommand(
+				cmd, owner, newSupervisorTestWatcher(), false, nil, true)
+			stopped := killFallback.Stop()
+			if !stopped {
+				<-fallbackDone
+			}
+			if !stopped || waitErr != nil || cmd.ProcessState != nil {
+				t.Fatalf("unconfirmed cleanup was not bounded: wait=%v state=%v", waitErr, cmd.ProcessState)
+			}
+			if directErr != nil && !errors.Is(cleanupErr, directErr) || !strings.Contains(cleanupErr.Error(), "wait skipped") ||
+				!strings.Contains(cleanupErr.Error(), "exit watch did not signal") ||
+				groupErr != nil && !errors.Is(cleanupErr, groupErr) {
+				t.Fatalf("cleanup error = %v, group error = %v", cleanupErr, groupErr)
+			}
 		}
 	}
 }

--- a/internal/host/launcher/process_group_supervisor_test.go
+++ b/internal/host/launcher/process_group_supervisor_test.go
@@ -4,360 +4,350 @@
 package launcher
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 )
 
-func TestProcessGroupSupervisorRunRetainsCancellationResult(t *testing.T) {
-	cause := errors.New("cancel fixture")
-	cleanupErr := errors.New("cleanup fixture")
-	ctx, cancel := context.WithCancelCause(context.Background())
-	defer cancel(context.Canceled)
-	marker := filepath.Join(t.TempDir(), "ready")
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `printf ready >"$1"; while :; do :; done`, "fixture", marker)
-	s := defaultProcessGroupSupervisor()
-	s.signalGroup = func(_ int, _ syscall.Signal) error {
-		return errors.Join(cmd.Process.Kill(), cleanupErr)
+type supervisorTestWatcher struct {
+	result  chan error
+	closeFn func() error
+}
+
+func newSupervisorTestWatcher() *supervisorTestWatcher {
+	return &supervisorTestWatcher{result: make(chan error, 1)}
+}
+func (w *supervisorTestWatcher) done() <-chan error { return w.result }
+func (w *supervisorTestWatcher) signal(err error) {
+	select {
+	case w.result <- err:
+	default:
 	}
-	s.waitAbsent = func(_ int, _ time.Duration) (bool, error) { return true, nil }
-	go func() {
-		for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
-			if _, err := os.Stat(marker); err == nil {
-				cancel(cause)
-				return
-			}
+}
+func (w *supervisorTestWatcher) close() error {
+	w.signal(nil)
+	if w.closeFn != nil {
+		return w.closeFn()
+	}
+	return nil
+}
+func fixturePID(t *testing.T, path string) int {
+	t.Helper()
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
+		data, err := os.ReadFile(path)
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err == nil && parseErr == nil && pid > 1 {
+			return pid
 		}
-		cancel(cause)
-	}()
-	result := s.run(ctx, cmd)
-	if !result.cleanupRan || result.preStartCanceled || !errors.Is(result.cleanupErr, cleanupErr) ||
-		!errors.Is(result.cause, cause) || result.runErr == nil || cmd.ProcessState == nil {
-		t.Fatalf("run result = %+v; process state = %v", result, cmd.ProcessState)
 	}
-
-	preCtx, preCancel := context.WithCancelCause(context.Background())
-	preCancel(cause)
-	preResult := defaultProcessGroupSupervisor().run(preCtx, exec.CommandContext(preCtx, "/usr/bin/true"))
-	if !preResult.preStartCanceled || preResult.cleanupRan || !errors.Is(preResult.cause, cause) {
-		t.Fatalf("pre-start run result = %+v", preResult)
+	t.Fatalf("fixture PID was not ready: %s", path)
+	return 0
+}
+func startSupervisorTestCommand(t *testing.T, cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
 	}
 }
 
-func TestProcessGroupSupervisorRejectsPresetGroupBeforeStart(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		attr syscall.SysProcAttr
-	}{
-		{name: "selected group", attr: syscall.SysProcAttr{Pgid: 42}},
-		{name: "foreground group", attr: syscall.SysProcAttr{Foreground: true}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			marker := filepath.Join(t.TempDir(), "started")
-			cmd := exec.Command("/bin/sh", "-c", `: >"$1"`, "fixture", marker)
-			cmd.SysProcAttr = &tc.attr
-			result := defaultProcessGroupSupervisor().run(context.Background(), cmd)
-			if result.runErr == nil || !strings.Contains(result.runErr.Error(), "must not select") {
-				t.Fatalf("run result = %+v", result)
-			}
-			if cmd.Process != nil {
-				t.Fatalf("rejected command started process %d", cmd.Process.Pid)
-			}
-			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
-				t.Fatalf("start marker exists: %v", err)
-			}
-		})
-	}
-}
-
-func TestProcessGroupSupervisorContinuesCleanupAfterErrors(t *testing.T) {
-	cause := errors.New("cancel fixture")
-	signalErr := errors.New("TERM fixture")
-	pollErr := errors.New("poll fixture")
-	killErr := errors.New("KILL fixture")
-	fallbackErr := errors.New("leader fallback fixture")
+func TestProcessGroupSupervisorLeaderExitCancellation(t *testing.T) {
+	cause := errors.New("leader exit cancellation")
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(context.Canceled)
-	marker := filepath.Join(t.TempDir(), "process")
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `trap '' TERM; printf '%s %s\n' "$$" "$(ps -o pgid= -p $$ | tr -d ' ')" >"$1"; while :; do :; done`, "fixture", marker)
+	dir := t.TempDir()
+	childPIDPath := filepath.Join(dir, "child-pid")
+	releasePath := filepath.Join(dir, "release")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `
+/bin/sh -c 'trap "" TERM; printf "%s\n" "$$" >"$1"; sleep 5' fixture-child "$1" &
+while [ ! -f "$2" ]; do sleep .01; done
+exit 0
+`, "fixture", childPIDPath, releasePath)
+
+	watchInstalled := make(chan struct{})
+	childReady := make(chan int, 1)
+	var signals []syscall.Signal
+	var signaledAfterReap, termSurvived, watchClosedBeforeWait bool
 	s := defaultProcessGroupSupervisor()
-	s.termGrace = 100 * time.Millisecond
-	s.proofLimit = 100 * time.Millisecond
-	s.waitDelay = 100 * time.Millisecond
 	s.signalGroup = func(groupID int, signal syscall.Signal) error {
-		actual, err := syscall.Getpgid(groupID)
-		if err != nil || actual != groupID || validateSafeProcessGroupID(groupID) != nil {
-			return fmt.Errorf("unsafe fixture group %d (actual %d): %w", groupID, actual, err)
-		}
+		signaledAfterReap = signaledAfterReap || cmd.ProcessState != nil
+		signals = append(signals, signal)
+		err := signalProcessGroup(groupID, signal)
 		if signal == syscall.SIGTERM {
-			return signalErr
+			termSurvived = syscall.Kill(<-childReady, 0) == nil
 		}
-		return killErr
+		return err
 	}
-	waitCall := 0
-	s.waitAbsent = func(_ int, _ time.Duration) (bool, error) {
-		waitCall++
-		if waitCall == 1 {
-			return false, pollErr
-		}
-		return false, nil
+	s.afterFunc = func(_ context.Context, callback func()) func() bool {
+		return func() bool { cancel(cause); callback(); return false }
 	}
-	s.killProcess = func(*os.Process) error { return fallbackErr }
-	go func() {
-		for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
-			if fields := pollProcessMarker(marker, 25*time.Millisecond, 2); len(fields) == 2 {
-				cancel(cause)
-				return
-			}
+	s.watchExit = func(pid int) (processExitWatcher, error) {
+		inner, err := startProcessExitWatch(pid)
+		if err != nil {
+			return nil, err
 		}
-		cancel(cause)
-	}()
+		watch := newSupervisorTestWatcher()
+		watch.closeFn = func() error {
+			watchClosedBeforeWait = cmd.ProcessState == nil
+			return inner.close()
+		}
+		go func() {
+			watch.signal(<-inner.done())
+		}()
+		close(watchInstalled)
+		return watch, nil
+	}
+
 	results := make(chan processGroupRunResult, 1)
 	go func() { results <- s.run(ctx, cmd) }()
+	select {
+	case <-watchInstalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("exit watcher was not installed")
+	}
+	childReady <- fixturePID(t, childPIDPath)
+	if err := os.WriteFile(releasePath, []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	var result processGroupRunResult
 	select {
 	case result = <-results:
-	case <-time.After(2 * time.Second):
-		_ = cmd.Process.Kill()
-		<-results
-		t.Fatal("cleanup did not return before its bounded fallback")
+	case <-time.After(10 * time.Second):
+		if cmd.Process != nil && cmd.ProcessState == nil {
+			_ = signalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		}
+		t.Fatal("leader-exit cleanup did not finish")
 	}
-	if !result.cleanupRan || !errors.Is(result.cleanupErr, signalErr) || !errors.Is(result.cleanupErr, pollErr) ||
-		!errors.Is(result.cleanupErr, killErr) || !errors.Is(result.cleanupErr, fallbackErr) ||
-		!errors.Is(result.cause, cause) || result.runErr == nil {
+	if result.runErr != nil || result.cleanupErr != nil || !result.cleanupRan || !errors.Is(result.cause, cause) {
 		t.Fatalf("run result = %+v", result)
 	}
-	absent, err := waitForProcessGroupExit(cmd.Process.Pid, time.Second)
-	if err != nil || !absent {
-		t.Fatalf("fixture group %d remains: absent=%v err=%v", cmd.Process.Pid, absent, err)
+	if len(signals) != 2 || signals[0] != syscall.SIGTERM || signals[1] != syscall.SIGKILL {
+		t.Fatalf("signals = %v, want TERM then KILL", signals)
+	}
+	if signaledAfterReap || !termSurvived || !watchClosedBeforeWait || cmd.ProcessState == nil {
+		t.Fatalf("ordering: after-reap=%v term-survived=%v close-before-wait=%v state=%v", signaledAfterReap, termSurvived, watchClosedBeforeWait, cmd.ProcessState)
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("process group %d remains after cleanup: %v", cmd.Process.Pid, err)
 	}
 }
-
-func TestOwnedProcessGroupSurvivesLeaderExit(t *testing.T) {
-	dir := t.TempDir()
-	marker, release := filepath.Join(dir, "processes"), filepath.Join(dir, "release")
-	cmd := exec.Command("/bin/sh", "-c", `
-while [ ! -f "$WORKCELL_TEST_OUTER_GROUP_READY" ]; do sleep .01; done
-sh -c 'trap "" TERM; while :; do sleep 1; done' fixture-child "$1" & child=$!
-pgid=$(ps -o pgid= -p $$ | tr -d ' ')
-printf '%s %s %s\n' "$pgid" "$$" "$child" >"$1.tmp"; mv "$1.tmp" "$1"
-while [ ! -f "$2" ]; do sleep .01; done
-`, "fixture", marker, release)
-	fixture := startOwnedFixtureCommand(t, cmd)
-	if fields := pollProcessMarker(marker, 5*time.Second, 3); len(fields) != 3 {
-		t.Fatal("process marker was not ready")
-	}
-	original, err := os.ReadFile(marker)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(marker, []byte("malformed\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateOwnedFixtureProcessGroupMarker(fixture.group, marker); err == nil {
-		t.Fatal("malformed behavior marker passed validation")
-	}
-	if err := os.WriteFile(marker, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	group := fixture.group
-	if err := validateOwnedFixtureProcessGroupMarker(group, marker); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(release, []byte("release\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := fixture.wait(); err != nil {
-		t.Fatal(err)
-	}
-	groupID, absent, err := ownedProcessGroupForProcess(cmd.Process)
-	if err != nil || absent || int(groupID) != group.id {
-		t.Fatalf("ownedProcessGroupForProcess() = %d, %v, %v", groupID, absent, err)
-	}
-	if err := signalProcessGroup(group.id, syscall.SIGKILL); err != nil {
-		t.Fatal(err)
-	}
-	group.proveAbsent(t)
-	_, absent, err = ownedProcessGroupForProcess(cmd.Process)
-	if err != nil || !absent {
-		t.Fatalf("absent group probe = %v, %v", absent, err)
+func TestProcessGroupSupervisorOrdinaryExit(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 7")
+	watch := newSupervisorTestWatcher()
+	watch.signal(nil)
+	closedBeforeWait := false
+	watch.closeFn = func() error { closedBeforeWait = cmd.ProcessState == nil; return nil }
+	s := defaultProcessGroupSupervisor()
+	s.watchExit = func(int) (processExitWatcher, error) { return watch, nil }
+	result := s.run(context.Background(), cmd)
+	var exitErr *exec.ExitError
+	if result.cleanupRan || !closedBeforeWait || cmd.ProcessState == nil ||
+		!errors.As(result.runErr, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("run result = %+v, want ordinary exit 7", result)
 	}
 }
-
-func TestFixtureOwnerHandshakeFailsClosed(t *testing.T) {
-	if os.Getenv("WORKCELL_OWNER_HANDSHAKE_HELPER") == "1" {
-		waitForOwnedFixtureCommandReady()
-		cmd := exec.Command(os.Getenv("WORKCELL_OWNER_HANDSHAKE_BIN"))
-		cmd.Stdout = os.Stdout
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-		if err := cmd.Start(); err != nil {
-			os.Exit(125)
-		}
-		_ = cmd.Wait()
-		os.Exit(0)
-	}
-	for _, tc := range []struct {
-		name   string
-		output string
+func TestProcessGroupSupervisorWatchFailures(t *testing.T) {
+	sentinel := errors.New("supervision failed")
+	tests := []struct {
+		name      string
+		configure func(*processGroupSupervisor, *supervisorTestWatcher)
+		wantErr   error
+		wantText  string
 	}{
-		{"missing", ""},
-		{"malformed", "printf 'bad owner record\\n'"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			fake := writeFakeColima(t, dir, "#!/bin/sh\n"+tc.output+`
-count=0
-while [ ! -f "$WORKCELL_OWNER_HANDSHAKE_ACK" ] && [ "$count" -lt 100 ]; do sleep .01; count=$((count + 1)); done
-exit 125
-`)
-			cmd := exec.Command(os.Args[0], "-test.run=^TestFixtureOwnerHandshakeFailsClosed$")
-			ownerPipe, err := cmd.StdoutPipe()
-			if err != nil {
-				t.Fatal(err)
+		{"capture generation", func(s *processGroupSupervisor, _ *supervisorTestWatcher) {
+			s.captureGeneration = func(int) (string, error) { return "", sentinel }
+		}, sentinel, ""},
+		{"unsupported generation", func(s *processGroupSupervisor, _ *supervisorTestWatcher) {
+			s.captureGeneration = func(int) (string, error) { return "legacy start time", nil }
+		}, nil, "unsupported generation"},
+		{"second generation observation", func(s *processGroupSupervisor, _ *supervisorTestWatcher) {
+			calls := 0
+			s.observeGeneration = func(_ int, recorded string) (string, error) {
+				calls++
+				return []string{recorded, "darwin:reused"}[calls-1], nil
 			}
-			cmd.Env = append(os.Environ(),
-				"WORKCELL_OWNER_HANDSHAKE_HELPER=1",
-				"WORKCELL_OWNER_HANDSHAKE_BIN="+fake,
-				"WORKCELL_OWNER_HANDSHAKE_ACK="+filepath.Join(dir, "not-created"),
-			)
-			fixture := startOwnedFixtureCommand(t, cmd)
-			if group, err := readOwnedFixtureProcessGroupPipe(ownerPipe, cmd.Process.Pid, fake); err == nil || group != nil {
-				t.Fatalf("invalid owner handshake = %v, %v", group, err)
-			}
-			if err := fixture.wait(); err != nil {
-				t.Fatal(err)
-			}
-			fixture.group.proveAbsent(t)
-			if !waitForFixtureCommandPathAbsent(fake, 5*time.Second) {
-				t.Fatalf("fixture command remains: %s", fake)
-			}
-		})
+		}, nil, "generation changed"},
+		{"watch setup", func(s *processGroupSupervisor, _ *supervisorTestWatcher) {
+			s.watchExit = func(int) (processExitWatcher, error) { return nil, sentinel }
+		}, sentinel, ""},
+		{"watch runtime", func(s *processGroupSupervisor, w *supervisorTestWatcher) {
+			s.watchExit = func(int) (processExitWatcher, error) { w.signal(sentinel); return w, nil }
+		}, sentinel, ""},
+		{"nil watcher", func(s *processGroupSupervisor, _ *supervisorTestWatcher) {
+			s.watchExit = func(int) (processExitWatcher, error) { return nil, nil }
+		}, nil, "exit watch"},
 	}
-}
-
-func waitForFixtureCommandPathAbsent(path string, limit time.Duration) bool {
-	for deadline := time.Now().Add(limit); time.Now().Before(deadline); time.Sleep(25 * time.Millisecond) {
-		output, err := exec.Command("/bin/ps", "-axo", "command=").Output()
-		if err == nil && !strings.Contains(string(output), path) {
-			return true
-		}
-	}
-	return false
-}
-
-func TestProcessGroupSupervisorTerminate(t *testing.T) {
-	sentinel := errors.New("fixture failure")
-	for _, tc := range []struct {
-		name         string
-		waits        []bool
-		signalFail   int
-		waitFail     int
-		wantSignal   []syscall.Signal
-		wantFallback int
-		wantErr      error
-		wantText     string
-	}{
-		{name: "TERM is sufficient", waits: []bool{true}, wantSignal: []syscall.Signal{syscall.SIGTERM}},
-		{name: "escalates to KILL", waits: []bool{false, true}, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}},
-		{name: "TERM fails", waits: []bool{false, true}, signalFail: 1, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantErr: sentinel},
-		{name: "TERM poll fails", waits: []bool{false, true}, waitFail: 1, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantErr: sentinel},
-		{name: "KILL fails", waits: []bool{false, true}, signalFail: 2, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantFallback: 1, wantErr: sentinel},
-		{name: "KILL poll fails", waits: []bool{false}, waitFail: 2, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantFallback: 1, wantErr: sentinel},
-		{name: "group survives KILL", waits: []bool{false, false}, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantFallback: 1, wantText: "remains after SIGKILL"},
-	} {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("/bin/sleep", "2")
+			watch := newSupervisorTestWatcher()
 			var signals []syscall.Signal
-			waitCall := 0
-			fallbacks := 0
-			s := processGroupSupervisor{
-				signalGroup: func(_ int, signal syscall.Signal) error {
-					signals = append(signals, signal)
-					if len(signals) == tc.signalFail {
-						return sentinel
-					}
-					return nil
-				},
-				waitAbsent: func(_ int, _ time.Duration) (bool, error) {
-					waitCall++
-					if waitCall == tc.waitFail {
-						return false, sentinel
-					}
-					if waitCall <= len(tc.waits) {
-						return tc.waits[waitCall-1], nil
-					}
-					return false, nil
-				},
-				killProcess: func(*os.Process) error { fallbacks++; return nil },
-				termGrace:   time.Second,
-				proofLimit:  time.Second,
+			signaledAfterReap := false
+			s := defaultProcessGroupSupervisor()
+			tc.configure(&s, watch)
+			s.signalGroup = func(groupID int, signal syscall.Signal) error {
+				signaledAfterReap = signaledAfterReap || cmd.ProcessState != nil
+				signals = append(signals, signal)
+				return signalProcessGroup(groupID, signal)
 			}
-			err := s.terminate(ownedProcessGroupID(4242), &os.Process{Pid: 4242})
-			if !reflect.DeepEqual(signals, tc.wantSignal) {
-				t.Fatalf("signals = %v, want %v", signals, tc.wantSignal)
+			result := s.run(context.Background(), cmd)
+			if result.cleanupErr != nil || cmd.ProcessState == nil || signaledAfterReap ||
+				len(signals) != 1 || signals[0] != syscall.SIGKILL {
+				t.Fatalf("run result=%+v signals=%v after-reap=%v state=%v", result, signals, signaledAfterReap, cmd.ProcessState)
 			}
-			if fallbacks != tc.wantFallback {
-				t.Fatalf("leader fallbacks = %d, want %d", fallbacks, tc.wantFallback)
+			if tc.wantErr != nil && !errors.Is(result.runErr, tc.wantErr) ||
+				tc.wantText != "" && !strings.Contains(result.runErr.Error(), tc.wantText) {
+				t.Fatalf("run error = %v, want %v %q", result.runErr, tc.wantErr, tc.wantText)
 			}
-			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
-				t.Fatalf("error = %v, want %v", err, tc.wantErr)
-			}
-			if tc.wantText != "" && (err == nil || !strings.Contains(err.Error(), tc.wantText)) {
-				t.Fatalf("error = %v, want %q", err, tc.wantText)
-			}
-			if tc.wantErr == nil && tc.wantText == "" && err != nil {
-				t.Fatal(err)
+			if code, err := colimaRunResult(result.runErr); code != 0 || err == nil {
+				t.Fatalf("colima result = %d, %v; want surfaced supervision error", code, err)
 			}
 		})
 	}
 }
-
-func TestProcessGroupHelpersRejectUnsafeIDs(t *testing.T) {
-	for _, groupID := range []int{-1, 0, 1, syscall.Getpgrp()} {
-		killCalled := false
-		recordKill := func(int, syscall.Signal) error { killCalled = true; return nil }
-		err := signalProcessGroupWithKill(groupID, syscall.SIGTERM, recordKill)
-		if err == nil || killCalled {
-			t.Fatalf("signalProcessGroupWithKill(%d) = %v; kill called=%v", groupID, err, killCalled)
+func TestProcessGroupSupervisorSkipsWaitAfterDirectKillFailure(t *testing.T) {
+	directErr := errors.New("direct kill failed")
+	for _, groupErr := range []error{errors.New("group signal failed"), nil} {
+		cmd := exec.Command("/bin/sh", "-c", "trap '' TERM; while :; do sleep 1; done")
+		startSupervisorTestCommand(t, cmd)
+		t.Cleanup(func() {
+			if cmd.ProcessState == nil {
+				_ = signalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+				_ = cmd.Wait()
+			}
+		})
+		s := defaultProcessGroupSupervisor()
+		owner, err := s.captureOwner(cmd.Process)
+		if err != nil {
+			t.Fatal(err)
 		}
-		probeCalled := false
-		recordProbe := func(int, syscall.Signal) error { probeCalled = true; return nil }
-		absent, err := waitForProcessGroupExitWithProbe(groupID, 0, recordProbe, time.Now, time.Sleep)
-		if err == nil || absent || probeCalled {
-			t.Fatalf("waitForProcessGroupExitWithProbe(%d) = %v, %v; probe called=%v", groupID, absent, err, probeCalled)
+		s.termGrace, s.proofLimit = 10*time.Millisecond, 10*time.Millisecond
+		s.signalGroup = func(int, syscall.Signal) error { return groupErr }
+		s.killProcess = func(*os.Process) error { return directErr }
+		started := time.Now()
+		waitErr, cleanupErr := s.stopStartedCommand(
+			cmd, owner, newSupervisorTestWatcher(), false, nil, true)
+		if time.Since(started) > time.Second || waitErr != nil || cmd.ProcessState != nil {
+			t.Fatalf("unconfirmed cleanup was not bounded: wait=%v state=%v", waitErr, cmd.ProcessState)
+		}
+		if !errors.Is(cleanupErr, directErr) || !strings.Contains(cleanupErr.Error(), "wait skipped") ||
+			groupErr != nil && !errors.Is(cleanupErr, groupErr) {
+			t.Fatalf("cleanup error = %v, group error = %v", cleanupErr, groupErr)
 		}
 	}
-	group := ownedFixtureProcessGroup{id: 42, members: map[int]string{42: "original"}}
-	if group.hasLiveMemberWith(func(int) (int, string, error) { return 42, "reused", nil }) {
-		t.Fatal("stale process generation was accepted")
+}
+func TestProcessGroupSupervisorSignalEPERMRequiresProof(t *testing.T) {
+	proofErr := errors.New("absence proof failed")
+	tests := []struct {
+		signal    syscall.Signal
+		absent    bool
+		proofErr  error
+		reuse     bool
+		wantError bool
+	}{
+		{syscall.SIGTERM, true, nil, false, false},
+		{syscall.SIGTERM, false, nil, false, true},
+		{syscall.SIGKILL, true, nil, false, false},
+		{syscall.SIGKILL, false, proofErr, false, true},
+		{syscall.SIGKILL, false, nil, true, true},
 	}
-	if !group.hasLiveMemberWith(func(int) (int, string, error) { return 42, "original", nil }) {
-		t.Fatal("matching process generation was rejected")
+	for _, tc := range tests {
+		cmd := exec.Command("/bin/sh", "-c", "while :; do sleep 1; done")
+		startSupervisorTestCommand(t, cmd)
+		owner := processGroupOwner{pid: cmd.Process.Pid, generation: "darwin:test"}
+		watch := newSupervisorTestWatcher()
+		watch.signal(nil)
+		signaledAfterReap := false
+		s := defaultProcessGroupSupervisor()
+		s.signalGroup = func(_ int, signal syscall.Signal) error {
+			signaledAfterReap = signaledAfterReap || cmd.ProcessState != nil
+			if signal == tc.signal {
+				return syscall.EPERM
+			}
+			return nil
+		}
+		s.killProcess = func(process *os.Process) error { return process.Kill() }
+		s.observeGeneration = func(pid int, _ string) (string, error) {
+			if tc.reuse {
+				return "darwin:reused", nil
+			}
+			return "", processGoneErr{pid: pid}
+		}
+		s.waitAbsent = func(int, time.Duration) (bool, error) {
+			return tc.absent, tc.proofErr
+		}
+		_, cleanupErr := s.stopStartedCommand(cmd, owner, watch, true, nil, true)
+		if cmd.ProcessState == nil || signaledAfterReap {
+			t.Fatalf("ordering: state=%v after-reap=%v", cmd.ProcessState, signaledAfterReap)
+		}
+		if (cleanupErr != nil) != tc.wantError || tc.wantError && !errors.Is(cleanupErr, syscall.EPERM) ||
+			tc.proofErr != nil && !errors.Is(cleanupErr, tc.proofErr) ||
+			tc.reuse && !strings.Contains(cleanupErr.Error(), "generation changed after wait") {
+			t.Fatalf("cleanup error = %v for signal=%s proof=%v reuse=%v", cleanupErr, tc.signal, tc.proofErr, tc.reuse)
+		}
+	}
+}
+func TestColimaCancellationResultsPreserveFailures(t *testing.T) {
+	runErr, cleanupErr, cause := errors.New("run failed"), errors.New("cleanup failed"), context.DeadlineExceeded
+	if code, err := colimaCancellationResult(runErr, cleanupErr, cause); code != 0 ||
+		!errors.Is(err, runErr) || !errors.Is(err, cleanupErr) || !errors.Is(err, cause) {
+		t.Fatalf("cleanup failure result = %d, %v", code, err)
+	}
+}
+func TestWaitStartedCommandWaitDelayIsSynchronous(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "sleep .2 & exit 0")
+	cmd.Stdout = &bytes.Buffer{}
+	startSupervisorTestCommand(t, cmd)
+	if err := waitStartedCommand(cmd, 20*time.Millisecond); !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("wait error = %v, want ErrWaitDelay", err)
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("Wait returned before recording process state")
+	}
+	if absent, err := waitForProcessGroupExit(cmd.Process.Pid, 2*time.Second); err != nil || !absent {
+		t.Fatalf("held-pipe process group remains: absent=%v err=%v", absent, err)
+	}
+}
+func TestProcessGroupSupervisorRejectsPresetGroup(t *testing.T) {
+	for _, attr := range []syscall.SysProcAttr{{Pgid: 42}, {Foreground: true}} {
+		cmd := exec.Command("/usr/bin/true")
+		cmd.SysProcAttr = &attr
+		result := defaultProcessGroupSupervisor().run(context.Background(), cmd)
+		if result.runErr == nil || !strings.Contains(result.runErr.Error(), "must not select") || cmd.Process != nil {
+			t.Fatalf("preset group result=%+v process=%v", result, cmd.Process)
+		}
 	}
 }
 
-func TestWaitForProcessGroupExitTreatsEPERMAsPresent(t *testing.T) {
-	now := time.Unix(1, 0)
-	absent, err := waitForProcessGroupExitWithProbe(
-		42,
-		0,
+func TestProcessGroupHelpersRejectUnsafeIDsAndTreatEPERMAsPresent(t *testing.T) {
+	for _, groupID := range []int{-1, 0, 1, syscall.Getpgrp()} {
+		called := false
+		if err := signalProcessGroupWithKill(groupID, syscall.SIGTERM, func(int, syscall.Signal) error { called = true; return nil }); err == nil || called {
+			t.Fatalf("unsafe signal group %d: err=%v called=%v", groupID, err, called)
+		}
+		if absent, err := waitForProcessGroupExitWithProbe(groupID, 0,
+			func(int, syscall.Signal) error { called = true; return nil },
+			time.Now, time.Sleep); err == nil || absent || called {
+			t.Fatalf("unsafe probe group %d: absent=%v err=%v called=%v", groupID, absent, err, called)
+		}
+	}
+	absent, err := waitForProcessGroupExitWithProbe(42, 0,
 		func(pid int, signal syscall.Signal) error {
 			if pid != -42 || signal != 0 {
 				t.Fatalf("probe = (%d, %d)", pid, signal)
 			}
 			return syscall.EPERM
 		},
-		func() time.Time { return now },
-		func(time.Duration) { t.Fatal("unexpected sleep") },
-	)
+		func() time.Time { return time.Unix(1, 0) },
+		func(time.Duration) { t.Fatal("unexpected sleep") })
 	if err != nil || absent {
-		t.Fatalf("waitForProcessGroupExitWithProbe() = %v, %v, want present", absent, err)
+		t.Fatalf("EPERM probe = absent=%v err=%v, want present", absent, err)
 	}
 }

--- a/internal/host/launcher/process_group_supervisor_test.go
+++ b/internal/host/launcher/process_group_supervisor_test.go
@@ -311,6 +311,16 @@ func TestColimaCancellationResultsPreserveFailures(t *testing.T) {
 		!errors.Is(err, runErr) || !errors.Is(err, cleanupErr) || !errors.Is(err, cause) {
 		t.Fatalf("cleanup failure result = %d, %v", code, err)
 	}
+	if code, err := colimaCancellationResult(runErr, nil, cause); code != 0 || !errors.Is(err, runErr) {
+		t.Fatalf("unexpected wait failure result = %d, %v", code, err)
+	}
+}
+func TestColimaCancellationResultPreservesTimeout(t *testing.T) {
+	runErr := exec.Command("/bin/sh", "-c", "exit 11").Run()
+	var exitErr *exec.ExitError
+	if code, err := colimaCancellationResult(runErr, nil, context.DeadlineExceeded); !errors.As(runErr, &exitErr) || code != ColimaTimeoutExitCode || err != nil {
+		t.Fatalf("graceful nonzero timeout result = %d, %v", code, err)
+	}
 }
 func TestWaitStartedCommandWaitDelayIsSynchronous(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", "sleep .2 & exit 0")

--- a/internal/host/launcher/process_group_supervisor_test.go
+++ b/internal/host/launcher/process_group_supervisor_test.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package launcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestProcessGroupSupervisorRunRetainsCancellationResult(t *testing.T) {
+	cause := errors.New("cancel fixture")
+	cleanupErr := errors.New("cleanup fixture")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	marker := filepath.Join(t.TempDir(), "ready")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `printf ready >"$1"; while :; do :; done`, "fixture", marker)
+	s := defaultProcessGroupSupervisor()
+	s.signalGroup = func(_ int, _ syscall.Signal) error {
+		return errors.Join(cmd.Process.Kill(), cleanupErr)
+	}
+	s.waitAbsent = func(_ int, _ time.Duration) (bool, error) { return true, nil }
+	go func() {
+		for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
+			if _, err := os.Stat(marker); err == nil {
+				cancel(cause)
+				return
+			}
+		}
+		cancel(cause)
+	}()
+	result := s.run(ctx, cmd)
+	if !result.cleanupRan || result.preStartCanceled || !errors.Is(result.cleanupErr, cleanupErr) ||
+		!errors.Is(result.cause, cause) || result.runErr == nil || cmd.ProcessState == nil {
+		t.Fatalf("run result = %+v; process state = %v", result, cmd.ProcessState)
+	}
+
+	preCtx, preCancel := context.WithCancelCause(context.Background())
+	preCancel(cause)
+	preResult := defaultProcessGroupSupervisor().run(preCtx, exec.CommandContext(preCtx, "/usr/bin/true"))
+	if !preResult.preStartCanceled || preResult.cleanupRan || !errors.Is(preResult.cause, cause) {
+		t.Fatalf("pre-start run result = %+v", preResult)
+	}
+}
+
+func TestProcessGroupSupervisorRejectsPresetGroupBeforeStart(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		attr syscall.SysProcAttr
+	}{
+		{name: "selected group", attr: syscall.SysProcAttr{Pgid: 42}},
+		{name: "foreground group", attr: syscall.SysProcAttr{Foreground: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			marker := filepath.Join(t.TempDir(), "started")
+			cmd := exec.Command("/bin/sh", "-c", `: >"$1"`, "fixture", marker)
+			cmd.SysProcAttr = &tc.attr
+			result := defaultProcessGroupSupervisor().run(context.Background(), cmd)
+			if result.runErr == nil || !strings.Contains(result.runErr.Error(), "must not select") {
+				t.Fatalf("run result = %+v", result)
+			}
+			if cmd.Process != nil {
+				t.Fatalf("rejected command started process %d", cmd.Process.Pid)
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("start marker exists: %v", err)
+			}
+		})
+	}
+}
+
+func TestProcessGroupSupervisorContinuesCleanupAfterErrors(t *testing.T) {
+	cause := errors.New("cancel fixture")
+	signalErr := errors.New("TERM fixture")
+	pollErr := errors.New("poll fixture")
+	killErr := errors.New("KILL fixture")
+	fallbackErr := errors.New("leader fallback fixture")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	marker := filepath.Join(t.TempDir(), "process")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `trap '' TERM; printf '%s %s\n' "$$" "$(ps -o pgid= -p $$ | tr -d ' ')" >"$1"; while :; do :; done`, "fixture", marker)
+	s := defaultProcessGroupSupervisor()
+	s.termGrace = 100 * time.Millisecond
+	s.proofLimit = 100 * time.Millisecond
+	s.waitDelay = 100 * time.Millisecond
+	s.signalGroup = func(groupID int, signal syscall.Signal) error {
+		actual, err := syscall.Getpgid(groupID)
+		if err != nil || actual != groupID || validateSafeProcessGroupID(groupID) != nil {
+			return fmt.Errorf("unsafe fixture group %d (actual %d): %w", groupID, actual, err)
+		}
+		if signal == syscall.SIGTERM {
+			return signalErr
+		}
+		return killErr
+	}
+	waitCall := 0
+	s.waitAbsent = func(_ int, _ time.Duration) (bool, error) {
+		waitCall++
+		if waitCall == 1 {
+			return false, pollErr
+		}
+		return false, nil
+	}
+	s.killProcess = func(*os.Process) error { return fallbackErr }
+	go func() {
+		for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
+			if fields := pollProcessMarker(marker, 25*time.Millisecond, 2); len(fields) == 2 {
+				cancel(cause)
+				return
+			}
+		}
+		cancel(cause)
+	}()
+	results := make(chan processGroupRunResult, 1)
+	go func() { results <- s.run(ctx, cmd) }()
+	var result processGroupRunResult
+	select {
+	case result = <-results:
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		<-results
+		t.Fatal("cleanup did not return before its bounded fallback")
+	}
+	if !result.cleanupRan || !errors.Is(result.cleanupErr, signalErr) || !errors.Is(result.cleanupErr, pollErr) ||
+		!errors.Is(result.cleanupErr, killErr) || !errors.Is(result.cleanupErr, fallbackErr) ||
+		!errors.Is(result.cause, cause) || result.runErr == nil {
+		t.Fatalf("run result = %+v", result)
+	}
+	absent, err := waitForProcessGroupExit(cmd.Process.Pid, time.Second)
+	if err != nil || !absent {
+		t.Fatalf("fixture group %d remains: absent=%v err=%v", cmd.Process.Pid, absent, err)
+	}
+}
+
+func TestOwnedProcessGroupSurvivesLeaderExit(t *testing.T) {
+	dir := t.TempDir()
+	marker, release := filepath.Join(dir, "processes"), filepath.Join(dir, "release")
+	cmd := exec.Command("/bin/sh", "-c", `
+while [ ! -f "$WORKCELL_TEST_OUTER_GROUP_READY" ]; do sleep .01; done
+sh -c 'trap "" TERM; while :; do sleep 1; done' fixture-child "$1" & child=$!
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+printf '%s %s %s\n' "$pgid" "$$" "$child" >"$1.tmp"; mv "$1.tmp" "$1"
+while [ ! -f "$2" ]; do sleep .01; done
+`, "fixture", marker, release)
+	fixture := startOwnedFixtureCommand(t, cmd)
+	if fields := pollProcessMarker(marker, 5*time.Second, 3); len(fields) != 3 {
+		t.Fatal("process marker was not ready")
+	}
+	original, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte("malformed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateOwnedFixtureProcessGroupMarker(fixture.group, marker); err == nil {
+		t.Fatal("malformed behavior marker passed validation")
+	}
+	if err := os.WriteFile(marker, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	group := fixture.group
+	if err := validateOwnedFixtureProcessGroupMarker(group, marker); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(release, []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.wait(); err != nil {
+		t.Fatal(err)
+	}
+	groupID, absent, err := ownedProcessGroupForProcess(cmd.Process)
+	if err != nil || absent || int(groupID) != group.id {
+		t.Fatalf("ownedProcessGroupForProcess() = %d, %v, %v", groupID, absent, err)
+	}
+	if err := signalProcessGroup(group.id, syscall.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+	group.proveAbsent(t)
+	_, absent, err = ownedProcessGroupForProcess(cmd.Process)
+	if err != nil || !absent {
+		t.Fatalf("absent group probe = %v, %v", absent, err)
+	}
+}
+
+func TestFixtureOwnerHandshakeFailsClosed(t *testing.T) {
+	if os.Getenv("WORKCELL_OWNER_HANDSHAKE_HELPER") == "1" {
+		waitForOwnedFixtureCommandReady()
+		cmd := exec.Command(os.Getenv("WORKCELL_OWNER_HANDSHAKE_BIN"))
+		cmd.Stdout = os.Stdout
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		if err := cmd.Start(); err != nil {
+			os.Exit(125)
+		}
+		_ = cmd.Wait()
+		os.Exit(0)
+	}
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{"missing", ""},
+		{"malformed", "printf 'bad owner record\\n'"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			fake := writeFakeColima(t, dir, "#!/bin/sh\n"+tc.output+`
+count=0
+while [ ! -f "$WORKCELL_OWNER_HANDSHAKE_ACK" ] && [ "$count" -lt 100 ]; do sleep .01; count=$((count + 1)); done
+exit 125
+`)
+			cmd := exec.Command(os.Args[0], "-test.run=^TestFixtureOwnerHandshakeFailsClosed$")
+			ownerPipe, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd.Env = append(os.Environ(),
+				"WORKCELL_OWNER_HANDSHAKE_HELPER=1",
+				"WORKCELL_OWNER_HANDSHAKE_BIN="+fake,
+				"WORKCELL_OWNER_HANDSHAKE_ACK="+filepath.Join(dir, "not-created"),
+			)
+			fixture := startOwnedFixtureCommand(t, cmd)
+			if group, err := readOwnedFixtureProcessGroupPipe(ownerPipe, cmd.Process.Pid, fake); err == nil || group != nil {
+				t.Fatalf("invalid owner handshake = %v, %v", group, err)
+			}
+			if err := fixture.wait(); err != nil {
+				t.Fatal(err)
+			}
+			fixture.group.proveAbsent(t)
+			if !waitForFixtureCommandPathAbsent(fake, 5*time.Second) {
+				t.Fatalf("fixture command remains: %s", fake)
+			}
+		})
+	}
+}
+
+func waitForFixtureCommandPathAbsent(path string, limit time.Duration) bool {
+	for deadline := time.Now().Add(limit); time.Now().Before(deadline); time.Sleep(25 * time.Millisecond) {
+		output, err := exec.Command("/bin/ps", "-axo", "command=").Output()
+		if err == nil && !strings.Contains(string(output), path) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProcessGroupSupervisorTerminate(t *testing.T) {
+	sentinel := errors.New("fixture failure")
+	for _, tc := range []struct {
+		name         string
+		waits        []bool
+		signalFail   int
+		waitFail     int
+		wantSignal   []syscall.Signal
+		wantFallback int
+		wantErr      error
+		wantText     string
+	}{
+		{name: "TERM is sufficient", waits: []bool{true}, wantSignal: []syscall.Signal{syscall.SIGTERM}},
+		{name: "escalates to KILL", waits: []bool{false, true}, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}},
+		{name: "TERM fails", waits: []bool{false, true}, signalFail: 1, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantErr: sentinel},
+		{name: "TERM poll fails", waits: []bool{false, true}, waitFail: 1, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantErr: sentinel},
+		{name: "KILL fails", waits: []bool{false, true}, signalFail: 2, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantFallback: 1, wantErr: sentinel},
+		{name: "KILL poll fails", waits: []bool{false}, waitFail: 2, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantFallback: 1, wantErr: sentinel},
+		{name: "group survives KILL", waits: []bool{false, false}, wantSignal: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, wantFallback: 1, wantText: "remains after SIGKILL"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var signals []syscall.Signal
+			waitCall := 0
+			fallbacks := 0
+			s := processGroupSupervisor{
+				signalGroup: func(_ int, signal syscall.Signal) error {
+					signals = append(signals, signal)
+					if len(signals) == tc.signalFail {
+						return sentinel
+					}
+					return nil
+				},
+				waitAbsent: func(_ int, _ time.Duration) (bool, error) {
+					waitCall++
+					if waitCall == tc.waitFail {
+						return false, sentinel
+					}
+					if waitCall <= len(tc.waits) {
+						return tc.waits[waitCall-1], nil
+					}
+					return false, nil
+				},
+				killProcess: func(*os.Process) error { fallbacks++; return nil },
+				termGrace:   time.Second,
+				proofLimit:  time.Second,
+			}
+			err := s.terminate(ownedProcessGroupID(4242), &os.Process{Pid: 4242})
+			if !reflect.DeepEqual(signals, tc.wantSignal) {
+				t.Fatalf("signals = %v, want %v", signals, tc.wantSignal)
+			}
+			if fallbacks != tc.wantFallback {
+				t.Fatalf("leader fallbacks = %d, want %d", fallbacks, tc.wantFallback)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantText != "" && (err == nil || !strings.Contains(err.Error(), tc.wantText)) {
+				t.Fatalf("error = %v, want %q", err, tc.wantText)
+			}
+			if tc.wantErr == nil && tc.wantText == "" && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestProcessGroupHelpersRejectUnsafeIDs(t *testing.T) {
+	for _, groupID := range []int{-1, 0, 1, syscall.Getpgrp()} {
+		killCalled := false
+		recordKill := func(int, syscall.Signal) error { killCalled = true; return nil }
+		err := signalProcessGroupWithKill(groupID, syscall.SIGTERM, recordKill)
+		if err == nil || killCalled {
+			t.Fatalf("signalProcessGroupWithKill(%d) = %v; kill called=%v", groupID, err, killCalled)
+		}
+		probeCalled := false
+		recordProbe := func(int, syscall.Signal) error { probeCalled = true; return nil }
+		absent, err := waitForProcessGroupExitWithProbe(groupID, 0, recordProbe, time.Now, time.Sleep)
+		if err == nil || absent || probeCalled {
+			t.Fatalf("waitForProcessGroupExitWithProbe(%d) = %v, %v; probe called=%v", groupID, absent, err, probeCalled)
+		}
+	}
+	group := ownedFixtureProcessGroup{id: 42, members: map[int]string{42: "original"}}
+	if group.hasLiveMemberWith(func(int) (int, string, error) { return 42, "reused", nil }) {
+		t.Fatal("stale process generation was accepted")
+	}
+	if !group.hasLiveMemberWith(func(int) (int, string, error) { return 42, "original", nil }) {
+		t.Fatal("matching process generation was rejected")
+	}
+}
+
+func TestWaitForProcessGroupExitTreatsEPERMAsPresent(t *testing.T) {
+	now := time.Unix(1, 0)
+	absent, err := waitForProcessGroupExitWithProbe(
+		42,
+		0,
+		func(pid int, signal syscall.Signal) error {
+			if pid != -42 || signal != 0 {
+				t.Fatalf("probe = (%d, %d)", pid, signal)
+			}
+			return syscall.EPERM
+		},
+		func() time.Time { return now },
+		func(time.Duration) { t.Fatal("unexpected sleep") },
+	)
+	if err != nil || absent {
+		t.Fatalf("waitForProcessGroupExitWithProbe() = %v, %v, want present", absent, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Supervise each timed Colima command in a dedicated process group.
- Send TERM, then KILL, and prove group absence before return.
- Preserve timeout status when the leader exits nonzero during cancellation.
- Preserve ordinary status and report cleanup failures.

## Validation

- Commit-bound `pr-parity` passed from the signed head snapshot.
- Evidence binds base `e7425e01`, head `776f6901`, and tree `0f3eed36`.
- The evidence records a clean worktree.
- Focused timeout tests passed 50 repetitions.
- Live host checks and container smoke passed on the exact tree.
- Two independent reviews found no actionable issue.

## Complexity

- Pinned `gocyclo` reduced `colima.go` from 13 functions to 12.
- Total complexity decreased from 52 to 47.
- Maximum function complexity decreased from 8 to 7.

## Scope

- This PR contains the bounded-cancellation core for F-013.
- Separate signal-forwarding work remains outside this review unit.
- The change has eight paths, 1,200 lines, one area, and no binary files.

## Checklist

- [x] The commit signature is valid.
- [x] The repository shape gate passes.
- [x] Fresh PR parity passes.
- [x] Live certification passes.
- [x] Independent source review is clean.
