### PR TITLE
Separate release environment verification

### DIFF
--- a/internal/metadatautil/hostedcontrols.go
+++ b/internal/metadatautil/hostedcontrols.go
@@ -438,25 +438,13 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 	}
 	repoMeta := inputs.repoMeta
 	directCollaborators := inputs.directCollaborators
-	releaseEnv := inputs.releaseEnvironment
 	policy := inputs.policy
 
 	owner, _ := repoMeta["owner"].(map[string]any)
 	ownerLogin, _ := owner["login"].(string)
 	ownerType, _ := owner["type"].(string)
 	requireSingleOwnerCollaborator := func(mode string) error {
-		if len(directCollaborators) != 1 {
-			return fmt.Errorf("%s on %s requires exactly one direct collaborator", mode, repo)
-		}
-		collaborator, _ := directCollaborators[0].(map[string]any)
-		if login, _ := collaborator["login"].(string); login != ownerLogin {
-			return fmt.Errorf("%s on %s requires the owner to be the only direct collaborator", mode, repo)
-		}
-		permissions, _ := collaborator["permissions"].(map[string]any)
-		if admin, _ := permissions["admin"].(bool); !admin {
-			return fmt.Errorf("%s on %s requires the owner to retain admin permission", mode, repo)
-		}
-		return nil
+		return verifySingleOwnerCollaborator(directCollaborators, ownerLogin, mode, repo)
 	}
 
 	branchIntegrityPolicy, ok := policy["branch_integrity"].(map[string]any)
@@ -522,87 +510,7 @@ func VerifyGitHubHostedControls(tmpDir, repo, policyPath string) error {
 		return err
 	}
 
-	protectionRules, _ := releaseEnv["protection_rules"].([]any)
-	reviewerRules := make([]map[string]any, 0)
-	var adminBypassRule map[string]any
-	for _, raw := range protectionRules {
-		entry, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if typ, _ := entry["type"].(string); typ == "required_reviewers" {
-			reviewerRules = append(reviewerRules, entry)
-		}
-		if typ, _ := entry["type"].(string); typ == "admin_bypass" {
-			adminBypassRule = entry
-		}
-	}
-	switch releaseMode {
-	case "review-gated":
-		if len(reviewerRules) == 0 {
-			return fmt.Errorf("release environment on %s must require a human reviewer", repo)
-		}
-		hasReviewer := false
-		for _, rule := range reviewerRules {
-			if reviewers, _ := rule["reviewers"].([]any); len(reviewers) > 0 {
-				hasReviewer = true
-				break
-			}
-		}
-		if !hasReviewer {
-			return fmt.Errorf("release environment on %s must define at least one reviewer", repo)
-		}
-		if err := rejectReleaseAdminBypass(releaseEnv, adminBypassRule, repo); err != nil {
-			return err
-		}
-	case "plan-limited-private":
-		if private, _ := repoMeta["private"].(bool); !private {
-			return fmt.Errorf("release environment mode 'plan-limited-private' on %s is only valid for private repositories", repo)
-		}
-		if len(reviewerRules) > 0 {
-			return fmt.Errorf("release environment on %s must not define reviewer gates in plan-limited-private mode", repo)
-		}
-	case "single-owner-public":
-		if private, _ := repoMeta["private"].(bool); private {
-			return fmt.Errorf("release environment mode 'single-owner-public' on %s is only valid for public repositories", repo)
-		}
-		if ownerType != "User" {
-			return fmt.Errorf("release environment mode 'single-owner-public' on %s is only valid for user-owned repositories", repo)
-		}
-		if err := requireSingleOwnerCollaborator("release environment mode 'single-owner-public'"); err != nil {
-			return err
-		}
-		if len(reviewerRules) == 0 {
-			return fmt.Errorf("release environment on %s must define a reviewer gate in single-owner-public mode", repo)
-		}
-		hasReviewer := false
-		for _, rule := range reviewerRules {
-			if reviewers, _ := rule["reviewers"].([]any); len(reviewers) > 0 {
-				hasReviewer = true
-			}
-			if preventSelfReview, _ := rule["prevent_self_review"].(bool); preventSelfReview {
-				return fmt.Errorf("release environment on %s must allow self-review in single-owner-public mode", repo)
-			}
-		}
-		if !hasReviewer {
-			return fmt.Errorf("release environment on %s must define at least one reviewer in single-owner-public mode", repo)
-		}
-		if err := rejectReleaseAdminBypass(releaseEnv, adminBypassRule, repo); err != nil {
-			return err
-		}
-	default:
-		if private, _ := repoMeta["private"].(bool); !private {
-			return fmt.Errorf("release environment mode 'single-owner-private' on %s is only valid for private repositories", repo)
-		}
-		if ownerType != "User" {
-			return fmt.Errorf("release environment mode 'single-owner-private' on %s is only valid for user-owned repositories", repo)
-		}
-		if err := requireSingleOwnerCollaborator("release environment mode 'single-owner-private'"); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return verifyReleaseEnvironmentControls(releaseMode, inputs, ownerLogin, ownerType, repo)
 }
 
 func verifyWorkflowEnvironmentDeploymentPolicy(repo, environmentName string, environmentPolicy WorkflowEnvironmentPolicy, environmentMeta, environmentBranchPolicies map[string]any) error {

--- a/internal/metadatautil/hostedcontrols_dispatch_test.go
+++ b/internal/metadatautil/hostedcontrols_dispatch_test.go
@@ -82,6 +82,20 @@ func TestHostedControlDispatchPreservesRepositoryVariablesBeforeEnvironments(t *
 	}
 }
 
