### PR TITLE
.R Split hosted-control core validation

### DIFF
--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -432,54 +432,16 @@ func rejectReleaseAdminBypass(releaseEnv, adminBypassRule map[string]any, repo s
 }
 
 func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
-	var repoMeta map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "repo.json"), &repoMeta); err != nil {
-		return err
-	}
-	var actionsPermissions map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "actions-permissions.json"), &actionsPermissions); err != nil {
-		return err
-	}
-	var selectedActions map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "actions-selected-actions.json"), &selectedActions); err != nil {
-		return err
-	}
-	var workflowPermissions map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "actions-workflow-permissions.json"), &workflowPermissions); err != nil {
-		return err
-	}
-	var immutableReleases map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "immutable-releases.json"), &immutableReleases); err != nil {
-		return err
-	}
-	var actionsVariables map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "actions-variables.json"), &actionsVariables); err != nil {
-		return err
-	}
-	var environmentsIndex map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "environments.json"), &environmentsIndex); err != nil {
-		return err
-	}
-	var directCollaborators []any
-	if err := readJSONFile(filepath.Join(tmpDir, "collaborators-direct.json"), &directCollaborators); err != nil {
-		return err
-	}
-	var rulesets []any
-	if err := readJSONFile(filepath.Join(tmpDir, "rulesets.json"), &rulesets); err != nil {
-		return err
-	}
-	var releaseEnv map[string]any
-	if err := readJSONFile(filepath.Join(tmpDir, "environment-release.json"), &releaseEnv); err != nil {
-		return err
-	}
-	policyContent, err := os.ReadFile(policyPath)
+	inputs, err := loadHostedControlInputs(tmpDir, policyPath)
 	if err != nil {
 		return err
 	}
-	policy, err := tomlsubset.Parse(string(policyContent), policyPath)
-	if err != nil {
-		return err
-	}
+	repoMeta := inputs.repoMeta
+	actionsVariables := inputs.actionsVariables
+	environmentsIndex := inputs.environmentsIndex
+	directCollaborators := inputs.directCollaborators
+	releaseEnv := inputs.releaseEnvironment
+	policy := inputs.policy
 
 	owner, _ := repoMeta["owner"].(map[string]any)
 	ownerLogin, _ := owner["login"].(string)
@@ -548,223 +510,11 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return err
 	}
 
