### PR TITLE
Wait for detached monitor finalization in live verification

### DIFF
--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -556,6 +556,29 @@ extract_top_level_bash_function() {
   ' "${source_file}"
 }
 
+detached_session_monitor_command_matches() {
+  local monitor_pid="$1"
+  local state_file="$2"
+  local monitor_command=""
+
+  monitor_command="$(ps -o command= -p "${monitor_pid}" 2>/dev/null | head -n1 || true)"
+  [[ "${monitor_command}" == *"${ROOT_DIR}/scripts/workcell"*' session monitor --state-file '*"${state_file}" ]]
+}
+
+wait_for_detached_session_monitor_exit() {
+  local monitor_pid="$1"
+  local state_file="$2"
+  local attempts="${3:-10}"
+  local interval="${4:-1}"
+  local attempt=0
+
+  for ((attempt = 0; attempt < attempts; attempt++)); do
+    detached_session_monitor_command_matches "${monitor_pid}" "${state_file}" || return 0
+    sleep "${interval}"
+  done
+  ! detached_session_monitor_command_matches "${monitor_pid}" "${state_file}"
+}
+
 make_tree_user_writable_safely() {
   local target_path="$1"
 
@@ -7568,14 +7591,11 @@ EOF
     grep -q '^SESSION_STOPPING$' "${DETACHED_SESSION_SENTINEL_PATH}"
     grep -q '"current_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
     grep -q '"final_assurance": "managed-mutable"' "${DETACHED_SESSION_SHOW_STOPPED_OUT}"
-    DETACHED_SESSION_MONITOR_COMMAND="$(ps -o command= -p "${DETACHED_SESSION_MONITOR_PID}" 2>/dev/null | head -n1 || true)"
-    case "${DETACHED_SESSION_MONITOR_COMMAND}" in
-      *"${ROOT_DIR}/scripts/workcell"*' session monitor --state-file '*"${DETACHED_SESSION_MONITOR_STATE_FILE}")
-        echo "Detached session monitor remained alive after session finalization: ${DETACHED_SESSION_MONITOR_PID}" >&2
-        cat "${DETACHED_SESSION_SHOW_STOPPED_OUT}" >&2
-        exit 1
-        ;;
-    esac
+    if ! wait_for_detached_session_monitor_exit "${DETACHED_SESSION_MONITOR_PID}" "${DETACHED_SESSION_MONITOR_STATE_FILE}"; then
+      echo "Detached session monitor remained alive after session finalization: ${DETACHED_SESSION_MONITOR_PID}" >&2
+      cat "${DETACHED_SESSION_SHOW_STOPPED_OUT}" >&2
+      exit 1
+    fi
     test ! -e "${DETACHED_SESSION_AUDIT_DIR}"
     test ! -e "${DETACHED_SESSION_MONITOR_STATE_FILE}"
     if ! run_workcell_verify session timeline --id "${DETACHED_SESSION_ID}" >"${DETACHED_SESSION_TIMELINE_OUT}" 2>&1; then

--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -563,6 +563,50 @@ if [[ "${detached_launch_blocked}" -eq 0 ]]; then
 fi
 
 sed '/^if \[\[ \$# -gt 0 \]\]; then$/,$d' "${ROOT_DIR}/scripts/workcell" >"${WORKCELL_FUNCTIONS_COPY}"
+MONITOR_WAIT_FUNCTIONS_COPY="${TMP_DIR}/monitor-finalization-wait-functions"
+{
+  sed -n '/^detached_session_monitor_command_matches() {$/,/^}$/p' "${ROOT_DIR}/scripts/verify-invariants.sh"
+  sed -n '/^wait_for_detached_session_monitor_exit() {$/,/^}$/p' "${ROOT_DIR}/scripts/verify-invariants.sh"
+} >"${MONITOR_WAIT_FUNCTIONS_COPY}"
+monitor_finalization_wait_output="$(
+  bash -lc '
+    set -euo pipefail
+    source "$1"
+    ROOT_DIR="$2"
+    state_file="$3/session-monitor.env"
+
+    /bin/bash -c "sleep 0.05; :" "${ROOT_DIR}/scripts/workcell" session monitor --state-file "${state_file}" &
+    transient_pid="$!"
+    wait_for_detached_session_monitor_exit "${transient_pid}" "${state_file}" 20 0.01
+    wait "${transient_pid}"
+    printf "transient=accepted\n"
+
+    /bin/bash -c "sleep 0.2; :" "${ROOT_DIR}/scripts/workcell" session monitor --state-file "${state_file}" &
+    persistent_pid="$!"
+    if wait_for_detached_session_monitor_exit "${persistent_pid}" "${state_file}" 2 0.01; then
+      wait "${persistent_pid}"
+      echo "Persistent detached monitor unexpectedly passed the bounded wait" >&2
+      exit 1
+    fi
+    wait "${persistent_pid}"
+    printf "persistent=rejected\n"
+
+    /bin/sleep 0.05 &
+    reused_pid="$!"
+    wait_for_detached_session_monitor_exit "${reused_pid}" "${state_file}" 1 0.01
+    wait "${reused_pid}"
+    printf "reused=accepted\n"
+  ' _ "${MONITOR_WAIT_FUNCTIONS_COPY}" "${ROOT_DIR}" "${TMP_DIR}"
+)"
+grep -q '^transient=accepted$' <<<"${monitor_finalization_wait_output}"
+grep -q '^persistent=rejected$' <<<"${monitor_finalization_wait_output}"
+grep -q '^reused=accepted$' <<<"${monitor_finalization_wait_output}"
+awk '
+  index($0, "if ! wait_for_detached_session_monitor_exit") { wait_line = NR }
+  index($0, "test ! -e \"${DETACHED_SESSION_AUDIT_DIR}\"") { audit_line = NR }
+  index($0, "test ! -e \"${DETACHED_SESSION_MONITOR_STATE_FILE}\"") { state_line = NR }
+  END { exit !(wait_line && wait_line < audit_line && audit_line < state_line) }
+' "${ROOT_DIR}/scripts/verify-invariants.sh"
 state_path_output="$(
   bash -lc '
     set -euo pipefail


### PR DESCRIPTION
## Summary

- The live verifier waits for the exact detached monitor command to exit after terminal metadata appears.
- The wait is bounded at ten seconds.
- It still fails when the exact monitor remains alive.
- Audit-directory and state-file absence checks remain after the wait.
- Focused tests cover transient exit, a persistent process, PID reuse, and assertion order.
- This change does not alter a runtime contract.

## Validation

- Shell syntax, ShellCheck, and shfmt checks passed.
- Fifty focused stress iterations passed.
- The same-PID command-transition probe passed.
- Six independent review lenses found no blocker.
- Full live invariant verification passed.
- Exact-head PR parity and container smoke passed.

## Cyclomatic complexity

- This change modifies shell only, so gocyclo does not apply.
- The two new helpers have one purpose each and keep nesting shallow.
- Further safe reduction would remove required timeout or identity decisions, so no branch is redundant.
