### PR TITLE
Simplify the pinned-input load phase

### DIFF
--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -4,14 +4,11 @@
 package metadatautil
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/omkhar/workcell/internal/tomlsubset"
 )
 
 var (
@@ -61,15 +58,44 @@ type markdownlintPackageLockEntry struct {
 // pull_request_target and YAML helpers — lives in pinnedinputs_workflows.go.
 
 func CheckPinnedInputs(cfg PinnedInputsConfig) error {
-	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(cfg.RuntimeDockerfilePath), "..", ".."))
-	allowedActions, err := loadAllowedActions(filepath.Join(repoRoot, "policy", "allowed-actions.toml"))
-	if err != nil {
+	check := newPinnedInputsCheck(cfg)
+	if err := check.load(); err != nil {
 		return err
 	}
-	pins, err := loadToolPins(filepath.Join(repoRoot, "policy", "tool-pins.toml"))
-	if err != nil {
-		return err
-	}
+
+	repoRoot := check.repoRoot
+	allowedActions := check.allowedActions
+	pins := check.pins
+	cargoManifestPath := check.paths.cargoManifest
+	installDevToolsScriptPath := check.paths.installDevTools
+	validateRepoScriptPath := check.paths.validateRepo
+	markdownlintPackageJSONPath := check.paths.markdownlintJSON
+	markdownlintPackageLockPath := check.paths.markdownlintLock
+	rustToolchainPath := check.paths.rustToolchain
+	debianBootstrapManifestPath := check.paths.debianBootstrap
+	runtimeDockerfile := check.runtimeDockerfile
+	validatorDockerfile := check.validatorDockerfile
+	debianBootstrapManifest := check.debianBootstrapManifest
+	providersPackageJSON := check.providersPackageJSON
+	providersPackageLock := check.providersPackageLock
+	markdownlintPackageJSON := check.markdownlintPackageJSON
+	markdownlintPackageLock := check.markdownlintPackageLock
+	installDevToolsScript := check.installDevToolsScript
+	validateRepoScript := check.validateRepoScript
+	ciWorkflow := check.ciWorkflow
+	releaseWorkflow := check.releaseWorkflow
+	pinHygieneWorkflow := check.pinHygieneWorkflow
+	upstreamRefreshWorkflow := check.upstreamRefreshWorkflow
+	validatorImageScript := check.validatorImageScript
+	codeowners := check.codeowners
+	hostedControlsPolicy := check.hostedControlsPolicy
+	hostedControlsScript := check.hostedControlsScript
+	codexRequirementsText := check.codexRequirementsText
+	codexMCPConfigText := check.codexMCPConfigText
+	goModText := check.goModText
+	cargoManifestText := check.cargoManifestText
+	rustToolchainText := check.rustToolchainText
+
 	// requirePolicyPin binds a workflow's canonical tool pin to policy/tool-pins.toml
 	// so bumping a tool is a reviewed change to that one file. The existing
 	// cross-file asserts then keep every other workflow copy in lockstep.
@@ -79,125 +105,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		}
 		return nil
 	}