+func TestHostedControlDispatchPreservesWorkflowEnvironmentsBeforeReleaseMode(t *testing.T) {
+	t.Parallel()
+	root, policyPath := writeHostedControlsFixture(t, "review-gated", "review-gated", singleOwnerCollaborator())
+	rewriteFile(t, filepath.Join(root, "environment-release.json"), func(content string) string {
+		return strings.Replace(content, `"can_admins_bypass": false`, `"can_admins_bypass": true`, 1)
+	})
+
+	err := metadatautil.VerifyGitHubHostedControls(root, "omkhar/workcell", policyPath)
+	want := "workflow environment omkhar/workcell/release must set can_admins_bypass=false"
+	if err == nil || err.Error() != want {
+		t.Fatalf("VerifyGitHubHostedControls() error = %v, want %q", err, want)
+	}
+}
+
 func singleOwnerCollaborator() []map[string]any {
 	return []map[string]any{{
 		"login": "omkhar",

--- a/internal/metadatautil/hostedcontrols_release_test.go
+++ b/internal/metadatautil/hostedcontrols_release_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import "testing"
+
+func TestSummarizeReleaseProtectionPreservesPermissiveDecoding(t *testing.T) {
+	firstAdmin := map[string]any{"type": "admin_bypass", "enabled": false, "id": "first-admin"}
+	lastAdmin := map[string]any{"type": "admin_bypass", "enabled": true, "id": "last-admin"}
+	firstReviewer := map[string]any{"type": "required_reviewers", "reviewers": []any{}, "id": "first-reviewer"}
+	lastReviewer := map[string]any{"type": "required_reviewers", "reviewers": []any{"owner"}, "id": "last-reviewer"}
+	environment := map[string]any{"protection_rules": []any{
+		"malformed",
+		map[string]any{"type": "unknown"},
+		firstReviewer,
+		firstAdmin,
+		lastReviewer,
+		lastAdmin,
+	}}
+	summary := summarizeReleaseProtection(environment)
+	if len(summary.reviewerRules) != 2 || summary.reviewerRules[0]["id"] != "first-reviewer" || summary.reviewerRules[1]["id"] != "last-reviewer" {
+		t.Fatalf("reviewer rules = %#v, want both rules in input order", summary.reviewerRules)
+	}
+	if summary.adminBypassRule["id"] != "last-admin" {
+		t.Fatalf("admin bypass rule = %#v, want last rule", summary.adminBypassRule)
+	}
+}
+
+func TestVerifyReleaseEnvironmentControlsPreservesFailurePrecedence(t *testing.T) {
+	validCollaborator := []any{releaseTestCollaborator("owner", true)}
+	tests := []struct {
+		name          string
+		mode          string
+		environment   map[string]any
+		repoMeta      map[string]any
+		collaborators []any
+		ownerLogin    string
+		ownerType     string
+		want          string
+	}{
+		{
+			name: "review gate before admin bypass", mode: "review-gated",
+			environment: releaseTestEnvironment(true),
+			want:        "release environment on omkhar/workcell must require a human reviewer",
+		},
+		{
+			name: "empty reviewers before admin bypass", mode: "review-gated",
+			environment: releaseTestEnvironment(true, releaseTestReviewer(false, false)),
+			want:        "release environment on omkhar/workcell must define at least one reviewer",
+		},
+		{
+			name: "plan visibility before reviewer gates", mode: "plan-limited-private",
+			environment: releaseTestEnvironment(false, releaseTestReviewer(true, false)),
+			repoMeta:    map[string]any{"private": false},
+			want:        "release environment mode 'plan-limited-private' on omkhar/workcell is only valid for private repositories",
+		},
+		{
+			name: "public visibility before identity", mode: "single-owner-public",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": true},
+			ownerType: "Organization", want: "release environment mode 'single-owner-public' on omkhar/workcell is only valid for public repositories",
+		},
+		{
+			name: "public owner before collaborators", mode: "single-owner-public",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": false},
+			ownerType: "Organization", want: "release environment mode 'single-owner-public' on omkhar/workcell is only valid for user-owned repositories",
+		},
+		{
+			name: "collaborator count before reviewers", mode: "single-owner-public",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": false}, ownerLogin: "owner", ownerType: "User",
+			want: "release environment mode 'single-owner-public' on omkhar/workcell requires exactly one direct collaborator",
+		},
+		{
+			name: "collaborator login before reviewers", mode: "single-owner-public",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": false}, collaborators: []any{releaseTestCollaborator("other", true)}, ownerLogin: "owner", ownerType: "User",
+			want: "release environment mode 'single-owner-public' on omkhar/workcell requires the owner to be the only direct collaborator",
+		},
+		{
+			name: "collaborator admin before reviewers", mode: "single-owner-public",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": false}, collaborators: []any{releaseTestCollaborator("owner", false)}, ownerLogin: "owner", ownerType: "User",
+			want: "release environment mode 'single-owner-public' on omkhar/workcell requires the owner to retain admin permission",
+		},
+		{
+			name: "reviewer gate before admin bypass", mode: "single-owner-public",
+			environment: releaseTestEnvironment(true), repoMeta: map[string]any{"private": false}, collaborators: validCollaborator, ownerLogin: "owner", ownerType: "User",
+			want: "release environment on omkhar/workcell must define a reviewer gate in single-owner-public mode",
+		},
+		{
+			name: "self review before aggregate reviewer", mode: "single-owner-public",
+			environment: releaseTestEnvironment(false, releaseTestReviewer(false, true), releaseTestReviewer(true, false)), repoMeta: map[string]any{"private": false}, collaborators: validCollaborator, ownerLogin: "owner", ownerType: "User",
+			want: "release environment on omkhar/workcell must allow self-review in single-owner-public mode",
+		},
+		{
+			name: "aggregate reviewer before admin bypass", mode: "single-owner-public",
+			environment: releaseTestEnvironment(true, releaseTestReviewer(false, false)), repoMeta: map[string]any{"private": false}, collaborators: validCollaborator, ownerLogin: "owner", ownerType: "User",
+			want: "release environment on omkhar/workcell must define at least one reviewer in single-owner-public mode",
+		},
+		{
+			name: "admin bypass after valid reviewer", mode: "single-owner-public",
+			environment: releaseTestEnvironment(true, releaseTestReviewer(true, false)), repoMeta: map[string]any{"private": false}, collaborators: validCollaborator, ownerLogin: "owner", ownerType: "User",
+			want: "release environment on omkhar/workcell must not allow administrator bypass",
+		},
+		{
+			name: "private visibility before identity", mode: "single-owner-private",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": false}, ownerType: "Organization",
+			want: "release environment mode 'single-owner-private' on omkhar/workcell is only valid for private repositories",
+		},
+		{
+			name: "private owner before collaborators", mode: "single-owner-private",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": true}, ownerType: "Organization",
+			want: "release environment mode 'single-owner-private' on omkhar/workcell is only valid for user-owned repositories",
+		},
+		{
+			name: "private collaborator identity", mode: "single-owner-private",
+			environment: releaseTestEnvironment(false), repoMeta: map[string]any{"private": true}, ownerLogin: "owner", ownerType: "User",
+			want: "release environment mode 'single-owner-private' on omkhar/workcell requires exactly one direct collaborator",
+		},
+	}
+	for _, test := range tests {
+		inputs := hostedControlInputs{
+			releaseEnvironment:  test.environment,
+			repoMeta:            test.repoMeta,
+			directCollaborators: test.collaborators,
+		}
+		err := verifyReleaseEnvironmentControls(test.mode, inputs, test.ownerLogin, test.ownerType, "omkhar/workcell")
+		if err == nil || err.Error() != test.want {
+			t.Errorf("%s: error = %v, want %q", test.name, err, test.want)
+		}
+	}
+}
+
+func releaseTestEnvironment(adminBypass bool, rules ...map[string]any) map[string]any {
+	protectionRules := make([]any, 0, len(rules)+1)
+	for _, rule := range rules {
+		protectionRules = append(protectionRules, rule)
+	}
+	protectionRules = append(protectionRules, map[string]any{"type": "admin_bypass", "enabled": adminBypass})
+	return map[string]any{"protection_rules": protectionRules, "can_admins_bypass": adminBypass}
+}
+
+func releaseTestReviewer(hasReviewer, preventSelfReview bool) map[string]any {
+	reviewers := []any{}
+	if hasReviewer {
+		reviewers = append(reviewers, "owner")
+	}
+	return map[string]any{"type": "required_reviewers", "reviewers": reviewers, "prevent_self_review": preventSelfReview}
+}
+
+func releaseTestCollaborator(login string, admin bool) map[string]any {
+	return map[string]any{"login": login, "permissions": map[string]any{"admin": admin}}
+}

--- a/internal/metadatautil/hostedcontrols_verify.go
+++ b/internal/metadatautil/hostedcontrols_verify.go
@@ -34,6 +34,11 @@ type hostedRulesetControls struct {
 	tagRelease         map[string]any
 }
 
+type releaseProtectionSummary struct {
+	reviewerRules   []map[string]any
+	adminBypassRule map[string]any
+}
+
 func loadHostedControlInputs(tmpDir, policyPath string) (hostedControlInputs, error) {
 	var inputs hostedControlInputs
 	artifacts := []struct {
@@ -340,6 +345,136 @@ func verifyHostedEnvironmentDeployment(tmpDir, name string, policy WorkflowEnvir
 		return fmt.Errorf("read %s deployment branch policies: %w", name, err)
 	}
 	return verifyWorkflowEnvironmentDeploymentPolicy(repo, name, policy, meta, branchPolicies)
+}
+
+func verifySingleOwnerCollaborator(collaborators []any, ownerLogin, mode, repo string) error {
+	if len(collaborators) != 1 {
+		return fmt.Errorf("%s on %s requires exactly one direct collaborator", mode, repo)
+	}
+	collaborator, _ := collaborators[0].(map[string]any)
+	if login, _ := collaborator["login"].(string); login != ownerLogin {
+		return fmt.Errorf("%s on %s requires the owner to be the only direct collaborator", mode, repo)
+	}
+	permissions, _ := collaborator["permissions"].(map[string]any)
+	if admin, _ := permissions["admin"].(bool); !admin {
+		return fmt.Errorf("%s on %s requires the owner to retain admin permission", mode, repo)
+	}
+	return nil
+}
+
+func summarizeReleaseProtection(environment map[string]any) releaseProtectionSummary {
+	rawRules, _ := environment["protection_rules"].([]any)
+	var summary releaseProtectionSummary
+	for _, raw := range rawRules {
+		entry, ok := raw.(map[string]any)
+		if ok {
+			addReleaseProtectionRule(&summary, entry)
+		}
+	}
+	return summary
+}
+
+func addReleaseProtectionRule(summary *releaseProtectionSummary, rule map[string]any) {
+	if typ, _ := rule["type"].(string); typ == "required_reviewers" {
+		summary.reviewerRules = append(summary.reviewerRules, rule)
+	}
+	if typ, _ := rule["type"].(string); typ == "admin_bypass" {
+		summary.adminBypassRule = rule
+	}
+}
+
+func verifyReleaseEnvironmentControls(mode string, inputs hostedControlInputs, ownerLogin, ownerType, repo string) error {
+	summary := summarizeReleaseProtection(inputs.releaseEnvironment)
+	switch mode {
+	case "review-gated":
+		return verifyReviewGatedReleaseEnvironment(inputs.releaseEnvironment, summary, repo)
+	case "plan-limited-private":
+		return verifyPlanLimitedReleaseEnvironment(inputs.repoMeta, summary, repo)
+	case "single-owner-public":
+		return verifySingleOwnerPublicReleaseEnvironment(inputs, summary, ownerLogin, ownerType, repo)
+	default:
+		return verifySingleOwnerReleaseIdentity(inputs.repoMeta, inputs.directCollaborators, ownerLogin, ownerType, "single-owner-private", true, repo)
+	}
+}
+
+func verifyReviewGatedReleaseEnvironment(environment map[string]any, summary releaseProtectionSummary, repo string) error {
+	if err := requireReviewGatedReleaseReviewer(summary.reviewerRules, repo); err != nil {
+		return err
+	}
+	return rejectReleaseAdminBypass(environment, summary.adminBypassRule, repo)
+}
+
+func requireReviewGatedReleaseReviewer(rules []map[string]any, repo string) error {
+	if len(rules) == 0 {
+		return fmt.Errorf("release environment on %s must require a human reviewer", repo)
+	}
+	for _, rule := range rules {
+		if reviewers, _ := rule["reviewers"].([]any); len(reviewers) > 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("release environment on %s must define at least one reviewer", repo)
+}
+
+func verifyPlanLimitedReleaseEnvironment(repoMeta map[string]any, summary releaseProtectionSummary, repo string) error {
+	if private, _ := repoMeta["private"].(bool); !private {
+		return fmt.Errorf("release environment mode 'plan-limited-private' on %s is only valid for private repositories", repo)
+	}
+	if len(summary.reviewerRules) > 0 {
+		return fmt.Errorf("release environment on %s must not define reviewer gates in plan-limited-private mode", repo)
+	}
+	return nil
+}
+
+func verifySingleOwnerPublicReleaseEnvironment(inputs hostedControlInputs, summary releaseProtectionSummary, ownerLogin, ownerType, repo string) error {
+	if err := verifySingleOwnerReleaseIdentity(inputs.repoMeta, inputs.directCollaborators, ownerLogin, ownerType, "single-owner-public", false, repo); err != nil {
+		return err
+	}
+	if err := verifySingleOwnerPublicReviewers(summary.reviewerRules, repo); err != nil {
+		return err
+	}
+	return rejectReleaseAdminBypass(inputs.releaseEnvironment, summary.adminBypassRule, repo)
+}
+
+func verifySingleOwnerReleaseIdentity(repoMeta map[string]any, collaborators []any, ownerLogin, ownerType, mode string, expectedPrivate bool, repo string) error {
+	private, _ := repoMeta["private"].(bool)
+	if private != expectedPrivate {
+		visibility := "public"
+		if expectedPrivate {
+			visibility = "private"
+		}
+		return fmt.Errorf("release environment mode '%s' on %s is only valid for %s repositories", mode, repo, visibility)
+	}
+	if ownerType != "User" {
+		return fmt.Errorf("release environment mode '%s' on %s is only valid for user-owned repositories", mode, repo)
+	}
+	return verifySingleOwnerCollaborator(collaborators, ownerLogin, "release environment mode '"+mode+"'", repo)
+}
+
+func verifySingleOwnerPublicReviewers(rules []map[string]any, repo string) error {
+	if len(rules) == 0 {
+		return fmt.Errorf("release environment on %s must define a reviewer gate in single-owner-public mode", repo)
+	}
+	reviewerCount := 0
+	for _, rule := range rules {
+		ruleReviewerCount, err := inspectSingleOwnerPublicReviewer(rule, repo)
+		if err != nil {
+			return err
+		}
+		reviewerCount += ruleReviewerCount
+	}
+	if reviewerCount == 0 {
+		return fmt.Errorf("release environment on %s must define at least one reviewer in single-owner-public mode", repo)
+	}
+	return nil
+}
+
+func inspectSingleOwnerPublicReviewer(rule map[string]any, repo string) (int, error) {
+	reviewers, _ := rule["reviewers"].([]any)
+	if preventSelfReview, _ := rule["prevent_self_review"].(bool); preventSelfReview {
+		return 0, fmt.Errorf("release environment on %s must allow self-review in single-owner-public mode", repo)
+	}
+	return len(reviewers), nil
 }
 
 func verifyHostedRulesetControls(inputs hostedControlInputs, reviewMode, ownerType string, expectedContexts []string, requireOwner func(string) error, repo string) error {


### PR DESCRIPTION
## Summary

- Separate release environment verification into single-purpose helpers.
- Preserve error text, failure order, permissive decoding, and reviewer policy.
- Add tests for decoding behavior and failure precedence.

## Complexity

The audit uses gocyclo v0.6.0 on the same source scope before and after this change.

- `VerifyGitHubHostedControls`: 54 to 25.
- New production helpers: at most 5.
- Production decisions: 296 to 293.
- Production raw complexity: 360 to 368, because eleven new functions add eleven base points.

This change reduces decisions without changing the hosted-control policy.

## Validation

- Fresh metadata tests passed on the merged upstream-refresh base.
- `go vet ./internal/metadatautil` passed.
- Independent source review passed.
- The repository pre-commit hook passed, and the maintainer signature was verified.

- Exact-head `pr-parity` passed, including host invariants, documentation checks, and container smoke.
- Parity evidence binds head `e1977ef7af92b6949a2e3655eb4b98315d07b0bd` to base `3dd9bd9bce9965fbf849f1676d2820f766f98d66`.

Hosted-only checks remain subject to GitHub validation.
Linux dead-code output includes helpers with Darwin callers; these helpers remain required.
