### PR TITLE
Harden the hosted-control API collection

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -71,6 +71,8 @@ func subcommands() []subcommand {
 		{"generate-workflow-lane-manifest", "ROOT_DIR POLICY_PATH OUTPUT_PATH", 3, 3, cmdGenerateWorkflowLaneManifest},
 		{"verify-workflow-lane-manifest", "ROOT_DIR POLICY_PATH MANIFEST_PATH", 3, 3, cmdVerifyWorkflowLaneManifest},
 		{"plan-workflow-lanes", "MANIFEST_PATH CONFIG_JSON_PATH", 2, 2, cmdPlanWorkflowLanes},
+		{"merge-hosted-control-array-pages", "", 0, 0, cmdMergeHostedControlArrayPages},
+		{"merge-hosted-control-object-pages", "FIELD", 1, 1, cmdMergeHostedControlObjectPages},
 		{"fetch-rulesets", "TMP_DIR REPO", 2, 2, cmdFetchRulesets},
 		{"list-hosted-control-environments", "POLICY_PATH", 1, 1, cmdListHostedControlEnvironments},
 		{"verify-github-hosted-controls", "TMP_DIR REPO POLICY_PATH", 3, 3, cmdVerifyGitHubHostedControls},
@@ -286,6 +288,14 @@ func cmdPlanWorkflowLanes(args []string) error {
 
 func cmdFetchRulesets(args []string) error {
 	return metadatautil.FetchRulesets(args[0], args[1])
+}
+
+func cmdMergeHostedControlArrayPages(_ []string) error {
+	return metadatautil.MergeHostedControlArrayPages(os.Stdin, os.Stdout)
+}
+
+func cmdMergeHostedControlObjectPages(args []string) error {
+	return metadatautil.MergeHostedControlObjectPages(os.Stdin, os.Stdout, args[0])
 }
 
 func cmdListHostedControlEnvironments(args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require golang.org/x/sys v0.47.0
 require golang.org/x/text v0.41.0
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require mvdan.cc/sh/v3 v3.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,15 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=
+github.com/go-quicktest/qt v1.102.0/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
@@ -8,3 +18,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+mvdan.cc/sh/v3 v3.14.0 h1:wsPjcfrSXLJomdxwhVZqZ5j5Cue68l549Aj/DCqzbpc=
+mvdan.cc/sh/v3 v3.14.0/go.mod h1:syYCoFET8w9tvevxiXUtY8/ICrU+l26jHmhJDra3Vwo=

--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -19,6 +19,8 @@ import (
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
 
+const gitHubAPIVersion = "2026-03-10"
+
 type WorkflowEnvironmentPolicy struct {
 	Variables             map[string]string
 	RequiredSecrets       []string
@@ -316,36 +318,79 @@ func EnvironmentArtifactName(environmentName string) string {
 }
 
 func FetchRulesets(tmpDir, repo string) error {
-	var summary []any
-	if err := readJSONFile(filepath.Join(tmpDir, "rulesets-summary.json"), &summary); err != nil {
+	summary, err := readRulesetSummary(filepath.Join(tmpDir, "rulesets-summary.json"))
+	if err != nil {
 		return err
 	}
 
 	details := make([]any, 0, len(summary))
 	for _, raw := range summary {
-		entry, ok := raw.(map[string]any)
-		if !ok {
-			return fmt.Errorf("unexpected ruleset summary entry: %v", raw)
-		}
-		idValue, ok := entry["id"].(float64)
-		if !ok {
-			return fmt.Errorf("unexpected ruleset summary id: %v", entry)
-		}
-		rulesetID := strconv.FormatInt(int64(idValue), 10)
-		cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/rulesets/%s", repo, rulesetID))
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		output, err := cmd.Output()
+		detail, err := fetchRuleset(repo, raw)
 		if err != nil {
-			return fmt.Errorf("gh api repos/%s/rulesets/%s: %w (stderr: %s)", repo, rulesetID, err, strings.TrimSpace(stderr.String()))
-		}
-		var detail any
-		if err := json.Unmarshal(output, &detail); err != nil {
-			return fmt.Errorf("gh api repos/%s/rulesets/%s: parse JSON: %w", repo, rulesetID, err)
+			return err
 		}
 		details = append(details, detail)
 	}
 	return writeJSONFile(filepath.Join(tmpDir, "rulesets.json"), details)
+}
+
+func readRulesetSummary(path string) ([]any, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	values, err := decodeHostedControlPages(bytes.NewReader(content))
+	if err != nil {
+		return nil, err
+	}
+	if len(values) != 1 {
+		return nil, errors.New("ruleset summary must contain exactly one JSON value")
+	}
+	summary, ok := values[0].([]any)
+	if !ok {
+		return nil, errors.New("ruleset summary must be an array")
+	}
+	return summary, nil
+}
+
+func fetchRuleset(repo string, raw any) (any, error) {
+	id, err := rulesetSummaryID(raw)
+	if err != nil {
+		return nil, err
+	}
+	rulesetID := strconv.FormatInt(id, 10)
+	endpoint := fmt.Sprintf("repos/%s/rulesets/%s", repo, rulesetID)
+	cmd := exec.Command("gh", "api", "--hostname", "github.com", "-H", "X-GitHub-Api-Version: "+gitHubAPIVersion, endpoint)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api %s: %w (stderr: %s)", endpoint, err, strings.TrimSpace(stderr.String()))
+	}
+	var detail any
+	if err := json.Unmarshal(output, &detail); err != nil {
+		return nil, fmt.Errorf("gh api %s: parse JSON: %w", endpoint, err)
+	}
+	return detail, nil
+}
+
+func rulesetSummaryID(raw any) (int64, error) {
+	entry, ok := raw.(map[string]any)
+	if !ok {
+		return 0, fmt.Errorf("unexpected ruleset summary entry: %v", raw)
+	}
+	number, ok := entry["id"].(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("unexpected ruleset summary id: %v", entry)
+	}
+	value, err := number.Int64()
+	if err != nil {
+		return 0, fmt.Errorf("unexpected ruleset summary id: %v", entry)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("unexpected ruleset summary id: %v", entry)
+	}
+	return value, nil
 }
 
 func UnexpectedEnvironmentVariableNames(actual map[string]any, expected map[string]string) []string {

--- a/internal/metadatautil/hostedcontrols_fetch_external_test.go
+++ b/internal/metadatautil/hostedcontrols_fetch_external_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+const fetchHostedControlsRepo = "omkhar/workcell"
+
+func TestFetchRulesetsPinsGitHubAPIVersion(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(root, "gh.args")
+	stub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$WORKCELL_TEST_GH_LOG\"\nprintf '{\"name\":\"fixture\"}\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeHostedRulesetSummary(t, root)
+	t.Setenv("WORKCELL_TEST_GH_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if err := metadatautil.FetchRulesets(root, fetchHostedControlsRepo); err != nil {
+		t.Fatal(err)
+	}
+	requireFetchFileContains(t, logPath, "--hostname github.com -H X-GitHub-Api-Version: 2026-03-10 repos/omkhar/workcell/rulesets/42")
+}
+
+func TestFetchRulesetsRejectsMalformedSummaryIDs(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"non-object", `["42"]`, "unexpected ruleset summary entry"},
+		{"missing", `[{}]`, "unexpected ruleset summary id"},
+		{"string", `[{"id":"42"}]`, "unexpected ruleset summary id"},
+		{"boolean", `[{"id":true}]`, "unexpected ruleset summary id"},
+		{"zero", `[{"id":0}]`, "unexpected ruleset summary id"},
+		{"negative", `[{"id":-1}]`, "unexpected ruleset summary id"},
+		{"fractional", `[{"id":42.5}]`, "unexpected ruleset summary id"},
+		{"decimal integer", `[{"id":42.0}]`, "unexpected ruleset summary id"},
+		{"exponent", `[{"id":42e0}]`, "unexpected ruleset summary id"},
+		{"rounded", `[{"id":42.000000000000001}]`, "unexpected ruleset summary id"},
+		{"out of range", `[{"id":9223372036854775808}]`, "unexpected ruleset summary id"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, "rulesets-summary.json"), []byte(test.raw), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := metadatautil.FetchRulesets(root, fetchHostedControlsRepo)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("metadatautil.FetchRulesets() error = %v, want malformed-ID rejection", err)
+			}
+		})
+	}
+}
+
+func TestFetchRulesetsRejectsMalformedSummaryDocuments(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", ``, "must contain exactly one JSON value"},
+		{"multiple values", `[{"id":42}] [{"id":43}]`, "must contain exactly one JSON value"},
+		{"top-level object", `{"id":42}`, "must be an array"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, "rulesets-summary.json"), []byte(test.raw), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := metadatautil.FetchRulesets(root, fetchHostedControlsRepo)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("metadatautil.FetchRulesets() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func writeHostedRulesetSummary(tb testing.TB, root string) {
+	tb.Helper()
+	if err := writeJSONFile(filepath.Join(root, "rulesets-summary.json"), []map[string]any{{"id": float64(42)}}); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func requireFetchFileContains(tb testing.TB, filePath, want string) {
+	tb.Helper()
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if !strings.Contains(string(content), want) {
+		tb.Fatalf("%s = %q, want %q", filePath, content, want)
+	}
+}

--- a/internal/metadatautil/hostedcontrols_fetch_test.go
+++ b/internal/metadatautil/hostedcontrols_fetch_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRulesetSummaryIDRejectsInvalidJSONNumbers(t *testing.T) {
+	for _, literal := range []string{"42.0", "42e0", "42.000000000000001", "9223372036854775808"} {
+		_, err := rulesetSummaryID(map[string]any{"id": json.Number(literal)})
+		if err == nil {
+			t.Fatalf("rulesetSummaryID(%q) unexpectedly accepted a noncanonical ID", literal)
+		}
+	}
+}

--- a/internal/metadatautil/hostedcontrols_pages.go
+++ b/internal/metadatautil/hostedcontrols_pages.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var hostedControlCollectionFields = map[string]struct{}{
+	"branch_policies": {},
+	"environments":    {},
+	"secrets":         {},
+	"variables":       {},
+}
+
+type hostedControlCollectionPage struct {
+	totalCount int64
+	items      []any
+}
+
+func MergeHostedControlObjectPages(input io.Reader, output io.Writer, field string) error {
+	if _, ok := hostedControlCollectionFields[field]; !ok {
+		return fmt.Errorf("unsupported hosted-control collection field %q", field)
+	}
+	values, err := decodeHostedControlPages(input)
+	if err != nil {
+		return err
+	}
+	pages, err := parseHostedControlCollectionPages(values, field)
+	if err != nil {
+		return err
+	}
+	merged, err := mergeHostedControlCollectionPages(pages, field)
+	if err != nil {
+		return err
+	}
+	return encodeHostedControlPage(output, merged)
+}
+
+func MergeHostedControlArrayPages(input io.Reader, output io.Writer) error {
+	values, err := decodeHostedControlPages(input)
+	if err != nil {
+		return err
+	}
+	merged, err := mergeHostedControlArrayPages(values)
+	if err != nil {
+		return err
+	}
+	return encodeHostedControlPage(output, merged)
+}
+
+func decodeHostedControlPages(input io.Reader) ([]any, error) {
+	decoder := json.NewDecoder(input)
+	decoder.UseNumber()
+	var values []any
+	for {
+		var value any
+		err := decoder.Decode(&value)
+		if errors.Is(err, io.EOF) {
+			return values, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decode hosted-control page %d: %w", len(values)+1, err)
+		}
+		values = append(values, value)
+	}
+}
+
+func parseHostedControlCollectionPages(values []any, field string) ([]hostedControlCollectionPage, error) {
+	if len(values) == 0 {
+		return nil, errors.New("hosted-control collection response must contain at least one page")
+	}
+	pages := make([]hostedControlCollectionPage, 0, len(values))
+	for index, value := range values {
+		page, err := parseHostedControlCollectionPage(value, field, index)
+		if err != nil {
+			return nil, err
+		}
+		pages = append(pages, page)
+	}
+	return pages, nil
+}
+
+func parseHostedControlCollectionPage(value any, field string, index int) (hostedControlCollectionPage, error) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return hostedControlCollectionPage{}, fmt.Errorf("hosted-control collection page %d must be an object", index+1)
+	}
+	totalCount, err := hostedControlPageTotal(object, index)
+	if err != nil {
+		return hostedControlCollectionPage{}, err
+	}
+	items, ok := object[field].([]any)
+	if !ok {
+		return hostedControlCollectionPage{}, fmt.Errorf("hosted-control collection page %d field %q must be an array", index+1, field)
+	}
+	return hostedControlCollectionPage{totalCount: totalCount, items: items}, nil
+}
+
+func hostedControlPageTotal(object map[string]any, index int) (int64, error) {
+	value, present := object["total_count"]
+	if !present {
+		return 0, fmt.Errorf("hosted-control collection page %d must declare total_count", index+1)
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("hosted-control collection page %d total_count must be a nonnegative integer", index+1)
+	}
+	totalCount, err := number.Int64()
+	if err != nil {
+		return 0, fmt.Errorf("hosted-control collection page %d total_count must be a nonnegative integer", index+1)
+	}
+	if totalCount < 0 {
+		return 0, fmt.Errorf("hosted-control collection page %d total_count must be a nonnegative integer", index+1)
+	}
+	return totalCount, nil
+}
+
+func mergeHostedControlCollectionPages(pages []hostedControlCollectionPage, field string) (map[string]any, error) {
+	items := hostedControlCollectionItems(pages)
+	if err := validateHostedControlCollectionTotals(pages, len(items)); err != nil {
+		return nil, err
+	}
+	totalCount := pages[0].totalCount
+	return map[string]any{"total_count": totalCount, field: items}, nil
+}
+
+func hostedControlCollectionItems(pages []hostedControlCollectionPage) []any {
+	items := make([]any, 0)
+	for _, page := range pages {
+		items = append(items, page.items...)
+	}
+	return items
+}
+
+func validateHostedControlCollectionTotals(pages []hostedControlCollectionPage, itemCount int) error {
+	expected := pages[0].totalCount
+	for index, page := range pages[1:] {
+		if page.totalCount != expected {
+			return fmt.Errorf("hosted-control collection page %d total_count is inconsistent", index+2)
+		}
+	}
+	if int64(itemCount) != expected {
+		return errors.New("hosted-control collection total_count must equal the combined array length")
+	}
+	return nil
+}
+
+func mergeHostedControlArrayPages(values []any) ([]any, error) {
+	if len(values) == 0 {
+		return nil, errors.New("hosted-control array response must contain at least one page")
+	}
+	merged := make([]any, 0)
+	for index, value := range values {
+		page, ok := value.([]any)
+		if !ok {
+			return nil, fmt.Errorf("hosted-control array page %d must be an array", index+1)
+		}
+		merged = append(merged, page...)
+	}
+	return merged, nil
+}
+
+func encodeHostedControlPage(output io.Writer, value any) error {
+	if err := json.NewEncoder(output).Encode(value); err != nil {
+		return fmt.Errorf("encode merged hosted-control pages: %w", err)
+	}
+	return nil
+}

--- a/internal/metadatautil/hostedcontrols_pages_test.go
+++ b/internal/metadatautil/hostedcontrols_pages_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type mergedSecretPage struct {
+	TotalCount int            `json:"total_count"`
+	Secrets    []mergedSecret `json:"secrets"`
+}
+
+type mergedSecret struct {
+	Name string `json:"name"`
+}
+
+func TestMergeHostedControlObjectPagesPreservesOrder(t *testing.T) {
+	input := strings.NewReader("{\"total_count\":2,\"secrets\":[{\"name\":\"A\"}]}\n{\"total_count\":2,\"secrets\":[{\"name\":\"B\"}]}\n")
+	var output bytes.Buffer
+	if err := MergeHostedControlObjectPages(input, &output, "secrets"); err != nil {
+		t.Fatal(err)
+	}
+	var merged mergedSecretPage
+	if err := json.Unmarshal(output.Bytes(), &merged); err != nil {
+		t.Fatal(err)
+	}
+	expected := mergedSecretPage{TotalCount: 2, Secrets: []mergedSecret{{Name: "A"}, {Name: "B"}}}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("merged page = %#v, want %#v", merged, expected)
+	}
+}
+
+func TestMergeHostedControlObjectPagesPreservesEmptyArray(t *testing.T) {
+	var output bytes.Buffer
+	if err := MergeHostedControlObjectPages(strings.NewReader(`{"total_count":0,"secrets":[]}`), &output, "secrets"); err != nil {
+		t.Fatal(err)
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(output.Bytes(), &merged); err != nil {
+		t.Fatal(err)
+	}
+	if string(merged["secrets"]) != "[]" {
+		t.Fatalf("merged secrets = %s, want []", merged["secrets"])
+	}
+}
+
+func TestMergeHostedControlObjectPagesRejectsMalformedInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		input string
+		want  string
+	}{
+		{"unsupported field", "unknown", `{}`, "unsupported hosted-control collection field"},
+		{"empty stream", "secrets", ``, "must contain at least one page"},
+		{"null page", "secrets", `null`, "must be an object"},
+		{"array page", "secrets", `[]`, "must be an object"},
+		{"missing total", "secrets", `{"secrets":[]}`, "must declare total_count"},
+		{"string total", "secrets", `{"total_count":"0","secrets":[]}`, "must be a nonnegative integer"},
+		{"fractional total", "secrets", `{"total_count":0.5,"secrets":[]}`, "must be a nonnegative integer"},
+		{"negative total", "secrets", `{"total_count":-1,"secrets":[]}`, "must be a nonnegative integer"},
+		{"missing field", "secrets", `{"total_count":0}`, `field "secrets" must be an array`},
+		{"wrong field type", "secrets", `{"total_count":0,"secrets":{}}`, `field "secrets" must be an array`},
+		{"inconsistent totals", "secrets", "{\"total_count\":1,\"secrets\":[]}\n{\"total_count\":0,\"secrets\":[]}", "total_count is inconsistent"},
+		{"count mismatch", "secrets", `{"total_count":1,"secrets":[]}`, "must equal the combined array length"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := MergeHostedControlObjectPages(strings.NewReader(test.input), &output, test.field)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("MergeHostedControlObjectPages() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestMergeHostedControlArrayPagesPreservesOrder(t *testing.T) {
+	var output bytes.Buffer
+	err := MergeHostedControlArrayPages(strings.NewReader("[{\"id\":1}]\n[{\"id\":2}]\n"), &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var merged []map[string]int
+	if err := json.Unmarshal(output.Bytes(), &merged); err != nil {
+		t.Fatal(err)
+	}
+	expected := []map[string]int{{"id": 1}, {"id": 2}}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("merged pages = %#v, want %#v", merged, expected)
+	}
+}
+
+func TestMergeHostedControlArrayPagesPreservesEmptyArray(t *testing.T) {
+	var output bytes.Buffer
+	if err := MergeHostedControlArrayPages(strings.NewReader(`[]`), &output); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(output.String()) != "[]" {
+		t.Fatalf("merged pages = %q, want []", output.String())
+	}
+}
+
+func TestMergeHostedControlArrayPagesRejectsMalformedInput(t *testing.T) {
+	for _, input := range []string{"", "null", `{}`} {
+		var output bytes.Buffer
+		if err := MergeHostedControlArrayPages(strings.NewReader(input), &output); err == nil {
+			t.Fatalf("MergeHostedControlArrayPages(%q) unexpectedly succeeded", input)
+		}
+	}
+}

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -983,23 +983,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := ValidateCanonicalWorkflowEnvironments(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
 		return err
 	}
-	for _, needle := range []string{
-		"gh api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
-		"repos/${REPO}/actions/permissions/selected-actions",
-		"repos/${REPO}/actions/permissions/workflow",
-		"repos/${REPO}/immutable-releases",
-		"jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}'",
-		"gh api --paginate \"repos/${REPO}/environments?per_page=100\"",
-		`list-hosted-control-environments "${POLICY_PATH}"`,
-		"safe_environment_name=\"${encoded_environment_name}\"",
-		"environment-${safe_environment_name}.json",
-		"repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100",
-		"repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100",
-		`verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`,
-	} {
-		if !strings.Contains(hostedControlsScript, needle) {
-			return fmt.Errorf("scripts/verify-github-hosted-controls.sh must contain %q", needle)
-		}
+	if err := validateCanonicalHostedControlsScript(hostedControlsScript); err != nil {
+		return err
 	}
 	if err := requireNoRegistryBootstrapMCP(codexRequirementsText, cfg.CodexRequirementsPath); err != nil {
 		return err

--- a/internal/metadatautil/pinnedinputs_shell.go
+++ b/internal/metadatautil/pinnedinputs_shell.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const (
+	canonicalHostedAPIInvocation = `gh api --hostname github.com -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" "$@"`
+	canonicalHostedShellSHA256   = "6c4a55e4bc53a854fa4100f2683d787a949898c7f83d79a5063da4cd989a006f"
+	canonicalHostedToolFunction  = `require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required tool: $1" >&2
+    exit 1
+  }
+}`
+	canonicalHostedAPIFunction = `github_api() {
+  gh api --hostname github.com -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" "$@"
+}`
+	canonicalHostedCleanupFunction = `cleanup() {
+  rm -rf "${TMP_DIR}"
+  if [[ -n "${CITOOLS_BIN}" && -e "${CITOOLS_BIN}" ]]; then
+    rm -f "${CITOOLS_BIN}"
+  fi
+}`
+)
+
+var (
+	errHostedShellRouting   = errors.New("scripts/verify-github-hosted-controls.sh must use the exact reviewed command graph and versioned github_api wrapper")
+	allowedHostedShellCalls = map[string]int{
+		`set -euo pipefail`: 1,
+		`ROOT_DIR="$(CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"`: 1,
+		`CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.."`:                         1,
+		`pwd -P`: 1,
+		`source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"`:    1,
+		`workcell_require_modern_privileged_bash "$@"`:               1,
+		`workcell_require_canonical_build_environment`:               1,
+		`echo "Hosted controls reject ambient GH_HOST and GH_REPO."`: 1,
+		`exit 2`: 1,
+		`POLICY_PATH="${WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH:-${ROOT_DIR}/policy/github-hosted-controls.toml}"`: 1,
+		`source "${ROOT_DIR}/scripts/lib/go-run-env.sh"`:                                                               1,
+		`require_tool gh`: 1,
+		`require_tool jq`: 1,
+		`REPO="${1:-}"`:   1,
+		`REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"`:      1,
+		`gh repo view --json nameWithOwner --jq .nameWithOwner`:                1,
+		`TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-gh-controls.XXXXXX")"`: 1,
+		`mktemp -d "${TMPDIR:-/tmp}/workcell-gh-controls.XXXXXX"`:              1,
+		`CITOOLS_BIN=""`:    1,
+		`trap cleanup EXIT`: 1,
+		`CITOOLS_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-citools.XXXXXX")"`:           1,
+		`mktemp "${TMPDIR:-/tmp}/workcell-citools.XXXXXX"`:                            1,
+		`build_go_tool_in_repo "${ROOT_DIR}" "${CITOOLS_BIN}" ./cmd/workcell-citools`: 1,
+		`github_api "repos/${REPO}"`:                                                  1,
+		`github_api "repos/${REPO}/actions/permissions"`:                              1,
+		`github_api "repos/${REPO}/actions/permissions/selected-actions"`:             1,
+		`:`: 3,
+		`status="$(jq -r '.status // empty' "${TMP_DIR}/actions-selected-actions.json" 2>/dev/null || true)"`: 1,
+		`jq -r '.status // empty' "${TMP_DIR}/actions-selected-actions.json"`:                                 1,
+		`true`: 1,
+		`cat "${TMP_DIR}/actions-selected-actions.err"`:  1,
+		`cat "${TMP_DIR}/actions-selected-actions.json"`: 1,
+		`exit 1`: 3,
+		`github_api "repos/${REPO}/actions/permissions/workflow"`:                                                                1,
+		`github_api "repos/${REPO}/immutable-releases"`:                                                                          1,
+		`github_api --paginate "repos/${REPO}/actions/variables?per_page=100"`:                                                   1,
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages variables`:                                                           2,
+		`github_api "repos/${REPO}/collaborators?affiliation=direct&per_page=100"`:                                               1,
+		`github_api --paginate "repos/${REPO}/rulesets?per_page=100"`:                                                            1,
+		`"${CITOOLS_BIN}" merge-hosted-control-array-pages`:                                                                      1,
+		`"${CITOOLS_BIN}" fetch-rulesets "${TMP_DIR}" "${REPO}"`:                                                                 1,
+		`github_api --paginate "repos/${REPO}/environments?per_page=100"`:                                                        1,
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages environments`:                                                        1,
+		`github_api "repos/${REPO}/environments/release"`:                                                                        1,
+		`echo "Missing required release environment on ${REPO}"`:                                                                 1,
+		`IFS= read -r environment_name`:                                                                                          1,
+		`continue`:                                                                                                               1,
+		`encoded_environment_name="$(jq -rn --arg value "${environment_name}" '$value | @uri')"`:                                 1,
+		`jq -rn --arg value "${environment_name}" '$value | @uri'`:                                                               1,
+		`safe_environment_name="${encoded_environment_name}"`:                                                                    1,
+		`github_api "repos/${REPO}/environments/${encoded_environment_name}"`:                                                    1,
+		`echo "Missing required ${environment_name} environment on ${REPO}"`:                                                     1,
+		`github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/deployment-branch-policies?per_page=100"`: 1,
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages branch_policies`:                                                     1,
+		`github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100"`:                  1,
+		`github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100"`:                    1,
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages secrets`:                                                             1,
+		`"${CITOOLS_BIN}" list-hosted-control-environments "${POLICY_PATH}"`:                                                     1,
+		`"${CITOOLS_BIN}" verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`:                                 1,
+	}
+)
+
+type hostedShellRouteAudit struct {
+	script           string
+	toolFunctions    int
+	apiFunctions     int
+	cleanupFunctions int
+	callCounts       map[string]int
+	err              error
+}
+
+func validateCanonicalHostedControlsScript(script string) error {
+	if !strings.HasPrefix(script, "#!/bin/bash -p\n") {
+		return errors.New("scripts/verify-github-hosted-controls.sh must use the exact privileged Bash shebang")
+	}
+	for _, needle := range []string{
+		`readonly GITHUB_API_VERSION="2026-03-10"`,
+		"  " + canonicalHostedAPIInvocation,
+		"github_api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
+		"repos/${REPO}/actions/permissions/selected-actions",
+		"repos/${REPO}/actions/permissions/workflow",
+		"repos/${REPO}/immutable-releases",
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages variables >"${TMP_DIR}/actions-variables.json"`,
+		"github_api --paginate \"repos/${REPO}/rulesets?per_page=100\"",
+		`"${CITOOLS_BIN}" merge-hosted-control-array-pages >"${TMP_DIR}/rulesets-summary.json"`,
+		"github_api --paginate \"repos/${REPO}/environments?per_page=100\"",
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages environments >"${TMP_DIR}/environments.json"`,
+		`list-hosted-control-environments "${POLICY_PATH}"`,
+		"safe_environment_name=\"${encoded_environment_name}\"",
+		"environment-${safe_environment_name}.json",
+		"repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100",
+		"repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100",
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages branch_policies >"${TMP_DIR}/environment-${safe_environment_name}-deployment-branch-policies.json"`,
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages variables >"${TMP_DIR}/environment-${safe_environment_name}-variables.json"`,
+		`"${CITOOLS_BIN}" merge-hosted-control-object-pages secrets >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"`,
+		`verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`,
+	} {
+		if !strings.Contains(script, needle) {
+			return fmt.Errorf("scripts/verify-github-hosted-controls.sh must contain %q", needle)
+		}
+	}
+	return validateHostedControlsAPIRouting(script)
+}
+
+func validateHostedControlsAPIRouting(script string) error {
+	file, err := syntax.NewParser(syntax.Variant(syntax.LangBash)).Parse(strings.NewReader(script), "scripts/verify-github-hosted-controls.sh")
+	if err != nil {
+		return fmt.Errorf("parse scripts/verify-github-hosted-controls.sh: %w", err)
+	}
+	audit := hostedShellRouteAudit{script: script, callCounts: make(map[string]int)}
+	syntax.Walk(file, audit.visit)
+	if err := audit.result(); err != nil {
+		return err
+	}
+	return requireCanonicalHostedShell(file)
+}
+
+func requireCanonicalHostedShell(file *syntax.File) error {
+	var canonical bytes.Buffer
+	if err := syntax.NewPrinter().Print(&canonical, file); err != nil {
+		return fmt.Errorf("print scripts/verify-github-hosted-controls.sh: %w", err)
+	}
+	digest := sha256.Sum256(canonical.Bytes())
+	if fmt.Sprintf("%x", digest) != canonicalHostedShellSHA256 {
+		return fmt.Errorf("%w: unexpected shell structure", errHostedShellRouting)
+	}
+	return nil
+}
+
+func (audit *hostedShellRouteAudit) visit(node syntax.Node) bool {
+	if audit.err != nil {
+		return false
+	}
+	switch node := node.(type) {
+	case *syntax.CallExpr:
+		audit.err = audit.validateCall(node)
+	case *syntax.FuncDecl:
+		audit.err = audit.validateFunction(node)
+		return false
+	}
+	return audit.err == nil
+}
+
+func (audit *hostedShellRouteAudit) validateCall(call *syntax.CallExpr) error {
+	text := audit.nodeText(call)
+	if _, ok := allowedHostedShellCalls[text]; !ok {
+		return fmt.Errorf("%w: unexpected command %q", errHostedShellRouting, text)
+	}
+	audit.callCounts[text]++
+	return nil
+}
+
+func (audit *hostedShellRouteAudit) validateFunction(function *syntax.FuncDecl) error {
+	switch function.Name.Value {
+	case "require_tool":
+		audit.toolFunctions++
+		return requireHostedShellFunction(audit.nodeText(function), canonicalHostedToolFunction)
+	case "github_api":
+		audit.apiFunctions++
+		return requireHostedShellFunction(audit.nodeText(function), canonicalHostedAPIFunction)
+	case "cleanup":
+		audit.cleanupFunctions++
+		return requireHostedShellFunction(audit.nodeText(function), canonicalHostedCleanupFunction)
+	default:
+		return errHostedShellRouting
+	}
+}
+
+func requireHostedShellFunction(actual, expected string) error {
+	if actual != expected {
+		return errHostedShellRouting
+	}
+	return nil
+}
+
+func (audit hostedShellRouteAudit) result() error {
+	if audit.err != nil {
+		return audit.err
+	}
+	if !audit.hasCanonicalCounts() {
+		return errHostedShellRouting
+	}
+	return audit.requireCanonicalCallCounts()
+}
+
+func (audit hostedShellRouteAudit) hasCanonicalCounts() bool {
+	return allHostedShellCountsOne(
+		audit.toolFunctions,
+		audit.apiFunctions,
+		audit.cleanupFunctions,
+	)
+}
+
+func (audit hostedShellRouteAudit) requireCanonicalCallCounts() error {
+	for call, expected := range allowedHostedShellCalls {
+		actual := audit.callCounts[call]
+		if actual != expected {
+			return fmt.Errorf("%w: command %q appears %d times; expected %d", errHostedShellRouting, call, actual, expected)
+		}
+	}
+	return nil
+}
+
+func allHostedShellCountsOne(counts ...int) bool {
+	for _, count := range counts {
+		if count != 1 {
+			return false
+		}
+	}
+	return true
+}
+
+func (audit *hostedShellRouteAudit) nodeText(node syntax.Node) string {
+	return audit.script[int(node.Pos().Offset()):int(node.End().Offset())]
+}

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -168,6 +168,143 @@ func requirePinnedInputsErrorContains(tb testing.TB, cfg metadatautil.PinnedInpu
 	}
 }
 
+func TestCheckPinnedInputsRejectsHostedControlAPIVersionDrift(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+		return strings.Replace(content, `readonly GITHUB_API_VERSION="2026-03-10"`, `readonly GITHUB_API_VERSION="2022-11-28"`, 1)
+	})
+	requirePinnedInputsErrorContains(t, cfg, `readonly GITHUB_API_VERSION=\"2026-03-10\"`)
+}
+
+func TestCheckPinnedInputsRejectsHostedControlShebangDrift(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+		return strings.Replace(content, "#!/bin/bash -p", "#!/bin/bash", 1)
+	})
+	requirePinnedInputsErrorContains(t, cfg, "must use the exact privileged Bash shebang")
+}
+
+func TestCheckPinnedInputsRejectsDirectHostedControlAPICall(t *testing.T) {
+	tests := []struct {
+		name string
+		call string
+	}{
+		{"literal", `gh api repos/example/direct`},
+		{"continuation", "gh \\\n+  api repos/example/direct"},
+		{"quoted", `g""h a""pi repos/example/direct`},
+		{"absolute path", `/usr/bin/gh api repos/example/direct`},
+		{"dynamic command", `${WORKCELL_TEST_GH} api repos/example/direct`},
+		{"command wrapper", `command ${WORKCELL_TEST_GH} api repos/example/direct`},
+		{"curl API", `curl -fsS https://api.github.com/repos/example/direct`},
+		{"timeout absolute path", `timeout 1 /usr/bin/gh api repos/example/direct`},
+		{"unreviewed helper", `./scripts/unreviewed-hosted-helper`},
+		{"host override", `GH_HOST=attacker.example`},
+		{"header override", `github_api -H "X-GitHub-Api-Version: 2022-11-28" repos/example/direct`},
+		{"unapproved source", `source "${WORKCELL_TEST_SOURCE}"`},
+		{"function unset", `unset -f github_api`},
+		{"debug trap", `trap 'gh api repos/example/direct' DEBUG`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+				return strings.Replace(content, "require_tool jq", "require_tool jq\n"+test.call, 1)
+			})
+			requirePinnedInputsErrorContains(t, cfg, "must use the exact reviewed command graph and versioned github_api wrapper")
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsHostedControlFunctionShadowing(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition string
+	}{
+		{"API wrapper", `github_api() { printf '{}'; }`},
+		{"cleanup", `cleanup() { :; }`},
+		{"jq", `jq() { printf '{}'; }`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+				return content + "\n" + test.definition + "\n"
+			})
+			requirePinnedInputsErrorContains(t, cfg, "must use the exact reviewed command graph and versioned github_api wrapper")
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsHostedControlCallCountDrift(t *testing.T) {
+	tests := []struct {
+		name    string
+		rewrite func(string) string
+	}{
+		{"missing", func(content string) string { return strings.Replace(content, "require_tool jq\n", "", 1) }},
+		{"duplicate", func(content string) string {
+			return strings.Replace(content, "require_tool jq\n", "require_tool jq\nrequire_tool jq\n", 1)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", test.rewrite)
+			requirePinnedInputsErrorContains(t, cfg, "must use the exact reviewed command graph and versioned github_api wrapper")
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsHostedControlStructureDrift(t *testing.T) {
+	const verifyCall = `"${CITOOLS_BIN}" verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`
+	tests := []struct {
+		name    string
+		rewrite func(string) string
+	}{
+		{"conditional verifier", func(content string) string {
+			return strings.Replace(content, verifyCall, "if [[ -n \"\" ]]; then\n  "+verifyCall+"\nfi", 1)
+		}},
+		{"redirected repository", func(content string) string {
+			return strings.Replace(content, `>"${TMP_DIR}/repo.json"`, `>"${TMP_DIR}/ignored.json"`, 1)
+		}},
+		{"reordered repository", func(content string) string {
+			const repositoryCall = `github_api "repos/${REPO}" >"${TMP_DIR}/repo.json"`
+			content = strings.Replace(content, repositoryCall+"\n", "", 1)
+			const marker = `github_api "repos/${REPO}/immutable-releases" >"${TMP_DIR}/immutable-releases.json"`
+			return strings.Replace(content, marker, marker+"\n"+repositoryCall, 1)
+		}},
+		{"changed error condition", func(content string) string {
+			return strings.Replace(content, `[[ "${status}" != "409" ]]`, `[[ "${status}" != "404" ]]`, 1)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", test.rewrite)
+			requirePinnedInputsErrorContains(t, cfg, "unexpected shell structure")
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsUnpaginatedHostedRulesets(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+		return strings.Replace(content, `github_api --paginate "repos/${REPO}/rulesets?per_page=100"`, `github_api "repos/${REPO}/rulesets"`, 1)
+	})
+	requirePinnedInputsErrorContains(t, cfg, `github_api --paginate \"repos/${REPO}/rulesets?per_page=100\"`)
+}
+
+func TestCheckPinnedInputsRejectsFailOpenHostedRulesetAggregation(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+		return strings.Replace(content, `"${CITOOLS_BIN}" merge-hosted-control-array-pages`, `jq -s 'add'`, 1)
+	})
+	requirePinnedInputsErrorContains(t, cfg, "merge-hosted-control-array-pages")
+}
+
+func TestCheckPinnedInputsRejectsFailOpenHostedEmptyCollectionAggregation(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
+		return strings.Replace(
+			content,
+			`"${CITOOLS_BIN}" merge-hosted-control-object-pages secrets >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"`,
+			`jq -s '{total_count: 0, secrets: (map(.secrets // []) | add)}' >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"`,
+			1,
+		)
+	})
+	requirePinnedInputsErrorContains(t, cfg, "merge-hosted-control-object-pages secrets")
+}
+
 func TestCheckPinnedInputsRejectsCommentedDebianBootstrapGuard(t *testing.T) {
 	cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(content string) string {
 		return strings.Replace(content, `  && [[ "${#debian_bootstrap_pins[@]}" -eq 7 ]]`, `  # && [[ "${#debian_bootstrap_pins[@]}" -eq 7 ]]`, 1)

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -6,6 +6,10 @@ ROOT_DIR="$(CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"
 source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"
 workcell_require_modern_privileged_bash "$@"
 workcell_require_canonical_build_environment
+if [[ -n "${GH_HOST:-}" || -n "${GH_REPO:-}" ]]; then
+  echo "Hosted controls reject ambient GH_HOST and GH_REPO." >&2
+  exit 2
+fi
 POLICY_PATH="${WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH:-${ROOT_DIR}/policy/github-hosted-controls.toml}"
 # shellcheck source=scripts/lib/go-run-env.sh
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
@@ -15,6 +19,11 @@ require_tool() {
     echo "Missing required tool: $1" >&2
     exit 1
   }
+}
+
+readonly GITHUB_API_VERSION="2026-03-10"
+github_api() {
+  gh api --hostname github.com -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" "$@"
 }
 
 require_tool gh
@@ -38,9 +47,9 @@ trap cleanup EXIT
 CITOOLS_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-citools.XXXXXX")"
 build_go_tool_in_repo "${ROOT_DIR}" "${CITOOLS_BIN}" ./cmd/workcell-citools
 
-gh api "repos/${REPO}" >"${TMP_DIR}/repo.json"
-gh api "repos/${REPO}/actions/permissions" >"${TMP_DIR}/actions-permissions.json"
-if gh api "repos/${REPO}/actions/permissions/selected-actions" >"${TMP_DIR}/actions-selected-actions.json" 2>"${TMP_DIR}/actions-selected-actions.err"; then
+github_api "repos/${REPO}" >"${TMP_DIR}/repo.json"
+github_api "repos/${REPO}/actions/permissions" >"${TMP_DIR}/actions-permissions.json"
+if github_api "repos/${REPO}/actions/permissions/selected-actions" >"${TMP_DIR}/actions-selected-actions.json" 2>"${TMP_DIR}/actions-selected-actions.err"; then
   :
 else
   status="$(jq -r '.status // empty' "${TMP_DIR}/actions-selected-actions.json" 2>/dev/null || true)"
@@ -50,16 +59,17 @@ else
     exit 1
   fi
 fi
-gh api "repos/${REPO}/actions/permissions/workflow" >"${TMP_DIR}/actions-workflow-permissions.json"
-gh api "repos/${REPO}/immutable-releases" >"${TMP_DIR}/immutable-releases.json"
-gh api --paginate "repos/${REPO}/actions/variables?per_page=100" |
-  jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/actions-variables.json"
-gh api "repos/${REPO}/collaborators?affiliation=direct&per_page=100" >"${TMP_DIR}/collaborators-direct.json"
-gh api "repos/${REPO}/rulesets" >"${TMP_DIR}/rulesets-summary.json"
+github_api "repos/${REPO}/actions/permissions/workflow" >"${TMP_DIR}/actions-workflow-permissions.json"
+github_api "repos/${REPO}/immutable-releases" >"${TMP_DIR}/immutable-releases.json"
+github_api --paginate "repos/${REPO}/actions/variables?per_page=100" |
+  "${CITOOLS_BIN}" merge-hosted-control-object-pages variables >"${TMP_DIR}/actions-variables.json"
+github_api "repos/${REPO}/collaborators?affiliation=direct&per_page=100" >"${TMP_DIR}/collaborators-direct.json"
+github_api --paginate "repos/${REPO}/rulesets?per_page=100" |
+  "${CITOOLS_BIN}" merge-hosted-control-array-pages >"${TMP_DIR}/rulesets-summary.json"
 "${CITOOLS_BIN}" fetch-rulesets "${TMP_DIR}" "${REPO}"
-gh api --paginate "repos/${REPO}/environments?per_page=100" |
-  jq -s '{total_count: (map(.total_count // 0) | max // 0), environments: (map(.environments // []) | add)}' >"${TMP_DIR}/environments.json"
-if gh api "repos/${REPO}/environments/release" >"${TMP_DIR}/environment-release.json" 2>/dev/null; then
+github_api --paginate "repos/${REPO}/environments?per_page=100" |
+  "${CITOOLS_BIN}" merge-hosted-control-object-pages environments >"${TMP_DIR}/environments.json"
+if github_api "repos/${REPO}/environments/release" >"${TMP_DIR}/environment-release.json" 2>/dev/null; then
   :
 else
   echo "Missing required release environment on ${REPO}" >&2
@@ -69,18 +79,18 @@ while IFS= read -r environment_name; do
   [[ -n "${environment_name}" ]] || continue
   encoded_environment_name="$(jq -rn --arg value "${environment_name}" '$value | @uri')"
   safe_environment_name="${encoded_environment_name}"
-  if gh api "repos/${REPO}/environments/${encoded_environment_name}" >"${TMP_DIR}/environment-${safe_environment_name}.json" 2>/dev/null; then
+  if github_api "repos/${REPO}/environments/${encoded_environment_name}" >"${TMP_DIR}/environment-${safe_environment_name}.json" 2>/dev/null; then
     :
   else
     echo "Missing required ${environment_name} environment on ${REPO}" >&2
     exit 1
   fi
-  gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/deployment-branch-policies?per_page=100" |
-    jq -s '{total_count: (map(.total_count // 0) | max // 0), branch_policies: (map(.branch_policies // []) | add)}' >"${TMP_DIR}/environment-${safe_environment_name}-deployment-branch-policies.json"
-  gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100" |
-    jq -s '{total_count: (map(.total_count // 0) | max // 0), variables: (map(.variables // []) | add)}' >"${TMP_DIR}/environment-${safe_environment_name}-variables.json"
-  gh api --paginate "repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100" |
-    jq -s '{total_count: (map(.total_count // 0) | max // 0), secrets: (map(.secrets // []) | add)}' >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"
+  github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/deployment-branch-policies?per_page=100" |
+    "${CITOOLS_BIN}" merge-hosted-control-object-pages branch_policies >"${TMP_DIR}/environment-${safe_environment_name}-deployment-branch-policies.json"
+  github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100" |
+    "${CITOOLS_BIN}" merge-hosted-control-object-pages variables >"${TMP_DIR}/environment-${safe_environment_name}-variables.json"
+  github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100" |
+    "${CITOOLS_BIN}" merge-hosted-control-object-pages secrets >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"
 done < <("${CITOOLS_BIN}" list-hosted-control-environments "${POLICY_PATH}")
 
 "${CITOOLS_BIN}" verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"


### PR DESCRIPTION
## Summary

- The audit merges all pages for variables, rulesets, environments, branch policies, and environment secrets.
- It pins GitHub API calls to `github.com` and API version `2026-03-10`.
- It rejects ambient `GH_HOST` and `GH_REPO` values.

## Security invariants

- The validator accepts only the reviewed privileged Bash shebang and shell command graph.
- The page mergers reject empty streams, invalid page types, inconsistent totals, and count mismatches.
- Ruleset requests reject malformed, nonpositive, fractional, and out-of-range identifiers before each detail request.
- The mergers preserve item order and empty arrays.

## Validation

- The full Go test suite passed.
- Go vet passed.
- Focused race tests passed.
- Workflow, pinned-input, module, and mutation checks passed.
- The live read-only hosted-control audit passed.
- PR parity passed.

## Cyclomatic complexity

- gocyclo v0.6.0 reports `CheckPinnedInputs` at 231 before and 230 after this change.
- It reports `FetchRulesets` at 7 before and 4 after this change.
- It reports a score of 5 or less for every new function.