### PR TITLE
Reduce Docker pin validator complexity

### DIFF
--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -15,188 +15,347 @@ import (
 var aptInstallPattern = regexp.MustCompile(`apt-get install -y --no-install-recommends(?s:(.*?))&&`)
 
 func validateDockerPinnedInputs(cfg PinnedInputsConfig, repoRoot, runtimeDockerfile, validatorDockerfile string, debianBootstrapManifest DebianBootstrapManifest, debianBootstrapManifestPath, goModText, codexRequirementsText, codexMCPConfigText string) error {
-	goModPath := filepath.Join(repoRoot, "go.mod")
+	validator := dockerPinnedInputValidator{
+		cfg:                         cfg,
+		runtimeDockerfile:           runtimeDockerfile,
+		validatorDockerfile:         validatorDockerfile,
+		debianBootstrapManifest:     debianBootstrapManifest,
+		debianBootstrapManifestPath: debianBootstrapManifestPath,
+		goModText:                   goModText,
+		goModPath:                   filepath.Join(repoRoot, "go.mod"),
+		codexRequirementsText:       codexRequirementsText,
+		codexMCPConfigText:          codexMCPConfigText,
+	}
+	if err := validator.load(); err != nil {
+		return err
+	}
+	if err := validator.validateBaseAndBootstrapInputs(); err != nil {
+		return err
+	}
+	if err := validator.validateRuntimeProviderInputs(); err != nil {
+		return err
+	}
+	if err := validator.validateDockerPackageSets(); err != nil {
+		return err
+	}
+	return validator.validateValidatorToolInputs()
+}
 
-	runtimeBaseImage, err := requireArg(runtimeDockerfile, "NODE_BASE_IMAGE", cfg.RuntimeDockerfilePath)
-	if err != nil {
-		return err
-	}
-	validatorBaseImage, err := requireArg(validatorDockerfile, "VALIDATOR_BASE_IMAGE", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	codexVersion, err := requireArg(runtimeDockerfile, "CODEX_VERSION", cfg.RuntimeDockerfilePath)
-	if err != nil {
-		return err
-	}
-	claudeVersion, err := requireArg(runtimeDockerfile, "CLAUDE_VERSION", cfg.RuntimeDockerfilePath)
-	if err != nil {
-		return err
-	}
-	copilotVersion, err := requireArg(runtimeDockerfile, "COPILOT_VERSION", cfg.RuntimeDockerfilePath)
-	if err != nil {
-		return err
-	}
+type dockerPinnedInputValidator struct {
+	cfg                         PinnedInputsConfig
+	runtimeDockerfile           string
+	validatorDockerfile         string
+	debianBootstrapManifest     DebianBootstrapManifest
+	debianBootstrapManifestPath string
+	goModText                   string
+	goModPath                   string
+	codexRequirementsText       string
+	codexMCPConfigText          string
+	runtimeBaseImage            string
+	validatorBaseImage          string
+	codexVersion                string
+	claudeVersion               string
+	copilotVersion              string
+	runtimeInstallBlocks        [][]string
+	validatorInstallBlocks      [][]string
+	goLanguageVersion           string
+	goToolchainVersion          string
+	validatorGoVersion          string
+}
 
-	runtimeInstallBlocks, err := extractInstallBlocks(runtimeDockerfile, cfg.RuntimeDockerfilePath)
-	if err != nil {
+func (validator *dockerPinnedInputValidator) load() error {
+	if err := validator.loadBaseImages(); err != nil {
 		return err
 	}
-	validatorInstallBlocks, err := extractInstallBlocks(validatorDockerfile, cfg.ValidatorDockerfilePath)
-	if err != nil {
+	if err := validator.loadProviderVersions(); err != nil {
 		return err
 	}
+	return validator.loadInstallBlocks()
+}
 
-	if err := requirePinnedBaseImage(runtimeBaseImage, "NODE_BASE_IMAGE", cfg.RuntimeDockerfilePath); err != nil {
+func (validator *dockerPinnedInputValidator) loadBaseImages() error {
+	var err error
+	validator.runtimeBaseImage, err = requireArg(validator.runtimeDockerfile, "NODE_BASE_IMAGE", validator.cfg.RuntimeDockerfilePath)
+	if err != nil {
 		return err
 	}
-	if err := requirePinnedBaseImage(validatorBaseImage, "VALIDATOR_BASE_IMAGE", cfg.ValidatorDockerfilePath); err != nil {
+	validator.validatorBaseImage, err = requireArg(validator.validatorDockerfile, "VALIDATOR_BASE_IMAGE", validator.cfg.ValidatorDockerfilePath)
+	return err
+}
+
+func (validator *dockerPinnedInputValidator) loadProviderVersions() error {
+	var err error
+	validator.codexVersion, err = requireArg(validator.runtimeDockerfile, "CODEX_VERSION", validator.cfg.RuntimeDockerfilePath)
+	if err != nil {
 		return err
 	}
-	if err := verifySnapshotFreshness(debianBootstrapManifest.Snapshot, debianBootstrapManifestPath, cfg.MaxDebianSnapshotAgeDays); err != nil {
+	validator.claudeVersion, err = requireArg(validator.runtimeDockerfile, "CLAUDE_VERSION", validator.cfg.RuntimeDockerfilePath)
+	if err != nil {
 		return err
 	}
-	if err := validateDebianBootstrapDockerfilePins(runtimeDockerfile, cfg.RuntimeDockerfilePath, validatorDockerfile, cfg.ValidatorDockerfilePath); err != nil {
+	validator.copilotVersion, err = requireArg(validator.runtimeDockerfile, "COPILOT_VERSION", validator.cfg.RuntimeDockerfilePath)
+	return err
+}
+
+func (validator *dockerPinnedInputValidator) loadInstallBlocks() error {
+	var err error
+	validator.runtimeInstallBlocks, err = extractInstallBlocks(validator.runtimeDockerfile, validator.cfg.RuntimeDockerfilePath)
+	if err != nil {
 		return err
 	}
-	if err := requireNoRegistryBootstrapMCP(codexRequirementsText, cfg.CodexRequirementsPath); err != nil {
+	validator.validatorInstallBlocks, err = extractInstallBlocks(validator.validatorDockerfile, validator.cfg.ValidatorDockerfilePath)
+	return err
+}
+
+func (validator *dockerPinnedInputValidator) validateBaseAndBootstrapInputs() error {
+	if err := validator.validateBaseImages(); err != nil {
 		return err
 	}
-	if err := requireNoRegistryBootstrapMCP(codexMCPConfigText, cfg.CodexMCPConfigPath); err != nil {
+	if err := validator.validateBootstrapAndMCPInputs(); err != nil {
 		return err
 	}
-	if err := CheckProviderBumpPolicy(cfg.ProviderBumpPolicyPath, cfg.RuntimeDockerfilePath, cfg.ProvidersPackageJSONPath); err != nil {
+	return CheckProviderBumpPolicy(validator.cfg.ProviderBumpPolicyPath, validator.cfg.RuntimeDockerfilePath, validator.cfg.ProvidersPackageJSONPath)
+}
+
+func (validator *dockerPinnedInputValidator) validateBaseImages() error {
+	if err := requirePinnedBaseImage(validator.runtimeBaseImage, "NODE_BASE_IMAGE", validator.cfg.RuntimeDockerfilePath); err != nil {
 		return err
 	}
-	if _, _, err := requireRegex(runtimeDockerfile, `curl --ipv4 -fsSL "https://storage\.googleapis\.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/\$\{CLAUDE_VERSION\}/\$\{CLAUDE_PLATFORM\}/claude"`, "Claude native release download URL", cfg.RuntimeDockerfilePath); err != nil {
+	return requirePinnedBaseImage(validator.validatorBaseImage, "VALIDATOR_BASE_IMAGE", validator.cfg.ValidatorDockerfilePath)
+}
+
+func (validator *dockerPinnedInputValidator) validateBootstrapAndMCPInputs() error {
+	if err := verifySnapshotFreshness(validator.debianBootstrapManifest.Snapshot, validator.debianBootstrapManifestPath, validator.cfg.MaxDebianSnapshotAgeDays); err != nil {
 		return err
 	}
-	if _, _, err := requireRegex(runtimeDockerfile, `curl --ipv4 -fsSL "https://github\.com/github/copilot-cli/releases/download/v\$\{COPILOT_VERSION\}/copilot-\$\{COPILOT_PLATFORM\}\.tar\.gz"`, "Copilot native release download URL", cfg.RuntimeDockerfilePath); err != nil {
+	if err := validateDebianBootstrapDockerfilePins(validator.runtimeDockerfile, validator.cfg.RuntimeDockerfilePath, validator.validatorDockerfile, validator.cfg.ValidatorDockerfilePath); err != nil {
 		return err
 	}
-	if _, _, err := requireRegex(runtimeDockerfile, `echo "\$\{COPILOT_SHA256\}  /tmp/copilot\.tar\.gz" \| sha256sum -c -`, "Copilot native archive checksum verification", cfg.RuntimeDockerfilePath); err != nil {
+	if err := requireNoRegistryBootstrapMCP(validator.codexRequirementsText, validator.cfg.CodexRequirementsPath); err != nil {
 		return err
 	}
-	if _, _, err := requireRegex(runtimeDockerfile, `install -m 0755 /tmp/copilot /usr/local/libexec/workcell/real/copilot`, "executable Copilot runtime artifact install", cfg.RuntimeDockerfilePath); err != nil {
+	return requireNoRegistryBootstrapMCP(validator.codexMCPConfigText, validator.cfg.CodexMCPConfigPath)
+}
+
+func (validator *dockerPinnedInputValidator) validateRuntimeProviderInputs() error {
+	if err := validator.validateProviderInstallCommands(); err != nil {
 		return err
 	}
-	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*arm64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "arm64 Claude mapping", cfg.RuntimeDockerfilePath); err != nil {
+	if err := validator.validateClaudeArchitectureMappings(); err != nil {
 		return err
-	} else if match[1] != "linux-arm64" {
-		return fmt.Errorf("arm64 Claude mapping in %s must use linux-arm64", cfg.RuntimeDockerfilePath)
 	}
-	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*amd64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "amd64 Claude mapping", cfg.RuntimeDockerfilePath); err != nil {
+	if err := validator.validateProviderVersions(); err != nil {
 		return err
-	} else if match[1] != "linux-x64" {
-		return fmt.Errorf("amd64 Claude mapping in %s must use linux-x64", cfg.RuntimeDockerfilePath)
 	}
-	if !regexp.MustCompile(`^0\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`).MatchString(codexVersion) {
-		return fmt.Errorf("runtime/container/Dockerfile CODEX_VERSION must stay pinned to an explicit release, found %q", codexVersion)
-	}
-	if !regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`).MatchString(claudeVersion) {
-		return fmt.Errorf("runtime/container/Dockerfile CLAUDE_VERSION must stay pinned to an explicit release, found %q", claudeVersion)
-	}
-	if !regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`).MatchString(copilotVersion) {
-		return fmt.Errorf("runtime/container/Dockerfile COPILOT_VERSION must stay pinned to a non-prerelease GitHub Copilot CLI release, found %q", copilotVersion)
-	}
-	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*arm64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "arm64 Codex mapping", cfg.RuntimeDockerfilePath); err != nil {
+	if err := validator.validateCodexArchitectureMappings(); err != nil {
 		return err
-	} else if match[1] != "aarch64-unknown-linux-musl" {
-		return fmt.Errorf("arm64 Codex mapping in %s must use aarch64-unknown-linux-musl", cfg.RuntimeDockerfilePath)
 	}
-	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*amd64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "amd64 Codex mapping", cfg.RuntimeDockerfilePath); err != nil {
+	return validator.validateCopilotArchitectureMappings()
+}
+
+type dockerRegexRequirement struct {
+	pattern string
+	label   string
+}
+
+func (validator *dockerPinnedInputValidator) validateProviderInstallCommands() error {
+	requirements := []dockerRegexRequirement{
+		{`curl --ipv4 -fsSL "https://storage\.googleapis\.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/\$\{CLAUDE_VERSION\}/\$\{CLAUDE_PLATFORM\}/claude"`, "Claude native release download URL"},
+		{`curl --ipv4 -fsSL "https://github\.com/github/copilot-cli/releases/download/v\$\{COPILOT_VERSION\}/copilot-\$\{COPILOT_PLATFORM\}\.tar\.gz"`, "Copilot native release download URL"},
+		{`echo "\$\{COPILOT_SHA256\}  /tmp/copilot\.tar\.gz" \| sha256sum -c -`, "Copilot native archive checksum verification"},
+		{`install -m 0755 /tmp/copilot /usr/local/libexec/workcell/real/copilot`, "executable Copilot runtime artifact install"},
+	}
+	for _, requirement := range requirements {
+		if _, _, err := requireRegex(validator.runtimeDockerfile, requirement.pattern, requirement.label, validator.cfg.RuntimeDockerfilePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type dockerArchitectureMapping struct {
+	pattern string
+	label   string
+	want    string
+}
+
+func validateDockerArchitectureMappings(text, path string, mappings []dockerArchitectureMapping) error {
+	for _, mapping := range mappings {
+		_, match, err := requireRegex(text, mapping.pattern, mapping.label, path)
+		if err != nil {
+			return err
+		}
+		if match[1] != mapping.want {
+			return fmt.Errorf("%s in %s must use %s", mapping.label, path, mapping.want)
+		}
+	}
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) validateClaudeArchitectureMappings() error {
+	return validateDockerArchitectureMappings(validator.runtimeDockerfile, validator.cfg.RuntimeDockerfilePath, []dockerArchitectureMapping{
+		{`(?m)^\s*arm64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "arm64 Claude mapping", "linux-arm64"},
+		{`(?m)^\s*amd64\)\s+\\\s*CLAUDE_PLATFORM="([^"]+)";\s+\\\s*CLAUDE_SHA256="([0-9a-f]{64})";`, "amd64 Claude mapping", "linux-x64"},
+	})
+}
+
+type providerVersionRequirement struct {
+	version     string
+	pattern     *regexp.Regexp
+	errorPrefix string
+}
+
+func (validator *dockerPinnedInputValidator) validateProviderVersions() error {
+	requirements := []providerVersionRequirement{
+		{validator.codexVersion, regexp.MustCompile(`^0\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`), "runtime/container/Dockerfile CODEX_VERSION must stay pinned to an explicit release"},
+		{validator.claudeVersion, regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$`), "runtime/container/Dockerfile CLAUDE_VERSION must stay pinned to an explicit release"},
+		{validator.copilotVersion, regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`), "runtime/container/Dockerfile COPILOT_VERSION must stay pinned to a non-prerelease GitHub Copilot CLI release"},
+	}
+	for _, requirement := range requirements {
+		if !requirement.pattern.MatchString(requirement.version) {
+			return fmt.Errorf("%s, found %q", requirement.errorPrefix, requirement.version)
+		}
+	}
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) validateCodexArchitectureMappings() error {
+	return validateDockerArchitectureMappings(validator.runtimeDockerfile, validator.cfg.RuntimeDockerfilePath, []dockerArchitectureMapping{
+		{`(?m)^\s*arm64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "arm64 Codex mapping", "aarch64-unknown-linux-musl"},
+		{`(?m)^\s*amd64\)\s+\\(?:\s*CLAUDE_[A-Z0-9_]+="[^"]+";\s+\\)*\s*CODEX_ARCH="([^"]+)";\s+\\\s*CODEX_SHA256="([0-9a-f]{64})";`, "amd64 Codex mapping", "x86_64-unknown-linux-musl"},
+	})
+}
+
+func (validator *dockerPinnedInputValidator) validateCopilotArchitectureMappings() error {
+	return validateDockerArchitectureMappings(validator.runtimeDockerfile, validator.cfg.RuntimeDockerfilePath, []dockerArchitectureMapping{
+		{`(?m)^\s*arm64\)\s+\\\s*COPILOT_PLATFORM="([^"]+)";\s+\\\s*COPILOT_SHA256="([0-9a-f]{64})";`, "arm64 Copilot mapping", "linux-arm64"},
+		{`(?m)^\s*amd64\)\s+\\\s*COPILOT_PLATFORM="([^"]+)";\s+\\\s*COPILOT_SHA256="([0-9a-f]{64})";`, "amd64 Copilot mapping", "linux-x64"},
+	})
+}
+
+func (validator *dockerPinnedInputValidator) validateDockerPackageSets() error {
+	if err := validator.validateInstallBlockShape(); err != nil {
 		return err
-	} else if match[1] != "x86_64-unknown-linux-musl" {
-		return fmt.Errorf("amd64 Codex mapping in %s must use x86_64-unknown-linux-musl", cfg.RuntimeDockerfilePath)
 	}
-	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*arm64\)\s+\\\s*COPILOT_PLATFORM="([^"]+)";\s+\\\s*COPILOT_SHA256="([0-9a-f]{64})";`, "arm64 Copilot mapping", cfg.RuntimeDockerfilePath); err != nil {
-		return err
-	} else if match[1] != "linux-arm64" {
-		return fmt.Errorf("arm64 Copilot mapping in %s must use linux-arm64", cfg.RuntimeDockerfilePath)
+	return validator.validateExactDockerPackages()
+}
+
+func (validator *dockerPinnedInputValidator) validateInstallBlockShape() error {
+	if len(validator.runtimeInstallBlocks) != 2 {
+		return errors.New("runtime/container/Dockerfile must contain exactly two apt install blocks (runtime base and runtime builder)")
 	}
-	if _, match, err := requireRegex(runtimeDockerfile, `(?m)^\s*amd64\)\s+\\\s*COPILOT_PLATFORM="([^"]+)";\s+\\\s*COPILOT_SHA256="([0-9a-f]{64})";`, "amd64 Copilot mapping", cfg.RuntimeDockerfilePath); err != nil {
-		return err
-	} else if match[1] != "linux-x64" {
-		return fmt.Errorf("amd64 Copilot mapping in %s must use linux-x64", cfg.RuntimeDockerfilePath)
-	}
-	if len(runtimeInstallBlocks) != 2 {
-		return fmt.Errorf("runtime/container/Dockerfile must contain exactly two apt install blocks (runtime base and runtime builder)")
-	}
-	if len(validatorInstallBlocks) != 1 {
+	if len(validator.validatorInstallBlocks) != 1 {
 		return errors.New("tools/validator/Dockerfile must contain exactly one apt install block")
 	}
-	if err := requireExactPackages(runtimeInstallBlocks[0], []string{"bash", "bubblewrap", "ca-certificates", "curl", "fd-find", "git", "jq", "less", "openssh-client", "passwd", "procps", "ripgrep", "sudo", "unzip", "util-linux", "xz-utils"}, "Runtime base", cfg.RuntimeDockerfilePath); err != nil {
+	return nil
+}
+
+type dockerPackageRequirement struct {
+	actual   []string
+	expected []string
+	label    string
+	path     string
+}
+
+func (validator *dockerPinnedInputValidator) validateExactDockerPackages() error {
+	requirements := []dockerPackageRequirement{
+		{validator.runtimeInstallBlocks[0], []string{"bash", "bubblewrap", "ca-certificates", "curl", "fd-find", "git", "jq", "less", "openssh-client", "passwd", "procps", "ripgrep", "sudo", "unzip", "util-linux", "xz-utils"}, "Runtime base", validator.cfg.RuntimeDockerfilePath},
+		{validator.runtimeInstallBlocks[1], []string{"gcc", "libc6-dev"}, "Runtime builder", validator.cfg.RuntimeDockerfilePath},
+		{validator.validatorInstallBlocks[0], []string{"acl", "ca-certificates", "codespell", "curl", "gcc", "git", "groff-base", "jq", "libc6-dev", "llvm", "mandoc", "openssh-client", "procps", "shellcheck", "shfmt", "yamllint"}, "Validator", validator.cfg.ValidatorDockerfilePath},
+	}
+	for _, requirement := range requirements {
+		if err := requireExactPackages(requirement.actual, requirement.expected, requirement.label, requirement.path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) validateValidatorToolInputs() error {
+	if err := validator.validateValidatorGoVersion(); err != nil {
 		return err
 	}
-	if err := requireExactPackages(runtimeInstallBlocks[1], []string{"gcc", "libc6-dev"}, "Runtime builder", cfg.RuntimeDockerfilePath); err != nil {
+	if err := validator.validateValidatorGoDigests(); err != nil {
 		return err
 	}
-	if err := requireExactPackages(validatorInstallBlocks[0], []string{"acl", "ca-certificates", "codespell", "curl", "gcc", "git", "groff-base", "jq", "libc6-dev", "llvm", "mandoc", "openssh-client", "procps", "shellcheck", "shfmt", "yamllint"}, "Validator", cfg.ValidatorDockerfilePath); err != nil {
+	if err := validator.validateValidatorHadolint(); err != nil {
 		return err
 	}
-	goLanguageVersion, err := requireGoDirective(goModText, "go", goModPath)
+	return validator.validateValidatorDeadcode()
+}
+
+func (validator *dockerPinnedInputValidator) validateValidatorGoVersion() error {
+	if err := validator.loadValidatorGoVersions(); err != nil {
+		return err
+	}
+	return validator.validateValidatorGoVersionParity()
+}
+
+func (validator *dockerPinnedInputValidator) loadValidatorGoVersions() error {
+	var err error
+	validator.goLanguageVersion, err = requireGoDirective(validator.goModText, "go", validator.goModPath)
 	if err != nil {
 		return err
 	}
-	goToolchainVersion, err := requireToolchainDirective(goModText, goModPath)
+	validator.goToolchainVersion, err = requireToolchainDirective(validator.goModText, validator.goModPath)
 	if err != nil {
 		return err
 	}
-	validatorGoVersion, err := requireArg(validatorDockerfile, "GO_VERSION", cfg.ValidatorDockerfilePath)
+	validator.validatorGoVersion, err = requireArg(validator.validatorDockerfile, "GO_VERSION", validator.cfg.ValidatorDockerfilePath)
+	return err
+}
+
+func (validator *dockerPinnedInputValidator) validateValidatorGoVersionParity() error {
+	if err := requireEqual("Go toolchain version", validator.goToolchainVersion, validator.goModPath, validator.validatorGoVersion, validator.cfg.ValidatorDockerfilePath); err != nil {
+		return err
+	}
+	expected, err := goLanguageVersionFromToolchain(validator.goToolchainVersion, validator.goModPath)
 	if err != nil {
 		return err
 	}
-	if err := requireEqual("Go toolchain version", goToolchainVersion, goModPath, validatorGoVersion, cfg.ValidatorDockerfilePath); err != nil {
-		return err
+	if validator.goLanguageVersion != expected {
+		return fmt.Errorf("go language version in %s must match the toolchain major/minor at patch zero, expected %q, found %q", validator.goModPath, expected, validator.goLanguageVersion)
 	}
-	expectedGoLanguageVersion, err := goLanguageVersionFromToolchain(goToolchainVersion, goModPath)
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) validateValidatorGoDigests() error {
+	return requireDockerSHAArgs(validator.validatorDockerfile, validator.cfg.ValidatorDockerfilePath,
+		"GO_LINUX_X86_64_SHA256", "GO_LINUX_ARM64_SHA256")
+}
+
+func requireDockerSHAArgs(dockerfile, path string, names ...string) error {
+	for _, name := range names {
+		value, err := requireArg(dockerfile, name, path)
+		if err != nil {
+			return err
+		}
+		if !isHexDigest(value) {
+			return fmt.Errorf("%s in %s must be a full SHA256 digest, found %q", name, path, value)
+		}
+	}
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) validateValidatorHadolint() error {
+	version, err := requireArg(validator.validatorDockerfile, "HADOLINT_VERSION", validator.cfg.ValidatorDockerfilePath)
 	if err != nil {
 		return err
 	}
-	if goLanguageVersion != expectedGoLanguageVersion {
-		return fmt.Errorf("go language version in %s must match the toolchain major/minor at patch zero, expected %q, found %q", goModPath, expectedGoLanguageVersion, goLanguageVersion)
+	if !pinnedReleaseTagPattern.MatchString(version) {
+		return fmt.Errorf("HADOLINT_VERSION must be an exact pinned release, found %q", version)
 	}
-	validatorGoSHAx86_64, err := requireArg(validatorDockerfile, "GO_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
+	return requireDockerSHAArgs(validator.validatorDockerfile, validator.cfg.ValidatorDockerfilePath,
+		"HADOLINT_LINUX_X86_64_SHA256", "HADOLINT_LINUX_ARM64_SHA256")
+}
+
+func (validator *dockerPinnedInputValidator) validateValidatorDeadcode() error {
+	version, err := requireArg(validator.validatorDockerfile, "DEADCODE_VERSION", validator.cfg.ValidatorDockerfilePath)
 	if err != nil {
 		return err
 	}
-	if !isHexDigest(validatorGoSHAx86_64) {
-		return fmt.Errorf("GO_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorGoSHAx86_64)
-	}
-	validatorGoSHAArm64, err := requireArg(validatorDockerfile, "GO_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	if !isHexDigest(validatorGoSHAArm64) {
-		return fmt.Errorf("GO_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorGoSHAArm64)
-	}
-	validatorHadolintVersion, err := requireArg(validatorDockerfile, "HADOLINT_VERSION", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	if !pinnedReleaseTagPattern.MatchString(validatorHadolintVersion) {
-		return fmt.Errorf("HADOLINT_VERSION must be an exact pinned release, found %q", validatorHadolintVersion)
-	}
-	validatorHadolintSHAx86_64, err := requireArg(validatorDockerfile, "HADOLINT_LINUX_X86_64_SHA256", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	if !isHexDigest(validatorHadolintSHAx86_64) {
-		return fmt.Errorf("HADOLINT_LINUX_X86_64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorHadolintSHAx86_64)
-	}
-	validatorHadolintSHAArm64, err := requireArg(validatorDockerfile, "HADOLINT_LINUX_ARM64_SHA256", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	if !isHexDigest(validatorHadolintSHAArm64) {
-		return fmt.Errorf("HADOLINT_LINUX_ARM64_SHA256 in %s must be a full SHA256 digest, found %q", cfg.ValidatorDockerfilePath, validatorHadolintSHAArm64)
-	}
-	validatorDeadcodeVersion, err := requireArg(validatorDockerfile, "DEADCODE_VERSION", cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	if !pinnedReleaseTagPattern.MatchString(validatorDeadcodeVersion) {
-		return fmt.Errorf("DEADCODE_VERSION must be an exact pinned release, found %q", validatorDeadcodeVersion)
+	if !pinnedReleaseTagPattern.MatchString(version) {
+		return fmt.Errorf("DEADCODE_VERSION must be an exact pinned release, found %q", version)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Split Docker pin validation into small, ordered checks.
- Preserve validation order, error text, and accepted inputs.
- Reduce the changed function from CC 57 to CC 5.

## Validation

- `./scripts/pre-merge.sh --profile pr-parity`
- Focused and adversarial metadata tests
- Independent complexity and behavior review