### PR TITLE
Split pinned-input workflow validation

### DIFF
--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -64,7 +64,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	}
 
 	repoRoot := check.repoRoot
-	allowedActions := check.allowedActions
 	pins := check.pins
 	cargoManifestPath := check.paths.cargoManifest
 	installDevToolsScriptPath := check.paths.installDevTools
@@ -87,9 +86,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	pinHygieneWorkflow := check.pinHygieneWorkflow
 	upstreamRefreshWorkflow := check.upstreamRefreshWorkflow
 	validatorImageScript := check.validatorImageScript
-	codeowners := check.codeowners
-	hostedControlsPolicy := check.hostedControlsPolicy
-	hostedControlsScript := check.hostedControlsScript
 	codexRequirementsText := check.codexRequirementsText
 	codexMCPConfigText := check.codexMCPConfigText
 	goModText := check.goModText
@@ -104,95 +100,6 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 			return fmt.Errorf("%s pin %q does not match policy/tool-pins.toml %q; the workflow and the policy must stay in lockstep (scripts/update-upstream-pins.sh rewrites both)", name, actual, policyValue)
 		}
 		return nil
-	}
-	requireYAMLKey := func(text, name, path string) (string, error) {
-		match := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `:\s*(.+)$`).FindStringSubmatch(text)
-		if match == nil {
-			return "", fmt.Errorf("unable to extract %s from %s", name, path)
-		}
-		return strings.TrimSpace(match[1]), nil
-	}
-	requireUniformWorkflowEnv := func(text, key, valuePattern, label, path string) (string, error) {
-		lineRE := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(key) + `:\s*(\S+)\s*$`)
-		valueRE := regexp.MustCompile(`^` + valuePattern + `$`)
-		matches := lineRE.FindAllStringSubmatch(text, -1)
-		if len(matches) == 0 {
-			return "", fmt.Errorf("%s in %s must define %s", label, path, key)
-		}
-		value := matches[0][1]
-		for _, match := range matches {
-			if !valueRE.MatchString(match[1]) {
-				return "", fmt.Errorf("%s in %s must match %q", label, path, valuePattern)
-			}
-			if match[1] != value {
-				return "", fmt.Errorf("%s in %s must use one reviewed value for %s", label, path, key)
-			}
-		}
-		return value, nil
-	}
-	requireCappedReleaseDownloads := func(text, path string, downloads []struct {
-		label string
-		url   string
-	}) error {
-		for _, download := range downloads {
-			offset := 0
-			found := false
-			for {
-				relativeURLIndex := strings.Index(text[offset:], download.url)
-				if relativeURLIndex < 0 {
-					break
-				}
-				found = true
-				urlIndex := offset + relativeURLIndex
-				curlIndex := strings.LastIndex(text[:urlIndex], "curl -fsSL")
-				if curlIndex < 0 {
-					return fmt.Errorf("%s must download %s with curl -fsSL", path, download.label)
-				}
-				block := text[curlIndex : urlIndex+len(download.url)]
-				for _, needle := range []string{"--max-time 60", "--connect-timeout 15", "--max-filesize 209715200"} {
-					if !strings.Contains(block, needle) {
-						return fmt.Errorf("%s must bound %s downloads with %s", path, download.label, needle)
-					}
-				}
-				offset = urlIndex + len(download.url)
-			}
-			if !found {
-				return fmt.Errorf("%s must derive the %s archive URL from its pinned version", path, download.label)
-			}
-		}
-		return nil
-	}
-	requireActionRef := func(text, action, path string) (string, error) {
-		re := regexp.MustCompile(regexp.QuoteMeta(action) + `@([0-9a-f]{40})`)
-		matches := re.FindAllStringSubmatch(text, -1)
-		if len(matches) == 0 {
-			return "", fmt.Errorf("%s must pin %s to an immutable commit SHA", path, action)
-		}
-		refs := map[string]struct{}{}
-		for _, match := range matches {
-			refs[match[1]] = struct{}{}
-		}
-		if len(refs) != 1 {
-			return "", fmt.Errorf("%s must use a single reviewed ref for %s", path, action)
-		}
-		for ref := range refs {
-			return ref, nil
-		}
-		return "", nil
-	}
-	requireTOMLString := func(text, key, path string) (string, error) {
-		match := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(key) + `\s*=\s*"([^"]+)"\s*$`).FindStringSubmatch(text)
-		if match == nil {
-			return "", fmt.Errorf("unable to extract %s from %s", key, path)
-		}
-		return match[1], nil
-	}
-	majorMinor := func(version, path string) (string, error) {
-		match := regexp.MustCompile(`^([0-9]+\.[0-9]+)\.[0-9]+$`).FindStringSubmatch(version)
-		if match == nil {
-			return "", fmt.Errorf("expected a semantic version in %s, found %q", path, version)
-		}
-		return match[1], nil
 	}
 	extractReproMatrixEntries := func(strategyBlock, path string) ([][3]string, error) {
 		re := regexp.MustCompile(`(?m)^\s{10}- platform:\s*(\S+)\n^\s{12}platform_name:\s*(\S+)\n^\s{12}runner:\s*(\S+)$`)
@@ -250,18 +157,25 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := requireEqual("RUST_VERSION", runtimeRustVersion, cfg.RuntimeDockerfilePath, validatorRustVersion, cfg.ValidatorDockerfilePath); err != nil {
-		return err
-	}
-	if err := requireEqual("Rust toolchain channel", rustToolchainVersion, rustToolchainPath, runtimeRustVersion, cfg.RuntimeDockerfilePath); err != nil {
-		return err
-	}
-	if err := requirePinnedBaseImage(runtimeRustToolchainImage, "RUST_TOOLCHAIN_IMAGE", cfg.RuntimeDockerfilePath); err != nil {
-		return err
-	}
 	expectedRustToolchainTrack := fmt.Sprintf("rust:%s-slim-trixie@", runtimeRustVersion)
-	if !strings.Contains(runtimeRustToolchainImage, expectedRustToolchainTrack) {
-		return fmt.Errorf("RUST_TOOLCHAIN_IMAGE in %s must pin the official rust:%s-slim-trixie image, found %q", cfg.RuntimeDockerfilePath, runtimeRustVersion, runtimeRustToolchainImage)
+	if err := firstPinnedInputError(
+		func() error {
+			return requireEqual("RUST_VERSION", runtimeRustVersion, cfg.RuntimeDockerfilePath, validatorRustVersion, cfg.ValidatorDockerfilePath)
+		},
+		func() error {
+			return requireEqual("Rust toolchain channel", rustToolchainVersion, rustToolchainPath, runtimeRustVersion, cfg.RuntimeDockerfilePath)
+		},
+		func() error {
+			return requirePinnedBaseImage(runtimeRustToolchainImage, "RUST_TOOLCHAIN_IMAGE", cfg.RuntimeDockerfilePath)
+		},
+		func() error {
+			return requireTextRequirements(textRequirement{
+				text: runtimeRustToolchainImage, needle: expectedRustToolchainTrack,
+				err: fmt.Errorf("RUST_TOOLCHAIN_IMAGE in %s must pin the official rust:%s-slim-trixie image, found %q", cfg.RuntimeDockerfilePath, runtimeRustVersion, runtimeRustToolchainImage),
+			})
+		},
+	); err != nil {
+		return err
 	}
 	expectedCargoRustVersion, err := majorMinor(rustToolchainVersion, rustToolchainPath)
 	if err != nil {
@@ -339,33 +253,8 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err := requirePinnedBaseImage(ciBuildkitImage, "WORKCELL_BUILDKIT_IMAGE", ".github/workflows/ci.yml"); err != nil {
 		return err
 	}
-	for _, workflowPath := range workflowYAMLFiles(cfg.WorkflowsDir) {
-		workflowText, err := readText(workflowPath)
-		if err != nil {
-			return err
-		}
-		workflowName := ".github/workflows/" + filepath.Base(workflowPath)
-		if regexp.MustCompile(`(?m)^\s*WORKCELL_BUILDX_VERSION:`).MatchString(workflowText) {
-			workflowBuildxVersion, err := requireYAMLKey(workflowText, "WORKCELL_BUILDX_VERSION", workflowName)
-			if err != nil {
-				return err
-			}
-			if err := requireEqual("WORKCELL_BUILDX_VERSION", ciBuildxVersion, ".github/workflows/ci.yml", workflowBuildxVersion, workflowName); err != nil {
-				return err
-			}
-		}
-		if regexp.MustCompile(`(?m)^\s*WORKCELL_BUILDKIT_IMAGE:`).MatchString(workflowText) {
-			workflowBuildkitImage, err := requireYAMLKey(workflowText, "WORKCELL_BUILDKIT_IMAGE", workflowName)
-			if err != nil {
-				return err
-			}
-			if err := requireEqual("WORKCELL_BUILDKIT_IMAGE", ciBuildkitImage, ".github/workflows/ci.yml", workflowBuildkitImage, workflowName); err != nil {
-				return err
-			}
-			if !strings.Contains(workflowText, "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}") {
-				return fmt.Errorf("%s must pin the BuildKit daemon image used by setup-buildx-action", workflowName)
-			}
-		}
+	if err := validateWorkflowBuilderPins(cfg.WorkflowsDir, ciBuildxVersion, ciBuildkitImage); err != nil {
+		return err
 	}
 	validatorImageFallback := regexp.MustCompile(`(?m)^BUILDKIT_IMAGE="\$\{WORKCELL_BUILDKIT_IMAGE:-([^}]+)\}"$`).FindStringSubmatch(validatorImageScript)
 	if validatorImageFallback == nil {
@@ -433,14 +322,12 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if len(map[string]struct{}{ciCosignInstallerRef: {}, releaseCosignInstallerRef: {}, pinHygieneCosignInstallerRef: {}, upstreamRefreshCosignInstallerRef: {}}) != 1 {
 		return errors.New("sigstore/cosign-installer must use the same reviewed commit SHA in .github/workflows/ci.yml, .github/workflows/release.yml, .github/workflows/pin-hygiene.yml, and .github/workflows/upstream-refresh.yml")
 	}
-	if !strings.Contains(ciWorkflow, "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}") {
-		return errors.New(".github/workflows/ci.yml must pin the BuildKit daemon image used by setup-buildx-action")
-	}
-	if !strings.Contains(releaseWorkflow, "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}") {
-		return errors.New(".github/workflows/release.yml must pin the BuildKit daemon image used by setup-buildx-action")
-	}
-	if !strings.Contains(ciWorkflow, "cache-binary: true") {
-		return errors.New("pinned buildx binary caching must stay enabled in .github/workflows/ci.yml")
+	if err := requireTextRequirements(
+		textRequirement{text: ciWorkflow, needle: "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}", err: errors.New(".github/workflows/ci.yml must pin the BuildKit daemon image used by setup-buildx-action")},
+		textRequirement{text: releaseWorkflow, needle: "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}", err: errors.New(".github/workflows/release.yml must pin the BuildKit daemon image used by setup-buildx-action")},
+		textRequirement{text: ciWorkflow, needle: "cache-binary: true", err: errors.New("pinned buildx binary caching must stay enabled in .github/workflows/ci.yml")},
+	); err != nil {
+		return err
 	}
 	extractBetween := func(text, startMarker, endMarker, label string) (string, error) {
 		start := strings.Index(text, startMarker)
@@ -534,16 +421,9 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 	if err != nil {
 		return err
 	}
-	securityActionlintVersion, err := requireUniformWorkflowEnv(securityWorkflow, "ACTIONLINT_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "security actionlint version", ".github/workflows/security.yml")
+	securityActionlintVersion, err := validateActionlintVersions(securityWorkflow, releaseWorkflow)
 	if err != nil {
 		return err
-	}
-	releaseActionlintVersion, err := requireUniformWorkflowEnv(releaseWorkflow, "ACTIONLINT_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "release actionlint version", ".github/workflows/release.yml")
-	if err != nil {
-		return err
-	}
-	if securityActionlintVersion != releaseActionlintVersion {
-		return errors.New("ACTIONLINT_VERSION must match between .github/workflows/security.yml and .github/workflows/release.yml")
 	}
 	securityActionlintSHA, err := requireUniformWorkflowEnv(securityWorkflow, "ACTIONLINT_SHA256", `[0-9a-f]{64}`, "security actionlint sha", ".github/workflows/security.yml")
 	if err != nil {
@@ -608,10 +488,7 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 		{text: securityWorkflow, path: ".github/workflows/security.yml"},
 		{text: releaseWorkflow, path: ".github/workflows/release.yml"},
 	} {
-		if err := requireCappedReleaseDownloads(workflow.text, workflow.path, []struct {
-			label string
-			url   string
-		}{
+		if err := requireCappedReleaseDownloads(workflow.text, workflow.path, []releaseDownload{
 			{
 				label: "actionlint",
 				url:   "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz",
@@ -640,266 +517,19 @@ func CheckPinnedInputs(cfg PinnedInputsConfig) error {
 			return fmt.Errorf(".github/workflows/security.yml must contain %q", needle)
 		}
 	}
-	if !strings.Contains(releaseWorkflow, "docker buildx imagetools create") {
-		return errors.New(".github/workflows/release.yml must assemble the published multi-arch manifest with docker buildx imagetools create")
-	}
-	if regexp.MustCompile(`docker/build-push-action@.*?platforms:\s*linux/amd64,linux/arm64`).MatchString(releaseWorkflow) {
-		return errors.New(".github/workflows/release.yml must not publish the final multi-arch image through one opaque multi-platform build-push step")
-	}
-	if !strings.Contains(runtimeDockerfile, "COPY runtime/container/rust /workcell-rust") {
-		return errors.New("runtime/container/Dockerfile must vendor the reviewed Rust runtime sources into the builder stage")
-	}
-	for _, needle := range []string{
-		"COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo",
-		"COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup",
-	} {
-		if !strings.Contains(runtimeDockerfile, needle) {
-			return fmt.Errorf("runtime/container/Dockerfile must copy the pinned Rust toolchain through %q", needle)
-		}
-	}
-	if !strings.Contains(runtimeDockerfile, "COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json") {
-		return errors.New("runtime/container/Dockerfile must copy the reviewed control-plane manifest into the runtime image")
-	}
-	hasOfflineCargoBuild := strings.Contains(runtimeDockerfile, "cargo build \\") ||
-		strings.Contains(runtimeDockerfile, "\"${toolchain_bin}/cargo\" build \\")
-	if !hasOfflineCargoBuild || !strings.Contains(runtimeDockerfile, "--locked \\") || !strings.Contains(runtimeDockerfile, "--offline \\") {
-		return errors.New("runtime/container/Dockerfile must build the shipped Rust launcher artifacts with cargo --locked --offline")
-	}
-	if !strings.Contains(runtimeDockerfile, "CARGO_HOME=/workcell-rust/cargo-home") {
-		return errors.New("runtime/container/Dockerfile must isolate Cargo home inside the vendored runtime source tree")
-	}
-	for _, needle := range []string{
-		"name: workcell-release-preflight",
-		"name: workcell-release-install-candidate",
-		"name: Release install verification (${{ matrix.runner_label }})",
-		"brew tap-new",
-		"brew --repo",
-		"brew install \"${tap_name}/workcell\"",
-		"macos-26",
-		"macos-15",
-		"actions/download-artifact@",
-		"context: dist/release-source",
-		"name: Re-verify pinned upstreams from archived source tree",
-		"name: Verify GitHub macOS release test runners",
-		"working-directory: dist/release-source",
-		"WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source",
-		"WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source",
-		"Verify published platform digests match preflight",
-		"docker buildx imagetools inspect --raw",
-		"{{json .Manifest}}",
-		"vnd.docker.reference.type",
-		"RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}",
-		"actions/attest@",
-		"Verify release bundle matches preflight",
-		"Verify control-plane manifest matches preflight",
-		"github/codeql-action/init@",
-		"github/codeql-action/analyze@",
-		"./scripts/publish-github-release.sh",
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	if strings.Contains(releaseWorkflow, "{{json .manifest}}") {
-		return errors.New(".github/workflows/release.yml must not use the unsupported lowercase Buildx .manifest template field")
-	}
-	if !strings.Contains(releaseWorkflow, "dist/${{ env.BUNDLE_NAME }}.sigstore.json") ||
-		!strings.Contains(releaseWorkflow, "dist/workcell-control-plane.sigstore.json") ||
-		!strings.Contains(releaseWorkflow, "dist/workcell-image.digest.sigstore.json") ||
-		!strings.Contains(releaseWorkflow, "dist/workcell-source.spdx.sigstore.json") ||
-		!strings.Contains(releaseWorkflow, "dist/workcell-image.spdx.sigstore.json") {
-		return errors.New(".github/workflows/release.yml must publish direct signature bundles for release artifacts")
-	}
-	if err := ValidateReleaseWorkflowControlPlaneFlow(releaseWorkflow); err != nil {
-		return err
-	}
-	if err := ValidateMacOSInstallVerificationFlow(releaseWorkflow, ".github/workflows/release.yml", "workcell-release-install-candidate", "name: Release install verification (${{ matrix.runner_label }})"); err != nil {
-		return err
-	}
-	if err := ValidateReleaseWorkflowGitHubAttestationFlow(releaseWorkflow); err != nil {
-		return err
-	}
-	if err := ValidateReleaseWorkflowPublicationGate(releaseWorkflow); err != nil {
-		return err
-	}
-	if strings.Contains(releaseWorkflow, "steps.build.outputs.digest") {
-		return errors.New(".github/workflows/release.yml must not keep referencing the old single-step multi-platform digest output")
-	}
-	if strings.Contains(releaseWorkflow, "gh release ") {
-		return errors.New(".github/workflows/release.yml must not depend on an ambient gh CLI; use a pinned release-publish action")
-	}
-	if !strings.Contains(releaseWorkflow, "./scripts/publish-github-release.sh") {
-		return errors.New(".github/workflows/release.yml must publish assets through the reviewed repo-local GitHub Release API script")
-	}
-	if count := strings.Count(releaseWorkflow, "./scripts/check-release-tag-signature.sh --github-repo"); count != 2 {
-		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures in preflight and publish jobs, found %d checks", count)
-	}
-	for _, needle := range []string{
-		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
-		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
-		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
-		`--immutable-releases-preverified-by-hosted-controls`,
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	if !strings.Contains(releaseWorkflow, "environment:\n      name: hosted-controls-audit") {
-		return errors.New(".github/workflows/release.yml release preflight must bind to the hosted-controls-audit environment")
-	}
-	if err := ValidateUpstreamRefreshWorkflow(upstreamRefreshWorkflow); err != nil {
-		return err
-	}
-	hostedControlsWorkflow, err := readText(filepath.Join(cfg.WorkflowsDir, "hosted-controls.yml"))
-	if err != nil {
-		return err
-	}
-	for _, needle := range []string{
-		`name: hosted-controls-audit`,
-		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
-		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
-		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
-	} {
-		if !strings.Contains(hostedControlsWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/hosted-controls.yml must contain %q", needle)
-		}
-	}
-	for _, needle := range []string{
-		"./scripts/verify-github-macos-release-test-runners.sh",
-		"./scripts/verify-upstream-codex-release.sh",
-		"./scripts/verify-upstream-claude-release.sh",
-		"./scripts/verify-upstream-copilot-release.sh",
-		"./scripts/verify-upstream-gemini-release.sh",
-		"./scripts/update-upstream-pins.sh --check",
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	for _, needle := range []string{
-		"./scripts/ci/job-pin-hygiene.sh",
-	} {
-		if !strings.Contains(pinHygieneWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/pin-hygiene.yml must contain %q", needle)
-		}
-	}
-	pinHygieneJob, err := readText(filepath.Join(repoRoot, "scripts", "ci", "job-pin-hygiene.sh"))
-	if err != nil {
-		return err
-	}
-	validateJob, err := readText(filepath.Join(repoRoot, "scripts", "ci", "job-validate.sh"))
-	if err != nil {
-		return err
-	}
-	for _, needle := range []string{
-		"${ROOT_DIR}/scripts/verify-upstream-codex-release.sh",
-		"${ROOT_DIR}/scripts/verify-upstream-claude-release.sh",
-		"${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh",
-		"${ROOT_DIR}/scripts/verify-upstream-gemini-release.sh",
-	} {
-		if !strings.Contains(pinHygieneJob, needle) {
-			return fmt.Errorf("scripts/ci/job-pin-hygiene.sh must contain %q", needle)
-		}
-	}
-	for _, needle := range []string{
-		`WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"`,
-		"unset WORKCELL_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN",
-	} {
-		if !strings.Contains(validateJob, needle) {
-			return fmt.Errorf("scripts/ci/job-validate.sh must contain %q", needle)
-		}
-	}
-	for _, needle := range []string{
-		"./scripts/update-upstream-pins.sh --check",
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	for _, needle := range []string{
-		"environment:\n      name: release",
-		`sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign`,
-		`sudo install -m 0755 "$(command -v syft)" /usr/local/bin/syft`,
-		`actionlint_archive="${RUNNER_TEMP}/actionlint.tar.gz"`,
-		`tar -xzf "${actionlint_archive}" -C "${RUNNER_TEMP}" actionlint`,
-		"git -c safe.directory=/workspace archive \\",
-	} {
-		if !strings.Contains(releaseWorkflow, needle) {
-			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
-		}
-	}
-	for _, workflowPath := range workflowYAMLFiles(cfg.WorkflowsDir) {
-		workflowText, err := readText(workflowPath)
-		if err != nil {
-			return err
-		}
-		if !workflowPermissionsRE.MatchString(workflowText) {
-			return fmt.Errorf("workflow-level empty permissions declaration missing in %s", workflowPath)
-		}
-		if strings.Contains(workflowText, "pull_request_target") {
-			if err := IsSafePullRequestTargetWorkflow(workflowText, workflowPath); err != nil {
-				return err
-			}
-		}
-		if regexp.MustCompile(`secrets\.[A-Z0-9_]*(?:PAT|PERSONAL_ACCESS_TOKEN)\b|GH_PAT\b|PERSONAL_ACCESS_TOKEN\b`).MatchString(workflowText) {
-			return fmt.Errorf("%s must not contain long-lived personal access tokens", workflowPath)
-		}
-		usesRefs, err := extractWorkflowUses(workflowText)
-		if err != nil {
-			return fmt.Errorf("%s: %w", workflowPath, err)
-		}
-		for _, ref := range usesRefs {
-			action := actionRefPattern.FindStringSubmatch(ref)
-			if action == nil {
-				return fmt.Errorf("%s has an unsupported uses: reference %q; only pinned owner/repo actions are permitted (no docker:// or local ./ actions)", workflowPath, ref)
-			}
-			if !commitShaPattern.MatchString(action[2]) {
-				return fmt.Errorf("%s must pin GitHub Actions by full commit SHA; found %s@%s", workflowPath, action[1], action[2])
-			}
-			segments := strings.SplitN(action[1], "/", 3)
-			ownerRepo := segments[0] + "/" + segments[1]
-			if !allowedActions[ownerRepo] {
-				return fmt.Errorf("%s uses action %q which is not in the reviewed allowlist policy/allowed-actions.toml", workflowPath, ownerRepo)
-			}
-		}
-	}
-	for _, required := range []string{
-		"/.github/workflows/ @omkhar",
-		"/scripts/ @omkhar",
-		"/runtime/container/ @omkhar",
-		"/docs/provenance.md @omkhar",
-	} {
-		if !strings.Contains(codeowners, required) {
-			return fmt.Errorf(".github/CODEOWNERS must declare high-risk ownership for %q", required)
-		}
-	}
-	releaseEnvironment, _ := hostedControlsPolicy["release_environment"].(map[string]any)
-	releaseMode, _ := releaseEnvironment["mode"].(string)
-	if releaseMode != "review-gated" && releaseMode != "single-owner-public" && releaseMode != "single-owner-private" && releaseMode != "plan-limited-private" {
-		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'")
-	}
-	if _, err := GitHubActionsPolicy(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
-		return err
-	}
-	if _, err := ReleaseAssets(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
-		return err
-	}
-	if err := ValidateCanonicalRepositoryVariables(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
-		return err
-	}
-	if err := ValidateCanonicalWorkflowEnvironments(hostedControlsPolicy, "policy/github-hosted-controls.toml"); err != nil {
-		return err
-	}
-	if err := validateCanonicalHostedControlsScript(hostedControlsScript); err != nil {
-		return err
-	}
-	if err := requireNoRegistryBootstrapMCP(codexRequirementsText, cfg.CodexRequirementsPath); err != nil {
-		return err
-	}
-	if err := requireNoRegistryBootstrapMCP(codexMCPConfigText, cfg.CodexMCPConfigPath); err != nil {
-		return err
-	}
-	return nil
+	return firstPinnedInputError(
+		check.validateReleaseManifestAndRuntimeSources,
+		check.validateRuntimeCargoBuild,
+		check.validateReleaseRequiredSteps,
+		check.validateReleaseArtifactFlows,
+		check.validateReleaseLegacyReferences,
+		check.validateReleaseHostedControls,
+		check.validateHostedControlsWorkflow,
+		check.validateReleaseVerificationJobs,
+		check.validateReleasePublishingInputs,
+		check.validateWorkflowPolicies,
+		check.validateCodeownersAndHostedPolicy,
+	)
 }
 
 func requireArg(text, name, path string) (string, error) {

--- a/internal/metadatautil/pinnedinputs_check.go
+++ b/internal/metadatautil/pinnedinputs_check.go
@@ -5,7 +5,10 @@ package metadatautil
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/omkhar/workcell/internal/tomlsubset"
 )
@@ -39,13 +42,12 @@ type pinnedInputsCheck struct {
 	goModText                   string
 	cargoManifestText           string
 	rustToolchainText           string
-
-	debianBootstrapManifest DebianBootstrapManifest
-	providersPackageJSON    map[string]any
-	providersPackageLock    map[string]any
-	markdownlintPackageJSON markdownlintPackageJSON
-	markdownlintPackageLock markdownlintPackageLock
-	hostedControlsPolicy    map[string]any
+	debianBootstrapManifest     DebianBootstrapManifest
+	providersPackageJSON        map[string]any
+	providersPackageLock        map[string]any
+	markdownlintPackageJSON     markdownlintPackageJSON
+	markdownlintPackageLock     markdownlintPackageLock
+	hostedControlsPolicy        map[string]any
 }
 
 type pinnedInputPaths struct {
@@ -64,6 +66,14 @@ type pinnedInputPaths struct {
 type pinnedTextInput struct {
 	path   string
 	target *string
+}
+
+type releaseDownload struct{ label, url string }
+
+type textRequirement struct {
+	text, needle string
+	forbidden    bool
+	err          error
 }
 
 func newPinnedInputsCheck(cfg PinnedInputsConfig) *pinnedInputsCheck {
@@ -88,88 +98,74 @@ func newPinnedInputsCheck(cfg PinnedInputsConfig) *pinnedInputsCheck {
 
 func (check *pinnedInputsCheck) load() error {
 	return firstPinnedInputError(
-		check.loadAllowedActions,
-		check.loadToolPins,
-		check.loadDockerfiles,
-		check.loadDebianBootstrapManifest,
-		check.loadInitialTextInputs,
-		check.parseInitialTextInputs,
+		func() error {
+			path := filepath.Join(check.repoRoot, "policy", "allowed-actions.toml")
+			var err error
+			check.allowedActions, err = loadAllowedActions(path)
+			return err
+		},
+		func() error {
+			path := filepath.Join(check.repoRoot, "policy", "tool-pins.toml")
+			var err error
+			check.pins, err = loadToolPins(path)
+			return err
+		},
+		func() error {
+			return loadPinnedTextInputs([]pinnedTextInput{
+				{check.cfg.RuntimeDockerfilePath, &check.runtimeDockerfile},
+				{check.cfg.ValidatorDockerfilePath, &check.validatorDockerfile},
+			})
+		},
+		func() error {
+			var err error
+			check.debianBootstrapManifest, err = ReadDebianBootstrapManifest(check.paths.debianBootstrap)
+			return err
+		},
+		func() error {
+			return loadPinnedTextInputs([]pinnedTextInput{
+				{check.cfg.ProvidersPackageJSONPath, &check.providersPackageJSONText},
+				{check.cfg.ProvidersPackageLockPath, &check.providersPackageLockText},
+				{check.paths.markdownlintJSON, &check.markdownlintPackageJSONText},
+				{check.paths.markdownlintLock, &check.markdownlintPackageLockText},
+				{check.paths.installDevTools, &check.installDevToolsScript},
+				{check.paths.validateRepo, &check.validateRepoScript},
+				{check.cfg.CIWorkflowPath, &check.ciWorkflow},
+				{check.cfg.ReleaseWorkflowPath, &check.releaseWorkflow},
+				{check.cfg.PinHygieneWorkflowPath, &check.pinHygieneWorkflow},
+				{check.paths.upstreamRefresh, &check.upstreamRefreshWorkflow},
+				{check.paths.validatorImageScript, &check.validatorImageScript},
+				{check.cfg.CodeownersPath, &check.codeowners},
+				{check.cfg.HostedControlsPolicyPath, &check.hostedControlsPolicyText},
+				{check.cfg.HostedControlsScriptPath, &check.hostedControlsScript},
+				{check.cfg.CodexRequirementsPath, &check.codexRequirementsText},
+				{check.cfg.CodexMCPConfigPath, &check.codexMCPConfigText},
+				{check.paths.goMod, &check.goModText},
+				{check.paths.cargoManifest, &check.cargoManifestText},
+				{check.paths.rustToolchain, &check.rustToolchainText},
+			})
+		},
+		func() error {
+			return firstPinnedInputError(
+				func() error {
+					return json.Unmarshal([]byte(check.providersPackageJSONText), &check.providersPackageJSON)
+				},
+				func() error {
+					return json.Unmarshal([]byte(check.providersPackageLockText), &check.providersPackageLock)
+				},
+				func() error {
+					return json.Unmarshal([]byte(check.markdownlintPackageJSONText), &check.markdownlintPackageJSON)
+				},
+				func() error {
+					return json.Unmarshal([]byte(check.markdownlintPackageLockText), &check.markdownlintPackageLock)
+				},
+				func() error {
+					var err error
+					check.hostedControlsPolicy, err = tomlsubset.Parse(check.hostedControlsPolicyText, check.cfg.HostedControlsPolicyPath)
+					return err
+				},
+			)
+		},
 	)
-}
-
-func (check *pinnedInputsCheck) loadAllowedActions() error {
-	path := filepath.Join(check.repoRoot, "policy", "allowed-actions.toml")
-	var err error
-	check.allowedActions, err = loadAllowedActions(path)
-	return err
-}
-
-func (check *pinnedInputsCheck) loadToolPins() error {
-	path := filepath.Join(check.repoRoot, "policy", "tool-pins.toml")
-	var err error
-	check.pins, err = loadToolPins(path)
-	return err
-}
-
-func (check *pinnedInputsCheck) loadDockerfiles() error {
-	return loadPinnedTextInputs([]pinnedTextInput{
-		{check.cfg.RuntimeDockerfilePath, &check.runtimeDockerfile},
-		{check.cfg.ValidatorDockerfilePath, &check.validatorDockerfile},
-	})
-}
-
-func (check *pinnedInputsCheck) loadDebianBootstrapManifest() error {
-	var err error
-	check.debianBootstrapManifest, err = ReadDebianBootstrapManifest(check.paths.debianBootstrap)
-	return err
-}
-
-func (check *pinnedInputsCheck) loadInitialTextInputs() error {
-	return loadPinnedTextInputs([]pinnedTextInput{
-		{check.cfg.ProvidersPackageJSONPath, &check.providersPackageJSONText},
-		{check.cfg.ProvidersPackageLockPath, &check.providersPackageLockText},
-		{check.paths.markdownlintJSON, &check.markdownlintPackageJSONText},
-		{check.paths.markdownlintLock, &check.markdownlintPackageLockText},
-		{check.paths.installDevTools, &check.installDevToolsScript},
-		{check.paths.validateRepo, &check.validateRepoScript},
-		{check.cfg.CIWorkflowPath, &check.ciWorkflow},
-		{check.cfg.ReleaseWorkflowPath, &check.releaseWorkflow},
-		{check.cfg.PinHygieneWorkflowPath, &check.pinHygieneWorkflow},
-		{check.paths.upstreamRefresh, &check.upstreamRefreshWorkflow},
-		{check.paths.validatorImageScript, &check.validatorImageScript},
-		{check.cfg.CodeownersPath, &check.codeowners},
-		{check.cfg.HostedControlsPolicyPath, &check.hostedControlsPolicyText},
-		{check.cfg.HostedControlsScriptPath, &check.hostedControlsScript},
-		{check.cfg.CodexRequirementsPath, &check.codexRequirementsText},
-		{check.cfg.CodexMCPConfigPath, &check.codexMCPConfigText},
-		{check.paths.goMod, &check.goModText},
-		{check.paths.cargoManifest, &check.cargoManifestText},
-		{check.paths.rustToolchain, &check.rustToolchainText},
-	})
-}
-
-func (check *pinnedInputsCheck) parseInitialTextInputs() error {
-	return firstPinnedInputError(
-		func() error {
-			return json.Unmarshal([]byte(check.providersPackageJSONText), &check.providersPackageJSON)
-		},
-		func() error {
-			return json.Unmarshal([]byte(check.providersPackageLockText), &check.providersPackageLock)
-		},
-		func() error {
-			return json.Unmarshal([]byte(check.markdownlintPackageJSONText), &check.markdownlintPackageJSON)
-		},
-		func() error {
-			return json.Unmarshal([]byte(check.markdownlintPackageLockText), &check.markdownlintPackageLock)
-		},
-		check.parseHostedControlsPolicy,
-	)
-}
-
-func (check *pinnedInputsCheck) parseHostedControlsPolicy() error {
-	var err error
-	check.hostedControlsPolicy, err = tomlsubset.Parse(check.hostedControlsPolicyText, check.cfg.HostedControlsPolicyPath)
-	return err
 }
 
 func loadPinnedTextInputs(inputs []pinnedTextInput) error {
@@ -190,4 +186,115 @@ func firstPinnedInputError(checks ...func() error) error {
 		}
 	}
 	return nil
+}
+
+func requireYAMLKey(text, name, path string) (string, error) {
+	match := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `:\s*(.+)$`).FindStringSubmatch(text)
+	if match == nil {
+		return "", fmt.Errorf("unable to extract %s from %s", name, path)
+	}
+	return strings.TrimSpace(match[1]), nil
+}
+
+func requireUniformWorkflowEnv(text, key, valuePattern, label, path string) (string, error) {
+	lineRE := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(key) + `:\s*(\S+)\s*$`)
+	valueRE := regexp.MustCompile(`^` + valuePattern + `$`)
+	matches := lineRE.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%s in %s must define %s", label, path, key)
+	}
+	value := matches[0][1]
+	for _, match := range matches {
+		if !valueRE.MatchString(match[1]) {
+			return "", fmt.Errorf("%s in %s must match %q", label, path, valuePattern)
+		}
+		if match[1] != value {
+			return "", fmt.Errorf("%s in %s must use one reviewed value for %s", label, path, key)
+		}
+	}
+	return value, nil
+}
+
+func requireCappedReleaseDownloads(text, path string, downloads []releaseDownload) error {
+	for _, download := range downloads {
+		if err := requireCappedReleaseDownload(text, path, download); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireCappedReleaseDownload(text, path string, download releaseDownload) error {
+	count := strings.Count(text, download.url)
+	if count == 0 {
+		return fmt.Errorf("%s must derive the %s archive URL from its pinned version", path, download.label)
+	}
+	offset := 0
+	for range count {
+		relative := strings.Index(text[offset:], download.url)
+		urlIndex := offset + relative
+		curlIndex := strings.LastIndex(text[:urlIndex], "curl -fsSL")
+		if curlIndex < 0 {
+			return fmt.Errorf("%s must download %s with curl -fsSL", path, download.label)
+		}
+		block := text[curlIndex : urlIndex+len(download.url)]
+		if err := requireDownloadBounds(block, path, download.label); err != nil {
+			return err
+		}
+		offset = urlIndex + len(download.url)
+	}
+	return nil
+}
+
+func requireDownloadBounds(block, path, label string) error {
+	for _, needle := range []string{"--max-time 60", "--connect-timeout 15", "--max-filesize 209715200"} {
+		if !strings.Contains(block, needle) {
+			return fmt.Errorf("%s must bound %s downloads with %s", path, label, needle)
+		}
+	}
+	return nil
+}
+
+func requireActionRef(text, action, path string) (string, error) {
+	re := regexp.MustCompile(regexp.QuoteMeta(action) + `@([0-9a-f]{40})`)
+	matches := re.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%s must pin %s to an immutable commit SHA", path, action)
+	}
+	ref := matches[0][1]
+	for _, match := range matches[1:] {
+		if match[1] != ref {
+			return "", fmt.Errorf("%s must use a single reviewed ref for %s", path, action)
+		}
+	}
+	return ref, nil
+}
+
+func requireTOMLString(text, key, path string) (string, error) {
+	match := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(key) + `\s*=\s*"([^"]+)"\s*$`).FindStringSubmatch(text)
+	if match == nil {
+		return "", fmt.Errorf("unable to extract %s from %s", key, path)
+	}
+	return match[1], nil
+}
+
+func majorMinor(version, path string) (string, error) {
+	match := regexp.MustCompile(`^([0-9]+\.[0-9]+)\.[0-9]+$`).FindStringSubmatch(version)
+	if match == nil {
+		return "", fmt.Errorf("expected a semantic version in %s, found %q", path, version)
+	}
+	return match[1], nil
+}
+
+func requireTextRequirements(requirements ...textRequirement) error {
+	for _, requirement := range requirements {
+		if strings.Contains(requirement.text, requirement.needle) == requirement.forbidden {
+			return requirement.err
+		}
+	}
+	return nil
+}
+
+func requiredText(text, needle, path string) textRequirement {
+	return textRequirement{text: text, needle: needle, err: fmt.Errorf("%s must contain %q", path, needle)}
 }

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func validateActionlintVersions(securityWorkflow, releaseWorkflow string) (string, error) {
+	securityVersion, err := requireUniformWorkflowEnv(securityWorkflow, "ACTIONLINT_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "security actionlint version", ".github/workflows/security.yml")
+	if err != nil {
+		return "", err
+	}
+	releaseVersion, err := requireUniformWorkflowEnv(releaseWorkflow, "ACTIONLINT_VERSION", `[0-9]+\.[0-9]+\.[0-9]+`, "release actionlint version", ".github/workflows/release.yml")
+	if err != nil {
+		return "", err
+	}
+	if securityVersion != releaseVersion {
+		return "", errors.New("ACTIONLINT_VERSION must match between .github/workflows/security.yml and .github/workflows/release.yml")
+	}
+	return securityVersion, nil
+}
+
+func validateWorkflowBuilderPins(workflowsDir, buildx, buildkit string) error {
+	specs := [][3]string{
+		{"WORKCELL_BUILDX_VERSION", buildx, ""},
+		{"WORKCELL_BUILDKIT_IMAGE", buildkit, "driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}"},
+	}
+	for _, workflowPath := range workflowYAMLFiles(workflowsDir) {
+		text, err := readText(workflowPath)
+		if err != nil {
+			return err
+		}
+		path := ".github/workflows/" + filepath.Base(workflowPath)
+		for _, spec := range specs {
+			if err := validateOptionalWorkflowPin(text, path, spec); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateOptionalWorkflowPin(text, path string, spec [3]string) error {
+	name, expected, needle := spec[0], spec[1], spec[2]
+	present := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `:`).MatchString(text)
+	if !present {
+		return nil
+	}
+	value, err := requireYAMLKey(text, name, path)
+	if err != nil {
+		return err
+	}
+	if err := requireEqual(name, expected, ".github/workflows/ci.yml", value, path); err != nil {
+		return err
+	}
+	if needle == "" {
+		return nil
+	}
+	return requireTextRequirements(textRequirement{
+		text: text, needle: needle,
+		err: fmt.Errorf("%s must pin the BuildKit daemon image used by setup-buildx-action", path),
+	})
+}
+
+func (check *pinnedInputsCheck) validateReleaseManifestAndRuntimeSources() error {
+	if !strings.Contains(check.releaseWorkflow, "docker buildx imagetools create") {
+		return errors.New(".github/workflows/release.yml must assemble the published multi-arch manifest with docker buildx imagetools create")
+	}
+	if regexp.MustCompile(`docker/build-push-action@.*?platforms:\s*linux/amd64,linux/arm64`).MatchString(check.releaseWorkflow) {
+		return errors.New(".github/workflows/release.yml must not publish the final multi-arch image through one opaque multi-platform build-push step")
+	}
+	requirements := []textRequirement{
+		{
+			text: check.runtimeDockerfile, needle: "COPY runtime/container/rust /workcell-rust",
+			err: errors.New("runtime/container/Dockerfile must vendor the reviewed Rust runtime sources into the builder stage"),
+		},
+		{
+			text: check.runtimeDockerfile, needle: "COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo",
+			err: fmt.Errorf("runtime/container/Dockerfile must copy the pinned Rust toolchain through %q", "COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo"),
+		},
+		{
+			text: check.runtimeDockerfile, needle: "COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup",
+			err: fmt.Errorf("runtime/container/Dockerfile must copy the pinned Rust toolchain through %q", "COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup"),
+		},
+		{
+			text: check.runtimeDockerfile, needle: "COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json",
+			err: errors.New("runtime/container/Dockerfile must copy the reviewed control-plane manifest into the runtime image"),
+		},
+	}
+	return requireTextRequirements(requirements...)
+}
+
+func (check *pinnedInputsCheck) validateRuntimeCargoBuild() error {
+	hasOfflineCargoBuild := strings.Contains(check.runtimeDockerfile, "cargo build \\") ||
+		strings.Contains(check.runtimeDockerfile, "\"${toolchain_bin}/cargo\" build \\")
+	if !hasOfflineCargoBuild {
+		return errors.New("runtime/container/Dockerfile must build the shipped Rust launcher artifacts with cargo --locked --offline")
+	}
+	buildError := errors.New("runtime/container/Dockerfile must build the shipped Rust launcher artifacts with cargo --locked --offline")
+	return requireTextRequirements(
+		textRequirement{text: check.runtimeDockerfile, needle: "--locked \\", err: buildError},
+		textRequirement{text: check.runtimeDockerfile, needle: "--offline \\", err: buildError},
+		textRequirement{
+			text: check.runtimeDockerfile, needle: "CARGO_HOME=/workcell-rust/cargo-home",
+			err: errors.New("runtime/container/Dockerfile must isolate Cargo home inside the vendored runtime source tree"),
+		},
+	)
+}
+
+func (check *pinnedInputsCheck) validateReleaseRequiredSteps() error {
+	for _, needle := range []string{
+		"name: workcell-release-preflight",
+		"name: workcell-release-install-candidate",
+		"name: Release install verification (${{ matrix.runner_label }})",
+		"brew tap-new",
+		"brew --repo",
+		"brew install \"${tap_name}/workcell\"",
+		"macos-26",
+		"macos-15",
+		"actions/download-artifact@",
+		"context: dist/release-source",
+		"name: Re-verify pinned upstreams from archived source tree",
+		"name: Verify GitHub macOS release test runners",
+		"working-directory: dist/release-source",
+		"WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source",
+		"WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source",
+		"Verify published platform digests match preflight",
+		"docker buildx imagetools inspect --raw",
+		"{{json .Manifest}}",
+		"vnd.docker.reference.type",
+		"RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}",
+		"actions/attest@",
+		"Verify release bundle matches preflight",
+		"Verify control-plane manifest matches preflight",
+		"github/codeql-action/init@",
+		"github/codeql-action/analyze@",
+		"./scripts/publish-github-release.sh",
+	} {
+		if !strings.Contains(check.releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	return nil
+}
+
+func (check *pinnedInputsCheck) validateReleaseArtifactFlows() error {
+	if strings.Contains(check.releaseWorkflow, "{{json .manifest}}") {
+		return errors.New(".github/workflows/release.yml must not use the unsupported lowercase Buildx .manifest template field")
+	}
+	bundleError := errors.New(".github/workflows/release.yml must publish direct signature bundles for release artifacts")
+	if err := requireTextRequirements(
+		textRequirement{text: check.releaseWorkflow, needle: "dist/${{ env.BUNDLE_NAME }}.sigstore.json", err: bundleError},
+		textRequirement{text: check.releaseWorkflow, needle: "dist/workcell-control-plane.sigstore.json", err: bundleError},
+		textRequirement{text: check.releaseWorkflow, needle: "dist/workcell-image.digest.sigstore.json", err: bundleError},
+		textRequirement{text: check.releaseWorkflow, needle: "dist/workcell-source.spdx.sigstore.json", err: bundleError},
+		textRequirement{text: check.releaseWorkflow, needle: "dist/workcell-image.spdx.sigstore.json", err: bundleError},
+	); err != nil {
+		return err
+	}
+	return firstPinnedInputError(
+		func() error { return ValidateReleaseWorkflowControlPlaneFlow(check.releaseWorkflow) },
+		func() error {
+			return ValidateMacOSInstallVerificationFlow(check.releaseWorkflow, ".github/workflows/release.yml", "workcell-release-install-candidate", "name: Release install verification (${{ matrix.runner_label }})")
+		},
+		func() error { return ValidateReleaseWorkflowGitHubAttestationFlow(check.releaseWorkflow) },
+		func() error { return ValidateReleaseWorkflowPublicationGate(check.releaseWorkflow) },
+	)
+}
+
+func (check *pinnedInputsCheck) validateReleaseLegacyReferences() error {
+	if err := requireTextRequirements(
+		textRequirement{
+			text: check.releaseWorkflow, needle: "steps.build.outputs.digest", forbidden: true,
+			err: errors.New(".github/workflows/release.yml must not keep referencing the old single-step multi-platform digest output"),
+		},
+		textRequirement{
+			text: check.releaseWorkflow, needle: "gh release ", forbidden: true,
+			err: errors.New(".github/workflows/release.yml must not depend on an ambient gh CLI; use a pinned release-publish action"),
+		},
+		textRequirement{
+			text: check.releaseWorkflow, needle: "./scripts/publish-github-release.sh",
+			err: errors.New(".github/workflows/release.yml must publish assets through the reviewed repo-local GitHub Release API script"),
+		},
+	); err != nil {
+		return err
+	}
+	if count := strings.Count(check.releaseWorkflow, "./scripts/check-release-tag-signature.sh --github-repo"); count != 2 {
+		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures in preflight and publish jobs, found %d checks", count)
+	}
+	return nil
+}
+
+func (check *pinnedInputsCheck) validateReleaseHostedControls() error {
+	if err := requireTextRequirements(
+		textRequirement{
+			text: check.releaseWorkflow, needle: `run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+			err: fmt.Errorf(".github/workflows/release.yml must contain %q", `run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`),
+		},
+		textRequirement{
+			text: check.releaseWorkflow, needle: `WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
+			err: fmt.Errorf(".github/workflows/release.yml must contain %q", `WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`),
+		},
+		textRequirement{
+			text: check.releaseWorkflow, needle: `WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
+			err: fmt.Errorf(".github/workflows/release.yml must contain %q", `WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`),
+		},
+		textRequirement{
+			text: check.releaseWorkflow, needle: `--immutable-releases-preverified-by-hosted-controls`,
+			err: fmt.Errorf(".github/workflows/release.yml must contain %q", `--immutable-releases-preverified-by-hosted-controls`),
+		},
+		textRequirement{
+			text: check.releaseWorkflow, needle: "environment:\n      name: hosted-controls-audit",
+			err: errors.New(".github/workflows/release.yml release preflight must bind to the hosted-controls-audit environment"),
+		},
+	); err != nil {
+		return err
+	}
+	return ValidateUpstreamRefreshWorkflow(check.upstreamRefreshWorkflow)
+}
+
+func (check *pinnedInputsCheck) validateHostedControlsWorkflow() error {
+	workflow, err := readText(filepath.Join(check.cfg.WorkflowsDir, "hosted-controls.yml"))
+	if err != nil {
+		return err
+	}
+	for _, needle := range []string{
+		`name: hosted-controls-audit`,
+		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
+		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
+	} {
+		if !strings.Contains(workflow, needle) {
+			return fmt.Errorf(".github/workflows/hosted-controls.yml must contain %q", needle)
+		}
+	}
+	return nil
+}
+
+func (check *pinnedInputsCheck) validateReleaseVerificationJobs() error {
+	requirements := []textRequirement{
+		requiredText(check.releaseWorkflow, "./scripts/verify-github-macos-release-test-runners.sh", ".github/workflows/release.yml"),
+		requiredText(check.releaseWorkflow, "./scripts/verify-upstream-codex-release.sh", ".github/workflows/release.yml"),
+		requiredText(check.releaseWorkflow, "./scripts/verify-upstream-claude-release.sh", ".github/workflows/release.yml"),
+		requiredText(check.releaseWorkflow, "./scripts/verify-upstream-copilot-release.sh", ".github/workflows/release.yml"),
+		requiredText(check.releaseWorkflow, "./scripts/verify-upstream-gemini-release.sh", ".github/workflows/release.yml"),
+		requiredText(check.releaseWorkflow, "./scripts/update-upstream-pins.sh --check", ".github/workflows/release.yml"),
+		requiredText(check.pinHygieneWorkflow, "./scripts/ci/job-pin-hygiene.sh", ".github/workflows/pin-hygiene.yml"),
+	}
+	if err := requireTextRequirements(requirements...); err != nil {
+		return err
+	}
+	pinHygieneJob, err := readText(filepath.Join(check.repoRoot, "scripts", "ci", "job-pin-hygiene.sh"))
+	if err != nil {
+		return err
+	}
+	validateJob, err := readText(filepath.Join(check.repoRoot, "scripts", "ci", "job-validate.sh"))
+	if err != nil {
+		return err
+	}
+	requirements = []textRequirement{
+		requiredText(pinHygieneJob, "${ROOT_DIR}/scripts/verify-upstream-codex-release.sh", "scripts/ci/job-pin-hygiene.sh"),
+		requiredText(pinHygieneJob, "${ROOT_DIR}/scripts/verify-upstream-claude-release.sh", "scripts/ci/job-pin-hygiene.sh"),
+		requiredText(pinHygieneJob, "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh", "scripts/ci/job-pin-hygiene.sh"),
+		requiredText(pinHygieneJob, "${ROOT_DIR}/scripts/verify-upstream-gemini-release.sh", "scripts/ci/job-pin-hygiene.sh"),
+		requiredText(validateJob, `WORKCELL_COPILOT_RELEASE_HELP_MODE=checksum "${ROOT_DIR}/scripts/verify-upstream-copilot-release.sh"`, "scripts/ci/job-validate.sh"),
+		requiredText(validateJob, "unset WORKCELL_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN", "scripts/ci/job-validate.sh"),
+	}
+	return requireTextRequirements(requirements...)
+}
+
+func (check *pinnedInputsCheck) validateReleasePublishingInputs() error {
+	for _, needle := range []string{
+		"environment:\n      name: release",
+		`sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign`,
+		`sudo install -m 0755 "$(command -v syft)" /usr/local/bin/syft`,
+		`actionlint_archive="${RUNNER_TEMP}/actionlint.tar.gz"`,
+		`tar -xzf "${actionlint_archive}" -C "${RUNNER_TEMP}" actionlint`,
+		"git -c safe.directory=/workspace archive \\",
+	} {
+		if !strings.Contains(check.releaseWorkflow, needle) {
+			return fmt.Errorf(".github/workflows/release.yml must contain %q", needle)
+		}
+	}
+	return nil
+}
+
+func (check *pinnedInputsCheck) validateWorkflowPolicies() error {
+	for _, workflowPath := range workflowYAMLFiles(check.cfg.WorkflowsDir) {
+		text, err := readText(workflowPath)
+		if err != nil {
+			return err
+		}
+		if err := check.validateWorkflowPolicy(text, workflowPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (check *pinnedInputsCheck) validateWorkflowPolicy(text, path string) error {
+	if !workflowPermissionsRE.MatchString(text) {
+		return fmt.Errorf("workflow-level empty permissions declaration missing in %s", path)
+	}
+	if strings.Contains(text, "pull_request_target") {
+		if err := IsSafePullRequestTargetWorkflow(text, path); err != nil {
+			return err
+		}
+	}
+	if regexp.MustCompile(`secrets\.[A-Z0-9_]*(?:PAT|PERSONAL_ACCESS_TOKEN)\b|GH_PAT\b|PERSONAL_ACCESS_TOKEN\b`).MatchString(text) {
+		return fmt.Errorf("%s must not contain long-lived personal access tokens", path)
+	}
+	return validateWorkflowActions(text, path, check.allowedActions)
+}
+
+func validateWorkflowActions(text, path string, allowed map[string]bool) error {
+	refs, err := extractWorkflowUses(text)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	for _, ref := range refs {
+		if err := validateWorkflowAction(ref, path, allowed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWorkflowAction(ref, path string, allowed map[string]bool) error {
+	action := actionRefPattern.FindStringSubmatch(ref)
+	if action == nil {
+		return fmt.Errorf("%s has an unsupported uses: reference %q; only pinned owner/repo actions are permitted (no docker:// or local ./ actions)", path, ref)
+	}
+	if !commitShaPattern.MatchString(action[2]) {
+		return fmt.Errorf("%s must pin GitHub Actions by full commit SHA; found %s@%s", path, action[1], action[2])
+	}
+	segments := strings.SplitN(action[1], "/", 3)
+	ownerRepo := segments[0] + "/" + segments[1]
+	if !allowed[ownerRepo] {
+		return fmt.Errorf("%s uses action %q which is not in the reviewed allowlist policy/allowed-actions.toml", path, ownerRepo)
+	}
+	return nil
+}
+
+func (check *pinnedInputsCheck) validateCodeownersAndHostedPolicy() error {
+	for _, required := range []string{
+		"/.github/workflows/ @omkhar",
+		"/scripts/ @omkhar",
+		"/runtime/container/ @omkhar",
+		"/docs/provenance.md @omkhar",
+	} {
+		if !strings.Contains(check.codeowners, required) {
+			return fmt.Errorf(".github/CODEOWNERS must declare high-risk ownership for %q", required)
+		}
+	}
+	releaseEnvironment, _ := check.hostedControlsPolicy["release_environment"].(map[string]any)
+	releaseMode, _ := releaseEnvironment["mode"].(string)
+	allowedModes := map[string]bool{
+		"review-gated": true, "single-owner-public": true,
+		"single-owner-private": true, "plan-limited-private": true,
+	}
+	if !allowedModes[releaseMode] {
+		return errors.New("policy/github-hosted-controls.toml must set release_environment.mode to 'review-gated', 'single-owner-public', 'single-owner-private', or 'plan-limited-private'")
+	}
+	return firstPinnedInputError(
+		func() error {
+			_, err := GitHubActionsPolicy(check.hostedControlsPolicy, "policy/github-hosted-controls.toml")
+			return err
+		},
+		func() error {
+			_, err := ReleaseAssets(check.hostedControlsPolicy, "policy/github-hosted-controls.toml")
+			return err
+		},
+		func() error {
+			return ValidateCanonicalRepositoryVariables(check.hostedControlsPolicy, "policy/github-hosted-controls.toml")
+		},
+		func() error {
+			return ValidateCanonicalWorkflowEnvironments(check.hostedControlsPolicy, "policy/github-hosted-controls.toml")
+		},
+		func() error { return validateCanonicalHostedControlsScript(check.hostedControlsScript) },
+		func() error {
+			return requireNoRegistryBootstrapMCP(check.codexRequirementsText, check.cfg.CodexRequirementsPath)
+		},
+		func() error {
+			return requireNoRegistryBootstrapMCP(check.codexMCPConfigText, check.cfg.CodexMCPConfigPath)
+		},
+	)
+}

--- a/internal/metadatautil/pinnedinputs_precedence_test.go
+++ b/internal/metadatautil/pinnedinputs_precedence_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckPinnedInputsPreservesCompoundReadFailurePrecedence(t *testing.T) {
+	cfg := writePinnedInputsFixture(t)
+	if err := os.Remove(cfg.RuntimeDockerfilePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(cfg.ValidatorDockerfilePath); err != nil {
+		t.Fatal(err)
+	}
+	err := metadatautil.CheckPinnedInputs(cfg)
+	want := (&os.PathError{Op: "open", Path: cfg.RuntimeDockerfilePath, Err: syscall.ENOENT}).Error()
+	if err == nil || err.Error() != want {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want first read failure %q", err, want)
+	}
+}
+
+func TestCheckPinnedInputsPreservesCompoundParseFailurePrecedence(t *testing.T) {
+	cfg := writePinnedInputsFixture(t)
+	rewriteFile(t, cfg.ProvidersPackageJSONPath, func(string) string { return "{" })
+	rewriteFile(t, cfg.ProvidersPackageLockPath, func(string) string { return "!" })
+	err := metadatautil.CheckPinnedInputs(cfg)
+	if err == nil || err.Error() != "unexpected end of JSON input" {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want first JSON parse failure", err)
+	}
+}
+
+func TestCheckPinnedInputsPreservesCompoundValidationFailurePrecedence(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(testing.TB, metadatautil.PinnedInputsConfig)
+		want   func(metadatautil.PinnedInputsConfig) string
+	}{
+		{
+			name: "rust version before image",
+			mutate: func(tb testing.TB, cfg metadatautil.PinnedInputsConfig) {
+				rewriteFile(tb, cfg.RuntimeDockerfilePath, func(content string) string {
+					content = replaceFirstMatch(tb, content, regexp.MustCompile(`(?m)^ARG RUST_VERSION=.*$`), "ARG RUST_VERSION=1.2.3")
+					return replaceFirstMatch(tb, content, regexp.MustCompile(`(?m)^ARG RUST_TOOLCHAIN_IMAGE=.*$`), "ARG RUST_TOOLCHAIN_IMAGE=not-pinned")
+				})
+				rewriteFile(tb, cfg.ValidatorDockerfilePath, func(content string) string {
+					return replaceFirstMatch(tb, content, regexp.MustCompile(`(?m)^ARG RUST_VERSION=.*$`), "ARG RUST_VERSION=9.9.9")
+				})
+			},
+			want: func(cfg metadatautil.PinnedInputsConfig) string {
+				return fmt.Sprintf("RUST_VERSION must match between %s (%q) and %s (%q)", cfg.RuntimeDockerfilePath, "1.2.3", cfg.ValidatorDockerfilePath, "9.9.9")
+			},
+		},
+		{
+			name: "actionlint version before digest",
+			mutate: func(tb testing.TB, cfg metadatautil.PinnedInputsConfig) {
+				securityPath := filepath.Join(cfg.WorkflowsDir, "security.yml")
+				rewriteFile(tb, securityPath, func(content string) string {
+					content = replaceAllMatches(tb, content, regexp.MustCompile(`ACTIONLINT_VERSION: [0-9]+\.[0-9]+\.[0-9]+`), "ACTIONLINT_VERSION: 0.0.0")
+					return replaceAllMatches(tb, content, regexp.MustCompile(`ACTIONLINT_SHA256: [0-9a-f]{64}`), "ACTIONLINT_SHA256: deadbeef")
+				})
+			},
+			want: func(metadatautil.PinnedInputsConfig) string {
+				return "ACTIONLINT_VERSION must match between .github/workflows/security.yml and .github/workflows/release.yml"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := writePinnedInputsFixture(t)
+			test.mutate(t, cfg)
+			err := metadatautil.CheckPinnedInputs(cfg)
+			if err == nil || err.Error() != test.want(cfg) {
+				t.Fatalf("metadatautil.CheckPinnedInputs() error = %v, want %q", err, test.want(cfg))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Split workflow checks out of `CheckPinnedInputs` into focused helpers. Preserve input reads, parsing order, validation order, and error messages.

Add compound-failure tests for read, parse, Rust-version, and actionlint-version precedence. Existing checks still enforce pinned action references, tool versions, image digests, and download bounds.

## Complexity audit

Measured both revisions with `gocyclo` v0.6.0 and the same production scope:

- `CheckPinnedInputs`: 202 to 97.
- Total complexity: 231 to 212.
- Decision count: 213 to 174.
- Each added helper has complexity at most 5.

This is the first of two bounded refactor units. The next unit completes the build-check extraction and further reduces the remaining function.

## Validation

- Full Go tests and `go vet` passed.
- Metadata race tests and mutation checks passed.
- Pinned-input, workflow, dead-code, public-contract, and operator-contract checks passed.
- Compound-failure tests preserve observable error precedence.
- Three success-path benchmark samples showed no runtime slowdown, near 22 ms per check. Allocations increased by about 0.28 percent.
- Local `pr-parity` passed for this commit and current `main`, including live host invariants, documentation checks, and container smoke.
