### PR TITLE
.R Split hosted-control inventory validation (tests preserve precedence; primary refactor)

### DIFF
--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -437,8 +437,6 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return err
 	}
 	repoMeta := inputs.repoMeta
-	actionsVariables := inputs.actionsVariables
-	environmentsIndex := inputs.environmentsIndex
 	directCollaborators := inputs.directCollaborators
 	releaseEnv := inputs.releaseEnvironment
 	policy := inputs.policy
@@ -517,152 +515,11 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return err
 	}
 
-	actualRepoVariables := map[string]any{}
-	if variables, ok := actionsVariables["variables"].([]any); ok {
-		for _, raw := range variables {
-			entry, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			name, _ := entry["name"].(string)
-			if name != "" {
-				actualRepoVariables[name] = entry["value"]
-			}
-		}
+	if err := verifyHostedRepositoryVariables(inputs.actionsVariables, expectedRepoVariables, repo); err != nil {
+		return err
 	}
-	missingRepoVariables := make([]string, 0)
-	for name := range expectedRepoVariables {
-		if _, ok := actualRepoVariables[name]; !ok {
-			missingRepoVariables = append(missingRepoVariables, name)
-		}
-	}
-	slices.Sort(missingRepoVariables)
-	if len(missingRepoVariables) > 0 {
-		return fmt.Errorf("repository variables missing on %s: %s", repo, strings.Join(missingRepoVariables, ", "))
-	}
-	wrongRepoVariables := make([]string, 0)
-	for name, expectedValue := range expectedRepoVariables {
-		if actualRepoVariables[name] != expectedValue {
-			wrongRepoVariables = append(wrongRepoVariables, fmt.Sprintf("%s=%#v (expected %#v)", name, actualRepoVariables[name], expectedValue))
-		}
-	}
-	slices.Sort(wrongRepoVariables)
-	if len(wrongRepoVariables) > 0 {
-		return fmt.Errorf("repository variables on %s do not match policy: %s", repo, strings.Join(wrongRepoVariables, ", "))
-	}
-
-	actualEnvironmentNames := map[string]struct{}{}
-	if environments, ok := environmentsIndex["environments"].([]any); ok {
-		for _, raw := range environments {
-			entry, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			if name, _ := entry["name"].(string); name != "" {
-				actualEnvironmentNames[name] = struct{}{}
-			}
-		}
-	}
-	missingWorkflowEnvironments := make([]string, 0)
-	for environmentName := range expectedWorkflowEnvironments {
-		if _, ok := actualEnvironmentNames[environmentName]; !ok {
-			missingWorkflowEnvironments = append(missingWorkflowEnvironments, environmentName)
-		}
-	}
-	slices.Sort(missingWorkflowEnvironments)
-	if len(missingWorkflowEnvironments) > 0 {
-		return fmt.Errorf("workflow environments missing on %s: %s", repo, strings.Join(missingWorkflowEnvironments, ", "))
-	}
-	for environmentName, environmentPolicy := range expectedWorkflowEnvironments {
-		artifactName := EnvironmentArtifactName(environmentName)
-		var environmentMeta map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s.json", artifactName)), &environmentMeta); err != nil {
-			return fmt.Errorf("read %s environment metadata: %w", environmentName, err)
-		}
-		if actualName, ok := environmentMeta["name"].(string); ok && actualName != "" && actualName != environmentName {
-			return fmt.Errorf("workflow environment metadata for %s on %s resolved to %s", environmentName, repo, actualName)
-		}
-
-		var environmentVariables map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-variables.json", artifactName)), &environmentVariables); err != nil {
-			return fmt.Errorf("read %s environment variables: %w", environmentName, err)
-		}
-		actualEnvironmentVariables := map[string]any{}
-		if variables, ok := environmentVariables["variables"].([]any); ok {
-			for _, raw := range variables {
-				entry, ok := raw.(map[string]any)
-				if !ok {
-					continue
-				}
-				name, _ := entry["name"].(string)
-				if name != "" {
-					actualEnvironmentVariables[name] = entry["value"]
-				}
-			}
-		}
-		missingEnvironmentVariables := make([]string, 0)
-		for name := range environmentPolicy.Variables {
-			if _, ok := actualEnvironmentVariables[name]; !ok {
-				missingEnvironmentVariables = append(missingEnvironmentVariables, name)
-			}
-		}
-		slices.Sort(missingEnvironmentVariables)
-		if len(missingEnvironmentVariables) > 0 {
-			return fmt.Errorf("workflow environment variables missing on %s/%s: %s", repo, environmentName, strings.Join(missingEnvironmentVariables, ", "))
-		}
-		wrongEnvironmentVariables := make([]string, 0)
-		for name, expectedValue := range environmentPolicy.Variables {
-			if actualEnvironmentVariables[name] != expectedValue {
-				wrongEnvironmentVariables = append(wrongEnvironmentVariables, fmt.Sprintf("%s=%#v (expected %#v)", name, actualEnvironmentVariables[name], expectedValue))
-			}
-		}
-		slices.Sort(wrongEnvironmentVariables)
-		if len(wrongEnvironmentVariables) > 0 {
-			return fmt.Errorf("workflow environment variables on %s/%s do not match policy: %s", repo, environmentName, strings.Join(wrongEnvironmentVariables, ", "))
-		}
-		unexpectedEnvironmentVariables := UnexpectedEnvironmentVariableNames(actualEnvironmentVariables, environmentPolicy.Variables)
-		if len(unexpectedEnvironmentVariables) > 0 {
-			return fmt.Errorf("workflow environment variables on %s/%s include unexpected entries: %s", repo, environmentName, strings.Join(unexpectedEnvironmentVariables, ", "))
-		}
-
-		var environmentSecrets map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-secrets.json", artifactName)), &environmentSecrets); err != nil {
-			return fmt.Errorf("read %s environment secrets: %w", environmentName, err)
-		}
-		actualEnvironmentSecrets := map[string]struct{}{}
-		if secrets, ok := environmentSecrets["secrets"].([]any); ok {
-			for _, raw := range secrets {
-				entry, ok := raw.(map[string]any)
-				if !ok {
-					continue
-				}
-				if name, _ := entry["name"].(string); name != "" {
-					actualEnvironmentSecrets[name] = struct{}{}
-				}
-			}
-		}
-		missingEnvironmentSecrets := make([]string, 0)
-		for _, name := range environmentPolicy.RequiredSecrets {
-			if _, ok := actualEnvironmentSecrets[name]; !ok {
-				missingEnvironmentSecrets = append(missingEnvironmentSecrets, name)
-			}
-		}
-		slices.Sort(missingEnvironmentSecrets)
-		if len(missingEnvironmentSecrets) > 0 {
-			return fmt.Errorf("workflow environment secrets missing on %s/%s: %s", repo, environmentName, strings.Join(missingEnvironmentSecrets, ", "))
-		}
-		unexpectedEnvironmentSecrets := UnexpectedEnvironmentSecretNames(actualEnvironmentSecrets, environmentPolicy.RequiredSecrets)
-		if len(unexpectedEnvironmentSecrets) > 0 {
-			return fmt.Errorf("workflow environment secrets on %s/%s include unexpected entries: %s", repo, environmentName, strings.Join(unexpectedEnvironmentSecrets, ", "))
-		}
-
-		var environmentBranchPolicies map[string]any
-		if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-deployment-branch-policies.json", artifactName)), &environmentBranchPolicies); err != nil {
-			return fmt.Errorf("read %s deployment branch policies: %w", environmentName, err)
-		}
-		if err := verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName, environmentPolicy, environmentMeta, environmentBranchPolicies); err != nil {
-			return err
-		}
+	if err := verifyHostedWorkflowEnvironments(tmpDir, inputs.environmentsIndex, expectedWorkflowEnvironments, repo); err != nil {
+		return err
 	}
 
 	protectionRules, _ := releaseEnv["protection_rules"].([]any)