-	goModPath := filepath.Join(repoRoot, "go.mod")
-	cargoManifestPath := filepath.Join(repoRoot, "runtime", "container", "rust", "Cargo.toml")
-	installDevToolsScriptPath := filepath.Join(repoRoot, "scripts", "install-dev-tools.sh")
-	validateRepoScriptPath := filepath.Join(repoRoot, "scripts", "validate-repo.sh")
-	markdownlintPackageJSONPath := filepath.Join(repoRoot, "tools", "markdownlint", "package.json")
-	markdownlintPackageLockPath := filepath.Join(repoRoot, "tools", "markdownlint", "package-lock.json")
-	rustToolchainPath := filepath.Join(repoRoot, "runtime", "container", "rust", "rust-toolchain.toml")
-	debianBootstrapManifestPath := filepath.Join(repoRoot, filepath.FromSlash(DebianBootstrapManifestRelPath))
-
-	runtimeDockerfile, err := readText(cfg.RuntimeDockerfilePath)
-	if err != nil {
-		return err
-	}
-	validatorDockerfile, err := readText(cfg.ValidatorDockerfilePath)
-	if err != nil {
-		return err
-	}
-	debianBootstrapManifest, err := ReadDebianBootstrapManifest(debianBootstrapManifestPath)
-	if err != nil {
-		return err
-	}
-	providersPackageJSONText, err := readText(cfg.ProvidersPackageJSONPath)
-	if err != nil {
-		return err
-	}
-	providersPackageLockText, err := readText(cfg.ProvidersPackageLockPath)
-	if err != nil {
-		return err
-	}
-	markdownlintPackageJSONText, err := readText(markdownlintPackageJSONPath)
-	if err != nil {
-		return err
-	}
-	markdownlintPackageLockText, err := readText(markdownlintPackageLockPath)
-	if err != nil {
-		return err
-	}
-	installDevToolsScript, err := readText(installDevToolsScriptPath)
-	if err != nil {
-		return err
-	}
-	validateRepoScript, err := readText(validateRepoScriptPath)
-	if err != nil {
-		return err
-	}
-	ciWorkflow, err := readText(cfg.CIWorkflowPath)
-	if err != nil {
-		return err
-	}
-	releaseWorkflow, err := readText(cfg.ReleaseWorkflowPath)
-	if err != nil {
-		return err
-	}
-	pinHygieneWorkflow, err := readText(cfg.PinHygieneWorkflowPath)
-	if err != nil {
-		return err
-	}
-	upstreamRefreshWorkflow, err := readText(filepath.Join(cfg.WorkflowsDir, "upstream-refresh.yml"))
-	if err != nil {
-		return err
-	}
-	validatorImageScript, err := readText(filepath.Join(repoRoot, "scripts", "ci", "build-validator-image.sh"))
-	if err != nil {
-		return err
-	}
-	codeowners, err := readText(cfg.CodeownersPath)
-	if err != nil {
-		return err
-	}
-	hostedControlsPolicyText, err := readText(cfg.HostedControlsPolicyPath)
-	if err != nil {
-		return err
-	}
-	hostedControlsScript, err := readText(cfg.HostedControlsScriptPath)
-	if err != nil {
-		return err
-	}
-	codexRequirementsText, err := readText(cfg.CodexRequirementsPath)
-	if err != nil {
-		return err
-	}
-	codexMCPConfigText, err := readText(cfg.CodexMCPConfigPath)
-	if err != nil {
-		return err
-	}
-	goModText, err := readText(goModPath)
-	if err != nil {
-		return err
-	}
-	cargoManifestText, err := readText(cargoManifestPath)
-	if err != nil {
-		return err
-	}
-	rustToolchainText, err := readText(rustToolchainPath)
-	if err != nil {
-		return err
-	}
-
-	var providersPackageJSON map[string]any
-	if err := json.Unmarshal([]byte(providersPackageJSONText), &providersPackageJSON); err != nil {
-		return err
-	}
-	var providersPackageLock map[string]any
-	if err := json.Unmarshal([]byte(providersPackageLockText), &providersPackageLock); err != nil {
-		return err
-	}
-	var markdownlintPackageJSON markdownlintPackageJSON
-	if err := json.Unmarshal([]byte(markdownlintPackageJSONText), &markdownlintPackageJSON); err != nil {
-		return err
-	}
-	var markdownlintPackageLock markdownlintPackageLock
-	if err := json.Unmarshal([]byte(markdownlintPackageLockText), &markdownlintPackageLock); err != nil {
-		return err
-	}
-	hostedControlsPolicy, err := tomlsubset.Parse(hostedControlsPolicyText, cfg.HostedControlsPolicyPath)
-	if err != nil {
-		return err
-	}
-
 	requireYAMLKey := func(text, name, path string) (string, error) {
 		match := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `:\s*(.+)$`).FindStringSubmatch(text)
 		if match == nil {

--- a/internal/metadatautil/pinnedinputs_check.go
+++ b/internal/metadatautil/pinnedinputs_check.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"encoding/json"
+	"path/filepath"
+
+	"github.com/omkhar/workcell/internal/tomlsubset"
+)
+
+type pinnedInputsCheck struct {
+	cfg      PinnedInputsConfig
+	repoRoot string
+	paths    pinnedInputPaths
+
+	allowedActions map[string]bool
+	pins           toolPins
+
+	runtimeDockerfile           string
+	validatorDockerfile         string
+	providersPackageJSONText    string
+	providersPackageLockText    string
+	markdownlintPackageJSONText string
+	markdownlintPackageLockText string
+	installDevToolsScript       string
+	validateRepoScript          string
+	ciWorkflow                  string
+	releaseWorkflow             string
+	pinHygieneWorkflow          string
+	upstreamRefreshWorkflow     string
+	validatorImageScript        string
+	codeowners                  string
+	hostedControlsPolicyText    string
+	hostedControlsScript        string
+	codexRequirementsText       string
+	codexMCPConfigText          string
+	goModText                   string
+	cargoManifestText           string
+	rustToolchainText           string
+
+	debianBootstrapManifest DebianBootstrapManifest
+	providersPackageJSON    map[string]any
+	providersPackageLock    map[string]any
+	markdownlintPackageJSON markdownlintPackageJSON
+	markdownlintPackageLock markdownlintPackageLock
+	hostedControlsPolicy    map[string]any
+}
+
+type pinnedInputPaths struct {
+	goMod                string
+	cargoManifest        string
+	installDevTools      string
+	validateRepo         string
+	markdownlintJSON     string
+	markdownlintLock     string
+	rustToolchain        string
+	debianBootstrap      string
+	upstreamRefresh      string
+	validatorImageScript string
+}
+
+type pinnedTextInput struct {
+	path   string
+	target *string
+}
+
+func newPinnedInputsCheck(cfg PinnedInputsConfig) *pinnedInputsCheck {
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(cfg.RuntimeDockerfilePath), "..", ".."))
+	return &pinnedInputsCheck{
+		cfg:      cfg,
+		repoRoot: repoRoot,
+		paths: pinnedInputPaths{
+			goMod:                filepath.Join(repoRoot, "go.mod"),
+			cargoManifest:        filepath.Join(repoRoot, "runtime", "container", "rust", "Cargo.toml"),
+			installDevTools:      filepath.Join(repoRoot, "scripts", "install-dev-tools.sh"),
+			validateRepo:         filepath.Join(repoRoot, "scripts", "validate-repo.sh"),
+			markdownlintJSON:     filepath.Join(repoRoot, "tools", "markdownlint", "package.json"),
+			markdownlintLock:     filepath.Join(repoRoot, "tools", "markdownlint", "package-lock.json"),
+			rustToolchain:        filepath.Join(repoRoot, "runtime", "container", "rust", "rust-toolchain.toml"),
+			debianBootstrap:      filepath.Join(repoRoot, filepath.FromSlash(DebianBootstrapManifestRelPath)),
+			upstreamRefresh:      filepath.Join(cfg.WorkflowsDir, "upstream-refresh.yml"),
+			validatorImageScript: filepath.Join(repoRoot, "scripts", "ci", "build-validator-image.sh"),
+		},
+	}
+}
+
+func (check *pinnedInputsCheck) load() error {
+	return firstPinnedInputError(
+		check.loadAllowedActions,
+		check.loadToolPins,
+		check.loadDockerfiles,
+		check.loadDebianBootstrapManifest,
+		check.loadInitialTextInputs,
+		check.parseInitialTextInputs,
+	)
+}
+
+func (check *pinnedInputsCheck) loadAllowedActions() error {
+	path := filepath.Join(check.repoRoot, "policy", "allowed-actions.toml")
+	var err error
+	check.allowedActions, err = loadAllowedActions(path)
+	return err
+}
+
+func (check *pinnedInputsCheck) loadToolPins() error {
+	path := filepath.Join(check.repoRoot, "policy", "tool-pins.toml")
+	var err error
+	check.pins, err = loadToolPins(path)
+	return err
+}
+
+func (check *pinnedInputsCheck) loadDockerfiles() error {
+	return loadPinnedTextInputs([]pinnedTextInput{
+		{check.cfg.RuntimeDockerfilePath, &check.runtimeDockerfile},
+		{check.cfg.ValidatorDockerfilePath, &check.validatorDockerfile},
+	})
+}
+
+func (check *pinnedInputsCheck) loadDebianBootstrapManifest() error {
+	var err error
+	check.debianBootstrapManifest, err = ReadDebianBootstrapManifest(check.paths.debianBootstrap)
+	return err
+}
+
+func (check *pinnedInputsCheck) loadInitialTextInputs() error {
+	return loadPinnedTextInputs([]pinnedTextInput{
+		{check.cfg.ProvidersPackageJSONPath, &check.providersPackageJSONText},
+		{check.cfg.ProvidersPackageLockPath, &check.providersPackageLockText},
+		{check.paths.markdownlintJSON, &check.markdownlintPackageJSONText},
+		{check.paths.markdownlintLock, &check.markdownlintPackageLockText},
+		{check.paths.installDevTools, &check.installDevToolsScript},
+		{check.paths.validateRepo, &check.validateRepoScript},
+		{check.cfg.CIWorkflowPath, &check.ciWorkflow},
+		{check.cfg.ReleaseWorkflowPath, &check.releaseWorkflow},
+		{check.cfg.PinHygieneWorkflowPath, &check.pinHygieneWorkflow},
+		{check.paths.upstreamRefresh, &check.upstreamRefreshWorkflow},
+		{check.paths.validatorImageScript, &check.validatorImageScript},
+		{check.cfg.CodeownersPath, &check.codeowners},
+		{check.cfg.HostedControlsPolicyPath, &check.hostedControlsPolicyText},
+		{check.cfg.HostedControlsScriptPath, &check.hostedControlsScript},
+		{check.cfg.CodexRequirementsPath, &check.codexRequirementsText},
+		{check.cfg.CodexMCPConfigPath, &check.codexMCPConfigText},
+		{check.paths.goMod, &check.goModText},
+		{check.paths.cargoManifest, &check.cargoManifestText},
+		{check.paths.rustToolchain, &check.rustToolchainText},
+	})
+}
+
+func (check *pinnedInputsCheck) parseInitialTextInputs() error {
+	return firstPinnedInputError(
+		func() error {
+			return json.Unmarshal([]byte(check.providersPackageJSONText), &check.providersPackageJSON)
+		},
+		func() error {
+			return json.Unmarshal([]byte(check.providersPackageLockText), &check.providersPackageLock)
+		},
+		func() error {
+			return json.Unmarshal([]byte(check.markdownlintPackageJSONText), &check.markdownlintPackageJSON)
+		},
+		func() error {
+			return json.Unmarshal([]byte(check.markdownlintPackageLockText), &check.markdownlintPackageLock)
+		},
+		check.parseHostedControlsPolicy,
+	)
+}
+
+func (check *pinnedInputsCheck) parseHostedControlsPolicy() error {
+	var err error
+	check.hostedControlsPolicy, err = tomlsubset.Parse(check.hostedControlsPolicyText, check.cfg.HostedControlsPolicyPath)
+	return err
+}
+
+func loadPinnedTextInputs(inputs []pinnedTextInput) error {
+	for _, input := range inputs {
+		text, err := readText(input.path)
+		if err != nil {
+			return err
+		}
+		*input.target = text
+	}
+	return nil
+}
+
+func firstPinnedInputError(checks ...func() error) error {
+	for _, check := range checks {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- The validator now uses a typed state object for the initial input load and parse phases.
- The new structure preserves behavior, exact read order, exact parse order, exact error order, and error text.
- This refactor does not change a public contract.

## Validation

- Full Go tests passed.
- Focused race tests passed.
- Go vet passed.
- Pinned-input and contract checks passed.
- Six independent review roles reached consensus with no blocker.
- Exact-head PR parity passed.

## Cyclomatic complexity

- gocyclo v0.6.0 reports `CheckPinnedInputs` at 230 before and 202 after this change.
- The total score for this refactor scope decreases from 244 to 231.
- It reports each new helper at 3 or less.