-	if enabled, _ := actionsPermissions["enabled"].(bool); !enabled {
-		return fmt.Errorf("GitHub Actions must be enabled on %s", repo)
-	}
-	if required, _ := actionsPermissions["sha_pinning_required"].(bool); !required {
-		return fmt.Errorf("GitHub Actions SHA pinning must be required on %s", repo)
-	}
-	if actionsPolicy.AllowOnlyPinnedVerifiedOrExplicitlyTrustedActions {
-		if allowedActions, _ := actionsPermissions["allowed_actions"].(string); allowedActions != "selected" {
-			return fmt.Errorf("GitHub Actions on %s must restrict allowed_actions to selected", repo)
-		}
-		if githubOwnedAllowed, _ := selectedActions["github_owned_allowed"].(bool); !githubOwnedAllowed {
-			return fmt.Errorf("GitHub Actions selected policy on %s must allow GitHub-owned actions", repo)
-		}
-		if verifiedAllowed, _ := selectedActions["verified_allowed"].(bool); !verifiedAllowed {
-			return fmt.Errorf("GitHub Actions selected policy on %s must allow verified creator actions", repo)
-		}
-		patternsAllowed, _ := selectedActions["patterns_allowed"].([]any)
-		unexpectedPatterns := make([]string, 0)
-		for _, raw := range patternsAllowed {
-			if pattern, _ := raw.(string); pattern != "" {
-				unexpectedPatterns = append(unexpectedPatterns, pattern)
-			}
-		}
-		slices.Sort(unexpectedPatterns)
-		if len(unexpectedPatterns) > 0 {
-			return fmt.Errorf("GitHub Actions selected policy on %s must not allow unreviewed action patterns: %s", repo, strings.Join(unexpectedPatterns, ", "))
-		}
-	}
-	if actual, _ := workflowPermissions["default_workflow_permissions"].(string); actual != actionsPolicy.DefaultWorkflowTokenPermissions {
-		return fmt.Errorf("GitHub Actions default workflow token permissions on %s must be %q", repo, actionsPolicy.DefaultWorkflowTokenPermissions)
-	}
-	if canApprove, _ := workflowPermissions["can_approve_pull_request_reviews"].(bool); canApprove {
-		return fmt.Errorf("GitHub Actions workflow token on %s must not be allowed to approve pull requests", repo)
-	}
-	if releaseAssetsPolicy.ImmutableGitHubReleases {
-		if enabled, _ := immutableReleases["enabled"].(bool); !enabled {
-			return fmt.Errorf("immutable GitHub releases must be enabled on %s", repo)
-		}
-	}
-
-	activeRulesets := make([]map[string]any, 0)
-	for _, raw := range rulesets {
-		entry, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if enforcement, _ := entry["enforcement"].(string); enforcement == "active" {
-			activeRulesets = append(activeRulesets, entry)
-		}
-	}
-	if len(activeRulesets) == 0 {
-		return fmt.Errorf("no active rulesets found on %s", repo)
-	}
-
-	hasRefInclude := func(ruleset map[string]any, expected string) bool {
-		conditions, _ := ruleset["conditions"].(map[string]any)
-		refName, _ := conditions["ref_name"].(map[string]any)
-		include, _ := refName["include"].([]any)
-		for _, raw := range include {
-			if s, _ := raw.(string); s == expected {
-				return true
-			}
-		}
-		return false
-	}
-	hasRule := func(ruleset map[string]any, ruleType string) map[string]any {
-		rules, _ := ruleset["rules"].([]any)
-		for _, raw := range rules {
-			entry, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			if typ, _ := entry["type"].(string); typ == ruleType {
-				return entry
-			}
-		}
-		return nil
-	}
-	requireBypassShape := func(ruleset map[string]any, actorType, bypassMode string, requireNonEmpty bool) error {
-		actors, _ := ruleset["bypass_actors"].([]any)
-		if requireNonEmpty && len(actors) == 0 {
-			return fmt.Errorf("ruleset %v on %s must declare an explicit bypass actor", ruleset["name"], repo)
-		}
-		for _, raw := range actors {
-			entry, ok := raw.(map[string]any)
-			if !ok {
-				return fmt.Errorf("ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
-			}
-			if at, _ := entry["actor_type"].(string); at != actorType {
-				return fmt.Errorf("ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
-			}
-			if bm, _ := entry["bypass_mode"].(string); bm != bypassMode {
-				return fmt.Errorf("ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
-			}
-		}
-		return nil
-	}
-
-	var branchIntegrity, branchReview, branchStatusChecks, tagRelease map[string]any
-	for _, ruleset := range activeRulesets {
-		target, _ := ruleset["target"].(string)
-		if target == "branch" && hasRefInclude(ruleset, "~DEFAULT_BRANCH") {
-			if hasRule(ruleset, "required_signatures") != nil && hasRule(ruleset, "non_fast_forward") != nil && hasRule(ruleset, "deletion") != nil {
-				branchIntegrity = ruleset
-			}
-			if hasRule(ruleset, "pull_request") != nil {
-				branchReview = ruleset
-			}
-			if hasRule(ruleset, "required_status_checks") != nil {
-				branchStatusChecks = ruleset
-			}
-		}
-		if target == "tag" && hasRefInclude(ruleset, "refs/tags/v*") {
-			if hasRule(ruleset, "creation") != nil && hasRule(ruleset, "update") != nil && hasRule(ruleset, "deletion") != nil {
-				tagRelease = ruleset
-			}
-		}
-	}
-	if branchIntegrity == nil {
-		return fmt.Errorf("missing active default-branch integrity ruleset on %s with required_signatures, non_fast_forward, and deletion", repo)
-	}
-	if branchReview == nil {
-		return fmt.Errorf("missing active default-branch review ruleset on %s with a pull_request rule", repo)
-	}
-	if branchStatusChecks == nil {
-		return fmt.Errorf("missing active default-branch status-check ruleset on %s with a required_status_checks rule", repo)
-	}
-	if actors, _ := branchIntegrity["bypass_actors"].([]any); len(actors) > 0 {
-		return fmt.Errorf("default-branch integrity ruleset on %s must not declare bypass actors", repo)
-	}
-	if err := requireBypassShape(branchReview, "RepositoryRole", "pull_request", false); err != nil {
+	if err := verifyGitHubActionsControls(inputs, actionsPolicy, releaseAssetsPolicy, repo); err != nil {
 		return err
 	}
-	if tagRelease == nil {
-		return fmt.Errorf("missing active release-tag ruleset on %s for refs/tags/v* with creation/update/deletion protection", repo)
-	}
-	if err := requireBypassShape(tagRelease, "RepositoryRole", "always", true); err != nil {
+	if err := verifyHostedRulesetControls(inputs, branchReviewMode, ownerType, expectedContexts, requireSingleOwnerCollaborator, repo); err != nil {
 		return err
-	}
-
-	pullRequestRule := hasRule(branchReview, "pull_request")
-	parameters, _ := pullRequestRule["parameters"].(map[string]any)
-	if branchReviewMode == "review-gated" {
-		if count, _ := parameters["required_approving_review_count"].(float64); count < 1 {
-			return fmt.Errorf("default-branch review ruleset on %s must require at least one approving review", repo)
-		}
-		if required, _ := parameters["require_code_owner_review"].(bool); !required {
-			return fmt.Errorf("default-branch review ruleset on %s must require code owner review", repo)
-		}
-		if resolved, _ := parameters["required_review_thread_resolution"].(bool); !resolved {
-			return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads", repo)
-		}
-	} else {
-		if branchReviewMode == "single-owner-private-pr" {
-			if private, _ := repoMeta["private"].(bool); !private {
-				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for private repositories", repo)
-			}
-			if ownerType != "User" {
-				return fmt.Errorf("branch review mode 'single-owner-private-pr' on %s is only valid for user-owned repositories", repo)
-			}
-			if err := requireSingleOwnerCollaborator("branch review mode 'single-owner-private-pr'"); err != nil {
-				return err
-			}
-		} else {
-			if private, _ := repoMeta["private"].(bool); private {
-				return fmt.Errorf("branch review mode 'single-owner-public-pr' on %s is only valid for public repositories", repo)
-			}
-			if ownerType != "User" {
-				return fmt.Errorf("branch review mode 'single-owner-public-pr' on %s is only valid for user-owned repositories", repo)
-			}
-			if err := requireSingleOwnerCollaborator("branch review mode 'single-owner-public-pr'"); err != nil {
-				return err
-			}
-		}
-		if count, _ := parameters["required_approving_review_count"].(float64); count != 0 {
-			return fmt.Errorf("default-branch review ruleset on %s must require zero approving reviews in %s mode", repo, branchReviewMode)
-		}
-		if required, _ := parameters["require_code_owner_review"].(bool); required {
-			return fmt.Errorf("default-branch review ruleset on %s must not require code owner review in %s mode", repo, branchReviewMode)
-		}
-		if lastPushApproval, _ := parameters["require_last_push_approval"].(bool); lastPushApproval {
-			return fmt.Errorf("default-branch review ruleset on %s must not require last-push approval in %s mode", repo, branchReviewMode)
-		}
-		resolved, _ := parameters["required_review_thread_resolution"].(bool)
-		if branchReviewMode == "single-owner-public-pr" && !resolved {
-			return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads in single-owner-public-pr mode", repo)
-		}
-		if branchReviewMode == "single-owner-private-pr" && resolved {
-			return fmt.Errorf("default-branch review ruleset on %s must not require resolved review threads in single-owner-private-pr mode", repo)
-		}
-	}
-
-	statusRule := hasRule(branchStatusChecks, "required_status_checks")
-	statusParameters, _ := statusRule["parameters"].(map[string]any)
-	if strict, _ := statusParameters["strict_required_status_checks_policy"].(bool); !strict {
-		return fmt.Errorf("default-branch status-check ruleset on %s must require strict status checks", repo)
-	}
-	requiredStatusChecks, _ := statusParameters["required_status_checks"].([]any)
-	actualStatus := map[string]struct{}{}
-	for _, raw := range requiredStatusChecks {
-		entry, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if context, _ := entry["context"].(string); context != "" {
-			actualStatus[context] = struct{}{}
-		}
-	}
-	missingStatus := make([]string, 0)
-	for _, expected := range expectedContexts {
-		if _, ok := actualStatus[expected]; !ok {
-			missingStatus = append(missingStatus, expected)
-		}
-	}
-	slices.Sort(missingStatus)
-	if len(missingStatus) > 0 {
-		return fmt.Errorf("default-branch status-check ruleset on %s is missing required contexts: %s", repo, strings.Join(missingStatus, ", "))
 	}
 
 	actualRepoVariables := map[string]any{}

--- a/internal/metadatautil/hostedcontrols_dispatch_test.go
+++ b/internal/metadatautil/hostedcontrols_dispatch_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestHostedControlDispatchPreservesInputReadOrder(t *testing.T) {
+	t.Parallel()
+	root, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", singleOwnerCollaborator())
+	first := filepath.Join(root, "actions-permissions.json")
+	second := filepath.Join(root, "actions-selected-actions.json")
+	for _, path := range []string{first, second} {
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := metadatautil.VerifyGitHubHostedControls(root, "omkhar/workcell", policyPath)
+	var pathError *os.PathError
+	if !errors.As(err, &pathError) || pathError.Path != first {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want first read failure for %s", err, first)
+	}
+}
+
+func TestHostedControlDispatchPreservesActionsBeforeRulesets(t *testing.T) {
+	t.Parallel()
+	root, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", singleOwnerCollaborator())
+	rewriteFile(t, filepath.Join(root, "actions-permissions.json"), func(content string) string {
+		return strings.Replace(content, "\"allowed_actions\": \"selected\"", "\"allowed_actions\": \"all\"", 1)
+	})
+	rewriteFile(t, filepath.Join(root, "rulesets.json"), func(content string) string {
+		return strings.Replace(content, "\"type\": \"required_signatures\"", "\"type\": \"attacker-rule\"", 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(root, "omkhar/workcell", policyPath)
+	want := "GitHub Actions on omkhar/workcell must restrict allowed_actions to selected"
+	if err == nil || err.Error() != want {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want %q", err, want)
+	}
+}
+
+func TestHostedControlDispatchPreservesRulesetsBeforeVariables(t *testing.T) {
+	t.Parallel()
+	root, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", singleOwnerCollaborator())
+	rewriteFile(t, filepath.Join(root, "rulesets.json"), func(content string) string {
+		return strings.Replace(content, "\"require_code_owner_review\": true", "\"require_code_owner_review\": false", 1)
+	})
+	rewriteFile(t, filepath.Join(root, "actions-variables.json"), func(content string) string {
+		return strings.Replace(content, "\"value\": \"false\"", "\"value\": \"wrong\"", 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(root, "omkhar/workcell", policyPath)
+	want := "default-branch review ruleset on omkhar/workcell must require code owner review"
+	if err == nil || err.Error() != want {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want %q", err, want)
+	}
+}
+
+func singleOwnerCollaborator() []map[string]any {
+	return []map[string]any{{
+		"login": "omkhar",
+		"permissions": map[string]any{
+			"admin": true,
+		},
+	}}
+}

--- a/internal/metadatautil/hostedcontrols_verify.go
+++ b/internal/metadatautil/hostedcontrols_verify.go
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/tomlsubset"
+)
+
+type hostedControlInputs struct {
+	repoMeta            map[string]any
+	actionsPermissions  map[string]any
+	selectedActions     map[string]any
+	workflowPermissions map[string]any
+	immutableReleases   map[string]any
+	actionsVariables    map[string]any
+	environmentsIndex   map[string]any
+	directCollaborators []any
+	rulesets            []any
+	releaseEnvironment  map[string]any
+	policy              map[string]any
+}
+
+type hostedRulesetControls struct {
+	branchIntegrity    map[string]any
+	branchReview       map[string]any
+	branchStatusChecks map[string]any
+	tagRelease         map[string]any
+}
+
+func loadHostedControlInputs(tmpDir, policyPath string) (hostedControlInputs, error) {
+	var inputs hostedControlInputs
+	artifacts := []struct {
+		name   string
+		target any
+	}{
+		{"repo.json", &inputs.repoMeta},
+		{"actions-permissions.json", &inputs.actionsPermissions},
+		{"actions-selected-actions.json", &inputs.selectedActions},
+		{"actions-workflow-permissions.json", &inputs.workflowPermissions},
+		{"immutable-releases.json", &inputs.immutableReleases},
+		{"actions-variables.json", &inputs.actionsVariables},
+		{"environments.json", &inputs.environmentsIndex},
+		{"collaborators-direct.json", &inputs.directCollaborators},
+		{"rulesets.json", &inputs.rulesets},
+		{"environment-release.json", &inputs.releaseEnvironment},
+	}
+	for _, artifact := range artifacts {
+		if err := readJSONFile(filepath.Join(tmpDir, artifact.name), artifact.target); err != nil {
+			return hostedControlInputs{}, err
+		}
+	}
+	content, err := os.ReadFile(policyPath)
+	if err != nil {
+		return hostedControlInputs{}, err
+	}
+	inputs.policy, err = tomlsubset.Parse(string(content), policyPath)
+	return inputs, err
+}
+
+func verifyGitHubActionsControls(inputs hostedControlInputs, actionsPolicy ActionsPolicy, releasePolicy ReleaseAssetsPolicy, repo string) error {
+	if err := verifyActionsAvailability(inputs.actionsPermissions, repo); err != nil {
+		return err
+	}
+	if err := verifySelectedActions(inputs.actionsPermissions, inputs.selectedActions, actionsPolicy, repo); err != nil {
+		return err
+	}
+	if err := verifyWorkflowPermissions(inputs.workflowPermissions, actionsPolicy, repo); err != nil {
+		return err
+	}
+	return verifyImmutableReleases(inputs.immutableReleases, releasePolicy, repo)
+}
+
+func verifyActionsAvailability(actual map[string]any, repo string) error {
+	if enabled, _ := actual["enabled"].(bool); !enabled {
+		return fmt.Errorf("GitHub Actions must be enabled on %s", repo)
+	}
+	if required, _ := actual["sha_pinning_required"].(bool); !required {
+		return fmt.Errorf("GitHub Actions SHA pinning must be required on %s", repo)
+	}
+	return nil
+}
+
+func verifySelectedActions(actual, selected map[string]any, policy ActionsPolicy, repo string) error {
+	if !policy.AllowOnlyPinnedVerifiedOrExplicitlyTrustedActions {
+		return nil
+	}
+	if allowed, _ := actual["allowed_actions"].(string); allowed != "selected" {
+		return fmt.Errorf("GitHub Actions on %s must restrict allowed_actions to selected", repo)
+	}
+	if allowed, _ := selected["github_owned_allowed"].(bool); !allowed {
+		return fmt.Errorf("GitHub Actions selected policy on %s must allow GitHub-owned actions", repo)
+	}
+	if allowed, _ := selected["verified_allowed"].(bool); !allowed {
+		return fmt.Errorf("GitHub Actions selected policy on %s must allow verified creator actions", repo)
+	}
+	return rejectSelectedActionPatterns(selected, repo)
+}
+
+func rejectSelectedActionPatterns(selected map[string]any, repo string) error {
+	patterns, _ := selected["patterns_allowed"].([]any)
+	unexpected := make([]string, 0)
+	for _, raw := range patterns {
+		if pattern, _ := raw.(string); pattern != "" {
+			unexpected = append(unexpected, pattern)
+		}
+	}
+	slices.Sort(unexpected)
+	if len(unexpected) > 0 {
+		return fmt.Errorf("GitHub Actions selected policy on %s must not allow unreviewed action patterns: %s", repo, strings.Join(unexpected, ", "))
+	}
+	return nil
+}
+
+func verifyWorkflowPermissions(actual map[string]any, policy ActionsPolicy, repo string) error {
+	if value, _ := actual["default_workflow_permissions"].(string); value != policy.DefaultWorkflowTokenPermissions {
+		return fmt.Errorf("GitHub Actions default workflow token permissions on %s must be %q", repo, policy.DefaultWorkflowTokenPermissions)
+	}
+	if canApprove, _ := actual["can_approve_pull_request_reviews"].(bool); canApprove {
+		return fmt.Errorf("GitHub Actions workflow token on %s must not be allowed to approve pull requests", repo)
+	}
+	return nil
+}
+
+func verifyImmutableReleases(actual map[string]any, policy ReleaseAssetsPolicy, repo string) error {
+	if policy.ImmutableGitHubReleases {
+		if enabled, _ := actual["enabled"].(bool); !enabled {
+			return fmt.Errorf("immutable GitHub releases must be enabled on %s", repo)
+		}
+	}
+	return nil
+}
+
+func verifyHostedRulesetControls(inputs hostedControlInputs, reviewMode, ownerType string, expectedContexts []string, requireOwner func(string) error, repo string) error {
+	active := activeHostedRulesets(inputs.rulesets)
+	if len(active) == 0 {
+		return fmt.Errorf("no active rulesets found on %s", repo)
+	}
+	controls := classifyHostedRulesets(active)
+	if err := verifyHostedRulesetShape(controls, repo); err != nil {
+		return err
+	}
+	if err := verifyBranchReviewRuleset(controls.branchReview, inputs.repoMeta, reviewMode, ownerType, requireOwner, repo); err != nil {
+		return err
+	}
+	return verifyRequiredStatusRuleset(controls.branchStatusChecks, expectedContexts, repo)
+}
+
+func activeHostedRulesets(rawRulesets []any) []map[string]any {
+	active := make([]map[string]any, 0)
+	for _, raw := range rawRulesets {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if enforcement, _ := entry["enforcement"].(string); enforcement == "active" {
+			active = append(active, entry)
+		}
+	}
+	return active
+}
+
+func classifyHostedRulesets(rulesets []map[string]any) hostedRulesetControls {
+	var controls hostedRulesetControls
+	for _, ruleset := range rulesets {
+		if isDefaultBranchRuleset(ruleset) {
+			classifyDefaultBranchRuleset(&controls, ruleset)
+		}
+		if isReleaseTagRuleset(ruleset) {
+			controls.tagRelease = ruleset
+		}
+	}
+	return controls
+}
+
+func isDefaultBranchRuleset(ruleset map[string]any) bool {
+	target, _ := ruleset["target"].(string)
+	return target == "branch" && hostedRulesetHasRef(ruleset, "~DEFAULT_BRANCH")
+}
+
+func isReleaseTagRuleset(ruleset map[string]any) bool {
+	target, _ := ruleset["target"].(string)
+	return target == "tag" && hostedRulesetHasRef(ruleset, "refs/tags/v*") && hasReleaseTagRules(ruleset)
+}
+
+func classifyDefaultBranchRuleset(controls *hostedRulesetControls, ruleset map[string]any) {
+	if hasIntegrityRules(ruleset) {
+		controls.branchIntegrity = ruleset
+	}
+	if hostedRulesetRule(ruleset, "pull_request") != nil {
+		controls.branchReview = ruleset
+	}
+	if hostedRulesetRule(ruleset, "required_status_checks") != nil {
+		controls.branchStatusChecks = ruleset
+	}
+}
+
+func hasIntegrityRules(ruleset map[string]any) bool {
+	return hostedRulesetRule(ruleset, "required_signatures") != nil &&
+		hostedRulesetRule(ruleset, "non_fast_forward") != nil &&
+		hostedRulesetRule(ruleset, "deletion") != nil
+}
+
+func hasReleaseTagRules(ruleset map[string]any) bool {
+	return hostedRulesetRule(ruleset, "creation") != nil &&
+		hostedRulesetRule(ruleset, "update") != nil &&
+		hostedRulesetRule(ruleset, "deletion") != nil
+}
+
+func hostedRulesetHasRef(ruleset map[string]any, expected string) bool {
+	conditions, _ := ruleset["conditions"].(map[string]any)
+	refName, _ := conditions["ref_name"].(map[string]any)
+	include, _ := refName["include"].([]any)
+	for _, raw := range include {
+		if value, _ := raw.(string); value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func hostedRulesetRule(ruleset map[string]any, ruleType string) map[string]any {
+	rules, _ := ruleset["rules"].([]any)
+	for _, raw := range rules {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if value, _ := entry["type"].(string); value == ruleType {
+			return entry
+		}
+	}
+	return nil
+}
+
+func verifyHostedRulesetShape(controls hostedRulesetControls, repo string) error {
+	if controls.branchIntegrity == nil {
+		return fmt.Errorf("missing active default-branch integrity ruleset on %s with required_signatures, non_fast_forward, and deletion", repo)
+	}
+	if controls.branchReview == nil {
+		return fmt.Errorf("missing active default-branch review ruleset on %s with a pull_request rule", repo)
+	}
+	if controls.branchStatusChecks == nil {
+		return fmt.Errorf("missing active default-branch status-check ruleset on %s with a required_status_checks rule", repo)
+	}
+	return verifyHostedRulesetBypasses(controls, repo)
+}
+
+func verifyHostedRulesetBypasses(controls hostedRulesetControls, repo string) error {
+	if actors, _ := controls.branchIntegrity["bypass_actors"].([]any); len(actors) > 0 {
+		return fmt.Errorf("default-branch integrity ruleset on %s must not declare bypass actors", repo)
+	}
+	if err := requireHostedBypassShape(controls.branchReview, "RepositoryRole", "pull_request", false, repo); err != nil {
+		return err
+	}
+	if controls.tagRelease == nil {
+		return fmt.Errorf("missing active release-tag ruleset on %s for refs/tags/v* with creation/update/deletion protection", repo)
+	}
+	return requireHostedBypassShape(controls.tagRelease, "RepositoryRole", "always", true, repo)
+}
+
+func requireHostedBypassShape(ruleset map[string]any, actorType, bypassMode string, requireNonEmpty bool, repo string) error {
+	actors, _ := ruleset["bypass_actors"].([]any)
+	if requireNonEmpty && len(actors) == 0 {
+		return fmt.Errorf("ruleset %v on %s must declare an explicit bypass actor", ruleset["name"], repo)
+	}
+	for _, raw := range actors {
+		if !hostedBypassActorMatches(raw, actorType, bypassMode) {
+			return fmt.Errorf("ruleset %v on %s must only use %s/%s bypass actors", ruleset["name"], repo, actorType, bypassMode)
+		}
+	}
+	return nil
+}
+
+func hostedBypassActorMatches(raw any, actorType, bypassMode string) bool {
+	entry, ok := raw.(map[string]any)
+	if !ok {
+		return false
+	}
+	actualType, _ := entry["actor_type"].(string)
+	actualMode, _ := entry["bypass_mode"].(string)
+	return actualType == actorType && actualMode == bypassMode
+}
+
+func verifyBranchReviewRuleset(ruleset, repoMeta map[string]any, mode, ownerType string, requireOwner func(string) error, repo string) error {
+	rule := hostedRulesetRule(ruleset, "pull_request")
+	parameters, _ := rule["parameters"].(map[string]any)
+	if mode == "review-gated" {
+		return verifyReviewGatedParameters(parameters, repo)
+	}
+	if err := verifySingleOwnerReviewMode(repoMeta, mode, ownerType, requireOwner, repo); err != nil {
+		return err
+	}
+	return verifySingleOwnerReviewParameters(parameters, mode, repo)
+}
+
+func verifyReviewGatedParameters(parameters map[string]any, repo string) error {
+	if count, _ := parameters["required_approving_review_count"].(float64); count < 1 {
+		return fmt.Errorf("default-branch review ruleset on %s must require at least one approving review", repo)
+	}
+	if required, _ := parameters["require_code_owner_review"].(bool); !required {
+		return fmt.Errorf("default-branch review ruleset on %s must require code owner review", repo)
+	}
+	if resolved, _ := parameters["required_review_thread_resolution"].(bool); !resolved {
+		return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads", repo)
+	}
+	return nil
+}
+
+func verifySingleOwnerReviewMode(repoMeta map[string]any, mode, ownerType string, requireOwner func(string) error, repo string) error {
+	private, _ := repoMeta["private"].(bool)
+	if mode == "single-owner-private-pr" {
+		return verifySingleOwnerMode(private, true, ownerType, mode, requireOwner, repo)
+	}
+	return verifySingleOwnerMode(private, false, ownerType, mode, requireOwner, repo)
+}
+
+func verifySingleOwnerMode(private, expectedPrivate bool, ownerType, mode string, requireOwner func(string) error, repo string) error {
+	modeLabel := "branch review mode '" + mode + "'"
+	if private != expectedPrivate {
+		visibility := "public"
+		if expectedPrivate {
+			visibility = "private"
+		}
+		return fmt.Errorf("%s on %s is only valid for %s repositories", modeLabel, repo, visibility)
+	}
+	if ownerType != "User" {
+		return fmt.Errorf("%s on %s is only valid for user-owned repositories", modeLabel, repo)
+	}
+	return requireOwner(modeLabel)
+}
+
+func verifySingleOwnerReviewParameters(parameters map[string]any, mode, repo string) error {
+	if count, _ := parameters["required_approving_review_count"].(float64); count != 0 {
+		return fmt.Errorf("default-branch review ruleset on %s must require zero approving reviews in %s mode", repo, mode)
+	}
+	if required, _ := parameters["require_code_owner_review"].(bool); required {
+		return fmt.Errorf("default-branch review ruleset on %s must not require code owner review in %s mode", repo, mode)
+	}
+	if required, _ := parameters["require_last_push_approval"].(bool); required {
+		return fmt.Errorf("default-branch review ruleset on %s must not require last-push approval in %s mode", repo, mode)
+	}
+	return verifySingleOwnerThreadResolution(parameters, mode, repo)
+}
+
+func verifySingleOwnerThreadResolution(parameters map[string]any, mode, repo string) error {
+	resolved, _ := parameters["required_review_thread_resolution"].(bool)
+	if mode == "single-owner-public-pr" && !resolved {
+		return fmt.Errorf("default-branch review ruleset on %s must require resolved review threads in single-owner-public-pr mode", repo)
+	}
+	if mode == "single-owner-private-pr" && resolved {
+		return fmt.Errorf("default-branch review ruleset on %s must not require resolved review threads in single-owner-private-pr mode", repo)
+	}
+	return nil
+}
+
+func verifyRequiredStatusRuleset(ruleset map[string]any, expected []string, repo string) error {
+	rule := hostedRulesetRule(ruleset, "required_status_checks")
+	parameters, _ := rule["parameters"].(map[string]any)
+	if strict, _ := parameters["strict_required_status_checks_policy"].(bool); !strict {
+		return fmt.Errorf("default-branch status-check ruleset on %s must require strict status checks", repo)
+	}
+	missing := missingHostedStatusContexts(hostedStatusContexts(parameters), expected)
+	if len(missing) > 0 {
+		return fmt.Errorf("default-branch status-check ruleset on %s is missing required contexts: %s", repo, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func hostedStatusContexts(parameters map[string]any) map[string]struct{} {
+	rawChecks, _ := parameters["required_status_checks"].([]any)
+	actual := map[string]struct{}{}
+	for _, raw := range rawChecks {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if context, _ := entry["context"].(string); context != "" {
+			actual[context] = struct{}{}
+		}
+	}
+	return actual
+}
+
+func missingHostedStatusContexts(actual map[string]struct{}, expected []string) []string {
+	missing := make([]string, 0)
+	for _, context := range expected {
+		if _, ok := actual[context]; !ok {
+			missing = append(missing, context)
+		}
+	}
+	slices.Sort(missing)
+	return missing
+}


### PR DESCRIPTION
## Summary

Extract hosted-control input loading, Actions checks, and ruleset checks into focused private functions.
Preserve file-read order, validation order, error messages, malformed-input handling, and review-mode behavior.
Add compound-failure tests for input reads and validation precedence.

This change does not complete F052 or change hosted policy.
Repository-variable and environment checks remain in the original function for a later review unit.

## Complexity audit

Both revisions use `gocyclo` v0.6.0 with the same production scope, including the extracted file.

- `VerifyGitHubHostedControls`: 179 to 97.
- Every new production helper: at most 5.
- Production functions: 18 to 48.
- Total complexity: 320 to 346.
- Decision count: 302 to 298.

The total rises because each new function adds one baseline point.
The change reduces four decisions and separates cohesive checks; it does not claim a large aggregate reduction.
No analyzer settings or exclusions changed.

## Validation

- Independent six-role review found no actionable findings.
- Full Go tests, `go vet`, and metadata race tests passed.
- Focused uncached metadata tests and formatting checks passed.
- The dead-code check reported no hosted-control finding.
- Its existing Darwin-only diagnostic names a helper with a Linux production caller.
- Identical success-path benchmarks passed on the parent and signed head, with three samples each.
- Observed allocations changed from 999 to 989–990 per call. These limited samples do not establish performance improvement or equivalence.
- Local `pr-parity` passed for signed head `12e6d6bf71e60aefb78a24919e15a4dc929625ca` with a clean worktree.