--- a/internal/metadatautil/hostedcontrols_dispatch_test.go
+++ b/internal/metadatautil/hostedcontrols_dispatch_test.go
@@ -65,6 +65,23 @@ func TestHostedControlDispatchPreservesRulesetsBeforeVariables(t *testing.T) {
 	}
 }
 
+func TestHostedControlDispatchPreservesRepositoryVariablesBeforeEnvironments(t *testing.T) {
+	t.Parallel()
+	root, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", singleOwnerCollaborator())
+	rewriteFile(t, filepath.Join(root, "actions-variables.json"), func(content string) string {
+		return strings.Replace(content, `"value": "false"`, `"value": "wrong"`, 1)
+	})
+	if err := writeJSONFile(filepath.Join(root, "environments.json"), map[string]any{"environments": []any{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := metadatautil.VerifyGitHubHostedControls(root, "omkhar/workcell", policyPath)
+	want := `repository variables on omkhar/workcell do not match policy: WORKCELL_RELEASE_NO_ATTEST="wrong" (expected "false")`
+	if err == nil || err.Error() != want {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want %q", err, want)
+	}
+}
+
 func singleOwnerCollaborator() []map[string]any {
 	return []map[string]any{{
 		"login": "omkhar",

--- a/internal/metadatautil/hostedcontrols_inventory_test.go
+++ b/internal/metadatautil/hostedcontrols_inventory_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHostedNamedValuesPreservesMalformedAndDuplicateEntries(t *testing.T) {
+	payload := map[string]any{"variables": []any{
+		"malformed",
+		map[string]any{"name": ""},
+		map[string]any{"name": "DUPLICATE", "value": "first"},
+		map[string]any{"name": "DUPLICATE", "value": "last"},
+	}}
+	actual := hostedNamedValues(payload)
+	if len(actual) != 1 || actual["DUPLICATE"] != "last" {
+		t.Fatalf("hostedNamedValues() = %#v, want last duplicate value only", actual)
+	}
+}
+
+func TestHostedEnvironmentNamesPreservesMalformedAndDuplicateEntries(t *testing.T) {
+	index := map[string]any{"environments": []any{
+		"malformed",
+		map[string]any{"name": ""},
+		map[string]any{"name": "release"},
+		map[string]any{"name": "release"},
+	}}
+	actual := hostedEnvironmentNames(index)
+	if len(actual) != 1 {
+		t.Fatalf("hostedEnvironmentNames() = %#v, want release only", actual)
+	}
+	if _, ok := actual["release"]; !ok {
+		t.Fatalf("hostedEnvironmentNames() = %#v, want release", actual)
+	}
+}
+
+func TestHostedSecretNamesPreservesMalformedAndDuplicateEntries(t *testing.T) {
+	payload := map[string]any{"secrets": []any{
+		"malformed",
+		map[string]any{"name": ""},
+		map[string]any{"name": "TOKEN"},
+		map[string]any{"name": "TOKEN"},
+	}}
+	actual := hostedSecretNames(payload)
+	if len(actual) != 1 {
+		t.Fatalf("hostedSecretNames() = %#v, want TOKEN only", actual)
+	}
+	if _, ok := actual["TOKEN"]; !ok {
+		t.Fatalf("hostedSecretNames() = %#v, want TOKEN", actual)
+	}
+}
+
+func TestVerifyHostedRepositoryVariablesReportsMissingBeforeMismatch(t *testing.T) {
+	payload := map[string]any{"variables": []any{map[string]any{"name": "WRONG", "value": "actual"}}}
+	expected := map[string]any{"MISSING": "required", "WRONG": "expected"}
+	err := verifyHostedRepositoryVariables(payload, expected, "omkhar/workcell")
+	want := "repository variables missing on omkhar/workcell: MISSING"
+	if err == nil || err.Error() != want {
+		t.Fatalf("verifyHostedRepositoryVariables() error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyHostedWorkflowEnvironmentsReportsMissingBeforeArtifactReads(t *testing.T) {
+	expected := map[string]WorkflowEnvironmentPolicy{"release": {}}
+	err := verifyHostedWorkflowEnvironments(t.TempDir(), map[string]any{"environments": []any{}}, expected, "omkhar/workcell")
+	want := "workflow environments missing on omkhar/workcell: release"
+	if err == nil || err.Error() != want {
+		t.Fatalf("verifyHostedWorkflowEnvironments() error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyHostedWorkflowEnvironmentChecksMetadataBeforeVariables(t *testing.T) {
+	root := t.TempDir()
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release.json"), map[string]any{"name": "wrong"})
+	err := verifyHostedWorkflowEnvironment(root, "release", WorkflowEnvironmentPolicy{}, "omkhar/workcell")
+	want := "workflow environment metadata for release on omkhar/workcell resolved to wrong"
+	if err == nil || err.Error() != want {
+		t.Fatalf("verifyHostedWorkflowEnvironment() error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyHostedEnvironmentVariablesReportsMissingBeforeOtherFailures(t *testing.T) {
+	root := t.TempDir()
+	payload := map[string]any{"variables": []any{
+		map[string]any{"name": "WRONG", "value": "actual"},
+		map[string]any{"name": "UNEXPECTED", "value": "value"},
+	}}
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release-variables.json"), payload)
+	expected := map[string]string{"MISSING": "required", "WRONG": "expected"}
+	err := verifyHostedEnvironmentVariables(root, "release", expected, "omkhar/workcell")
+	want := "workflow environment variables missing on omkhar/workcell/release: MISSING"
+	if err == nil || err.Error() != want {
+		t.Fatalf("verifyHostedEnvironmentVariables() error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyHostedEnvironmentVariablesReportsMismatchBeforeUnexpected(t *testing.T) {
+	root := t.TempDir()
+	payload := map[string]any{"variables": []any{
+		map[string]any{"name": "WRONG", "value": "actual"},
+		map[string]any{"name": "UNEXPECTED", "value": "value"},
+	}}
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release-variables.json"), payload)
+	err := verifyHostedEnvironmentVariables(root, "release", map[string]string{"WRONG": "expected"}, "omkhar/workcell")
+	want := `workflow environment variables on omkhar/workcell/release do not match policy: WRONG="actual" (expected "expected")`
+	if err == nil || err.Error() != want {
+		t.Fatalf("verifyHostedEnvironmentVariables() error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyHostedEnvironmentSecretsReportsMissingBeforeUnexpected(t *testing.T) {
+	root := t.TempDir()
+	payload := map[string]any{"secrets": []any{map[string]any{"name": "UNEXPECTED"}}}
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release-secrets.json"), payload)
+	err := verifyHostedEnvironmentSecrets(root, "release", []string{"MISSING"}, "omkhar/workcell")
+	want := "workflow environment secrets missing on omkhar/workcell/release: MISSING"
+	if err == nil || err.Error() != want {
+		t.Fatalf("verifyHostedEnvironmentSecrets() error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyHostedWorkflowEnvironmentChecksVariablesBeforeSecrets(t *testing.T) {
+	root := t.TempDir()
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release.json"), map[string]any{"name": "release"})
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release-variables.json"), map[string]any{
+		"variables": []any{map[string]any{"name": "UNEXPECTED", "value": "value"}},
+	})
+	err := verifyHostedWorkflowEnvironment(root, "release", WorkflowEnvironmentPolicy{}, "omkhar/workcell")
+	if err == nil || !strings.Contains(err.Error(), "workflow environment variables on omkhar/workcell/release include unexpected entries") {
+		t.Fatalf("verifyHostedWorkflowEnvironment() error = %v, want unexpected-variable rejection", err)
+	}
+}
+
+func TestVerifyHostedWorkflowEnvironmentChecksSecretsBeforeDeployment(t *testing.T) {
+	root := t.TempDir()
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release.json"), map[string]any{"name": "release"})
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release-variables.json"), map[string]any{"variables": []any{}})
+	writeHostedInventoryJSON(t, filepath.Join(root, "environment-release-secrets.json"), map[string]any{
+		"secrets": []any{map[string]any{"name": "UNEXPECTED"}},
+	})
+	err := verifyHostedWorkflowEnvironment(root, "release", WorkflowEnvironmentPolicy{}, "omkhar/workcell")
+	if err == nil || !strings.Contains(err.Error(), "workflow environment secrets on omkhar/workcell/release include unexpected entries") {
+		t.Fatalf("verifyHostedWorkflowEnvironment() error = %v, want unexpected-secret rejection", err)
+	}
+}
+
+func writeHostedInventoryJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	content, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/metadatautil/hostedcontrols_verify.go
+++ b/internal/metadatautil/hostedcontrols_verify.go
@@ -137,6 +137,211 @@ func verifyImmutableReleases(actual map[string]any, policy ReleaseAssetsPolicy, 
 	return nil
 }
 
+func verifyHostedRepositoryVariables(payload, expected map[string]any, repo string) error {
+	actual := hostedNamedValues(payload)
+	if missing := missingHostedRepositoryVariableNames(actual, expected); len(missing) > 0 {
+		return fmt.Errorf("repository variables missing on %s: %s", repo, strings.Join(missing, ", "))
+	}
+	if wrong := mismatchedHostedRepositoryVariableValues(actual, expected); len(wrong) > 0 {
+		return fmt.Errorf("repository variables on %s do not match policy: %s", repo, strings.Join(wrong, ", "))
+	}
+	return nil
+}
+
+func hostedNamedValues(payload map[string]any) map[string]any {
+	actual := map[string]any{}
+	values, _ := payload["variables"].([]any)
+	for _, raw := range values {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := entry["name"].(string); name != "" {
+			actual[name] = entry["value"]
+		}
+	}
+	return actual
+}
+
+func missingHostedRepositoryVariableNames(actual, expected map[string]any) []string {
+	missing := make([]string, 0)
+	for name := range expected {
+		if _, ok := actual[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	slices.Sort(missing)
+	return missing
+}
+
+func mismatchedHostedRepositoryVariableValues(actual, expected map[string]any) []string {
+	wrong := make([]string, 0)
+	for name, expectedValue := range expected {
+		if actual[name] != expectedValue {
+			wrong = append(wrong, fmt.Sprintf("%s=%#v (expected %#v)", name, actual[name], expectedValue))
+		}
+	}
+	slices.Sort(wrong)
+	return wrong
+}
+
+func missingHostedVariableNames(actual map[string]any, expected map[string]string) []string {
+	missing := make([]string, 0)
+	for name := range expected {
+		if _, ok := actual[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	slices.Sort(missing)
+	return missing
+}
+
+func mismatchedHostedVariableValues(actual map[string]any, expected map[string]string) []string {
+	wrong := make([]string, 0)
+	for name, expectedValue := range expected {
+		if actual[name] != expectedValue {
+			wrong = append(wrong, fmt.Sprintf("%s=%#v (expected %#v)", name, actual[name], expectedValue))
+		}
+	}
+	slices.Sort(wrong)
+	return wrong
+}
+
+func verifyHostedWorkflowEnvironments(tmpDir string, index map[string]any, expected map[string]WorkflowEnvironmentPolicy, repo string) error {
+	missing := missingHostedEnvironmentNames(hostedEnvironmentNames(index), expected)
+	if len(missing) > 0 {
+		return fmt.Errorf("workflow environments missing on %s: %s", repo, strings.Join(missing, ", "))
+	}
+	for name, policy := range expected {
+		if err := verifyHostedWorkflowEnvironment(tmpDir, name, policy, repo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hostedEnvironmentNames(index map[string]any) map[string]struct{} {
+	actual := map[string]struct{}{}
+	environments, _ := index["environments"].([]any)
+	for _, raw := range environments {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := entry["name"].(string); name != "" {
+			actual[name] = struct{}{}
+		}
+	}
+	return actual
+}
+
+func missingHostedEnvironmentNames(actual map[string]struct{}, expected map[string]WorkflowEnvironmentPolicy) []string {
+	missing := make([]string, 0)
+	for name := range expected {
+		if _, ok := actual[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	slices.Sort(missing)
+	return missing
+}
+
+func verifyHostedWorkflowEnvironment(tmpDir, name string, policy WorkflowEnvironmentPolicy, repo string) error {
+	meta, err := readAndVerifyHostedEnvironmentMetadata(tmpDir, name, repo)
+	if err != nil {
+		return err
+	}
+	if err := verifyHostedEnvironmentVariables(tmpDir, name, policy.Variables, repo); err != nil {
+		return err
+	}
+	if err := verifyHostedEnvironmentSecrets(tmpDir, name, policy.RequiredSecrets, repo); err != nil {
+		return err
+	}
+	return verifyHostedEnvironmentDeployment(tmpDir, name, policy, meta, repo)
+}
+
+func readAndVerifyHostedEnvironmentMetadata(tmpDir, name, repo string) (map[string]any, error) {
+	var meta map[string]any
+	artifact := EnvironmentArtifactName(name)
+	if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s.json", artifact)), &meta); err != nil {
+		return nil, fmt.Errorf("read %s environment metadata: %w", name, err)
+	}
+	if actualName, ok := meta["name"].(string); ok && actualName != "" && actualName != name {
+		return nil, fmt.Errorf("workflow environment metadata for %s on %s resolved to %s", name, repo, actualName)
+	}
+	return meta, nil
+}
+
+func verifyHostedEnvironmentVariables(tmpDir, name string, expected map[string]string, repo string) error {
+	var payload map[string]any
+	artifact := EnvironmentArtifactName(name)
+	if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-variables.json", artifact)), &payload); err != nil {
+		return fmt.Errorf("read %s environment variables: %w", name, err)
+	}
+	actual := hostedNamedValues(payload)
+	if missing := missingHostedVariableNames(actual, expected); len(missing) > 0 {
+		return fmt.Errorf("workflow environment variables missing on %s/%s: %s", repo, name, strings.Join(missing, ", "))
+	}
+	if wrong := mismatchedHostedVariableValues(actual, expected); len(wrong) > 0 {
+		return fmt.Errorf("workflow environment variables on %s/%s do not match policy: %s", repo, name, strings.Join(wrong, ", "))
+	}
+	if unexpected := UnexpectedEnvironmentVariableNames(actual, expected); len(unexpected) > 0 {
+		return fmt.Errorf("workflow environment variables on %s/%s include unexpected entries: %s", repo, name, strings.Join(unexpected, ", "))
+	}
+	return nil
+}
+
+func verifyHostedEnvironmentSecrets(tmpDir, name string, expected []string, repo string) error {
+	var payload map[string]any
+	artifact := EnvironmentArtifactName(name)
+	if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-secrets.json", artifact)), &payload); err != nil {
+		return fmt.Errorf("read %s environment secrets: %w", name, err)
+	}
+	actual := hostedSecretNames(payload)
+	if missing := missingHostedSecretNames(actual, expected); len(missing) > 0 {
+		return fmt.Errorf("workflow environment secrets missing on %s/%s: %s", repo, name, strings.Join(missing, ", "))
+	}
+	if unexpected := UnexpectedEnvironmentSecretNames(actual, expected); len(unexpected) > 0 {
+		return fmt.Errorf("workflow environment secrets on %s/%s include unexpected entries: %s", repo, name, strings.Join(unexpected, ", "))
+	}
+	return nil
+}
+
+func hostedSecretNames(payload map[string]any) map[string]struct{} {
+	actual := map[string]struct{}{}
+	secrets, _ := payload["secrets"].([]any)
+	for _, raw := range secrets {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := entry["name"].(string); name != "" {
+			actual[name] = struct{}{}
+		}
+	}
+	return actual
+}
+
+func missingHostedSecretNames(actual map[string]struct{}, expected []string) []string {
+	missing := make([]string, 0)
+	for _, name := range expected {
+		if _, ok := actual[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	slices.Sort(missing)
+	return missing
+}
+
+func verifyHostedEnvironmentDeployment(tmpDir, name string, policy WorkflowEnvironmentPolicy, meta map[string]any, repo string) error {
+	var branchPolicies map[string]any
+	artifact := EnvironmentArtifactName(name)
+	if err := readJSONFile(filepath.Join(tmpDir, fmt.Sprintf("environment-%s-deployment-branch-policies.json", artifact)), &branchPolicies); err != nil {
+		return fmt.Errorf("read %s deployment branch policies: %w", name, err)
+	}
+	return verifyWorkflowEnvironmentDeploymentPolicy(repo, name, policy, meta, branchPolicies)
+}
+
 func verifyHostedRulesetControls(inputs hostedControlInputs, reviewMode, ownerType string, expectedContexts []string, requireOwner func(string) error, repo string) error {
 	active := activeHostedRulesets(inputs.rulesets)
 	if len(active) == 0 {


### PR DESCRIPTION
## Summary

Extract repository-variable and per-environment checks into focused private functions.
Preserve unsorted map handling, last-duplicate-wins behavior, malformed-entry skipping, validation order, and diagnostics.
Add characterization tests for repository variables, environment metadata, variables, secrets, deployment checks, and precedence.

This change does not complete F052 or change hosted policy.
Later units address the remaining hosted-control scope.

## Complexity audit

Both revisions use `gocyclo` v0.6.0 with the same production scope.

- `VerifyGitHubHostedControls`: 97 to 54.
- Every new production helper: at most 5.
- Production functions: 48 to 64.
- Production raw complexity: 346 to 360.
- Decision count: 298 to 296.

The raw total rises because each new function adds a baseline point.
The change reduces two decisions and separates cohesive checks.
It does not claim a large aggregate reduction.
No analyzer settings or exclusions changed.

## Validation

- Independent six-role review found no actionable findings.
- Full Go tests, `go vet`, and metadata race tests passed.
- The metadata race run completed successfully in 74.701 seconds.
- Focused tests and formatting checks passed.
- New production helpers preserve the existing read, validation, and error order.
- Reconciliation against merged main is complete.
- The maintainer-signed commit has a verified signature.
- Full local `pr-parity` passed for the signed head and current main base.

## Remaining gates

Hosted checks and current-head Codex review remain pending.
This body makes no full F052 closure claim.
