### PR TITLE
Guard Codex routing instructions

### DIFF
--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -130,6 +130,12 @@ Before ready and merge, inspect the required review surfaces again. Confirm
 that the clean result applies to the current head. Do not treat a `COMMENTED`
 review state as a clean result.
 
+When ready transitions trigger automatic Codex review, record the transition
+time and treat it as the review trigger. Wait for that review's current-head
+result before merge. Apply the existing finding-resolution and clean-result
+rules. Use the selected loop's existing wait and retry limits. Do not add a
+manual trigger unless its retry rule permits one.
+
 When a reviewed commit identifier is available, resolve it in GitHub. Require
 the resolved commit to equal the current head. Report a blocker when required
 review evidence is unavailable or mismatched.
@@ -174,7 +180,8 @@ thread states with stable identifiers.
 14. Mark the pull request ready only when required checks succeed and the
    review surfaces have no actionable finding.
 15. Wait for the ready-state base-policy run.
-16. Recheck the required review surfaces after ready.
+16. Complete any automatic ready-triggered Codex review, then recheck the
+    required review surfaces.
 17. Immediately before merge, recheck the required review surfaces.
 18. Merge the pull request.
 19. Follow all workflows for the merged `main` commit.

--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -107,6 +107,7 @@ func subcommands() []subcommand {
 		{"coverage-executables", "MESSAGE_PATH", 1, 1, cmdCoverageExecutables},
 		{"validate-json", "FILE [FILE...]", 1, -1, cmdValidateJSON},
 		{"validate-toml", "FILE [FILE...]", 1, -1, cmdValidateTOML},
+		{"validate-codex-routing-configs", "REPO_CONFIG MANAGED_CONFIG", 2, 2, cmdValidateCodexRoutingConfigs},
 		{"validate-requirements", "ROOT_DIR REQUIREMENTS_PATH", 2, 2, cmdValidateRequirements},
 		{"validate-operator-contract", "ROOT_DIR CONTRACT_PATH REQUIREMENTS_PATH", 3, 3, cmdValidateOperatorContract},
 		{"validate-public-contract", "ROOT_DIR CONTRACT_PATH", 2, 2, cmdValidatePublicContract},
@@ -618,6 +619,10 @@ func cmdValidateJSON(args []string) error {
 
 func cmdValidateTOML(args []string) error {
 	return metadatautil.ValidateTOMLFiles(args)
+}
+
+func cmdValidateCodexRoutingConfigs(args []string) error {
+	return metadatautil.ValidateCodexRoutingConfigs(args[0], args[1])
 }
 
 func cmdValidateRequirements(args []string) error {

--- a/internal/metadatautil/codex_routing.go
+++ b/internal/metadatautil/codex_routing.go
@@ -15,6 +15,7 @@ var requiredCodexRoutingBindings = []string{
 	"gpt-5.6-terra with medium reasoning",
 	"gpt-5.6-sol with high reasoning",
 	"gpt-6-astra with high reasoning",
+	"gpt-6-astra with xhigh reasoning",
 }
 
 // ValidateCodexRoutingConfigs verifies that both Codex baselines retain the

--- a/internal/metadatautil/codex_routing.go
+++ b/internal/metadatautil/codex_routing.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+var requiredCodexRoutingBindings = []string{
+	"gpt-5.6-luna with low reasoning",
+	"gpt-5.6-terra with medium reasoning",
+	"gpt-5.6-sol with high reasoning",
+	"gpt-6-astra with high reasoning",
+}
+
+// ValidateCodexRoutingConfigs verifies that both Codex baselines retain the
+// required routing bindings and decode to the same whitespace-normalized value.
+func ValidateCodexRoutingConfigs(repoConfigPath, managedConfigPath string) error {
+	repoInstructions, err := validatedCodexRoutingInstructions(repoConfigPath)
+	if err != nil {
+		return err
+	}
+	managedInstructions, err := validatedCodexRoutingInstructions(managedConfigPath)
+	if err != nil {
+		return err
+	}
+	if repoInstructions != managedInstructions {
+		return fmt.Errorf("Codex developer_instructions differ after whitespace normalization: %s and %s", repoConfigPath, managedConfigPath)
+	}
+	return nil
+}
+
+func validatedCodexRoutingInstructions(path string) (string, error) {
+	var config map[string]any
+	if _, err := toml.DecodeFile(path, &config); err != nil {
+		return "", fmt.Errorf("decode Codex config %s: %w", path, err)
+	}
+
+	developerInstructions, ok := config["developer_instructions"].(string)
+	if !ok {
+		return "", fmt.Errorf("%s: developer_instructions must be a top-level string", path)
+	}
+	instructions := strings.Join(strings.Fields(developerInstructions), " ")
+	if instructions == "" {
+		return "", fmt.Errorf("%s: developer_instructions must be nonblank", path)
+	}
+	for _, binding := range requiredCodexRoutingBindings {
+		if !strings.Contains(instructions, binding) {
+			return "", fmt.Errorf("%s: developer_instructions must bind %s", path, binding)
+		}
+	}
+	return instructions, nil
+}

--- a/internal/metadatautil/codex_routing_test.go
+++ b/internal/metadatautil/codex_routing_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validCodexRoutingFixture = `developer_instructions = """
+Use gpt-5.6-luna with low reasoning for mechanical work,
+gpt-5.6-terra with medium reasoning for ordinary work,
+gpt-5.6-sol with high reasoning for complex work, and
+gpt-6-astra with high reasoning for unresolved work.
+"""
+`
+
+const commentOnlyCodexRoutingFixture = `# gpt-5.6-luna with low reasoning
+# gpt-5.6-terra with medium reasoning
+# gpt-5.6-sol with high reasoning
+# gpt-6-astra with high reasoning
+analytics.enabled = false
+`
+
+func TestValidateCodexRoutingConfigsShippedBaselines(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	err := ValidateCodexRoutingConfigs(
+		filepath.Join(repoRoot, "adapters", "codex", ".codex", "config.toml"),
+		filepath.Join(repoRoot, "adapters", "codex", "managed_config.toml"),
+	)
+	if err != nil {
+		t.Fatalf("ValidateCodexRoutingConfigs() error = %v", err)
+	}
+}
+
+func TestValidateCodexRoutingConfigsNormalizesWhitespace(t *testing.T) {
+	managedFixture := strings.ReplaceAll(validCodexRoutingFixture, " for ", "\n\tfor ")
+	repoPath, managedPath := writeCodexRoutingFixtures(t, validCodexRoutingFixture, managedFixture)
+	if err := ValidateCodexRoutingConfigs(repoPath, managedPath); err != nil {
+		t.Fatalf("ValidateCodexRoutingConfigs() error = %v", err)
+	}
+}
+
+func TestValidateCodexRoutingConfigsRejectsInvalidRouting(t *testing.T) {
+	missingBinding := strings.ReplaceAll(validCodexRoutingFixture, "gpt-5.6-sol with high reasoning", "gpt-5.6-sol")
+	tests := []struct {
+		name        string
+		repoConfig  string
+		managed     string
+		wantMessage string
+	}{
+		{"missing from repo baseline", commentOnlyCodexRoutingFixture, validCodexRoutingFixture, "developer_instructions must be a top-level string"},
+		{"missing from managed baseline", validCodexRoutingFixture, commentOnlyCodexRoutingFixture, "developer_instructions must be a top-level string"},
+		{"case variant is not the top-level key", strings.Replace(validCodexRoutingFixture, "developer_instructions", "DEVELOPER_INSTRUCTIONS", 1), validCodexRoutingFixture, "developer_instructions must be a top-level string"},
+		{"wrong value type", "developer_instructions = true\n", validCodexRoutingFixture, "developer_instructions must be a top-level string"},
+		{"blank instructions", "developer_instructions = \"   \"\n", validCodexRoutingFixture, "developer_instructions must be nonblank"},
+		{"required binding missing in both", missingBinding, missingBinding, "must bind gpt-5.6-sol with high reasoning"},
+		{"divergent instructions", validCodexRoutingFixture, strings.Replace(validCodexRoutingFixture, "unresolved work.", "unresolved work. Keep evidence concise.", 1), "differ after whitespace normalization"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repoPath, managedPath := writeCodexRoutingFixtures(t, test.repoConfig, test.managed)
+			err := ValidateCodexRoutingConfigs(repoPath, managedPath)
+			if err == nil || !strings.Contains(err.Error(), test.wantMessage) {
+				t.Fatalf("ValidateCodexRoutingConfigs() error = %v, want message containing %q", err, test.wantMessage)
+			}
+		})
+	}
+}
+
+func writeCodexRoutingFixtures(t *testing.T, repoConfig, managedConfig string) (string, string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	repoPath := filepath.Join(tempDir, "config.toml")
+	managedPath := filepath.Join(tempDir, "managed_config.toml")
+	if err := os.WriteFile(repoPath, []byte(repoConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managedPath, []byte(managedConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return repoPath, managedPath
+}

--- a/internal/metadatautil/codex_routing_test.go
+++ b/internal/metadatautil/codex_routing_test.go
@@ -14,7 +14,8 @@ const validCodexRoutingFixture = `developer_instructions = """
 Use gpt-5.6-luna with low reasoning for mechanical work,
 gpt-5.6-terra with medium reasoning for ordinary work,
 gpt-5.6-sol with high reasoning for complex work, and
-gpt-6-astra with high reasoning for unresolved work.
+gpt-6-astra with high reasoning for unresolved work, and
+gpt-6-astra with xhigh reasoning for a direct exceptional task when evidence warrants it.
 """
 `
 
@@ -22,6 +23,7 @@ const commentOnlyCodexRoutingFixture = `# gpt-5.6-luna with low reasoning
 # gpt-5.6-terra with medium reasoning
 # gpt-5.6-sol with high reasoning
 # gpt-6-astra with high reasoning
+# gpt-6-astra with xhigh reasoning
 analytics.enabled = false
 `
 
@@ -58,7 +60,8 @@ func TestValidateCodexRoutingConfigsRejectsInvalidRouting(t *testing.T) {
 		{"wrong value type", "developer_instructions = true\n", validCodexRoutingFixture, "developer_instructions must be a top-level string"},
 		{"blank instructions", "developer_instructions = \"   \"\n", validCodexRoutingFixture, "developer_instructions must be nonblank"},
 		{"required binding missing in both", missingBinding, missingBinding, "must bind gpt-5.6-sol with high reasoning"},
-		{"divergent instructions", validCodexRoutingFixture, strings.Replace(validCodexRoutingFixture, "unresolved work.", "unresolved work. Keep evidence concise.", 1), "differ after whitespace normalization"},
+		{"exceptional xhigh binding missing in both", strings.Replace(validCodexRoutingFixture, "gpt-6-astra with xhigh reasoning", "gpt-6-astra", 1), strings.Replace(validCodexRoutingFixture, "gpt-6-astra with xhigh reasoning", "gpt-6-astra", 1), "must bind gpt-6-astra with xhigh reasoning"},
+		{"divergent instructions", validCodexRoutingFixture, strings.Replace(validCodexRoutingFixture, "evidence warrants it.", "evidence warrants it. Keep evidence concise.", 1), "differ after whitespace normalization"},
 	}
 
 	for _, test := range tests {

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -1443,6 +1443,9 @@ CODEX_MANAGED_CONFIG="${ROOT_DIR}/adapters/codex/managed_config.toml"
 CODEX_PROFILE_DIR="${ROOT_DIR}/adapters/codex/.codex"
 verify_codex_managed_config_invariants "${CODEX_CONFIG}" || exit 1
 verify_codex_managed_config_invariants "${CODEX_MANAGED_CONFIG}" || exit 1
+go_verify_citools validate-codex-routing-configs \
+  "${CODEX_CONFIG}" \
+  "${CODEX_MANAGED_CONFIG}" || exit 1
 verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/strict.config.toml" '"workspace-write"' '"on-request"' || exit 1
 verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/development.config.toml" '"workspace-write"' '"on-request"' || exit 1
 verify_codex_profile_layer_invariants "${CODEX_PROFILE_DIR}/build.config.toml" '"workspace-write"' '"never"' || exit 1


### PR DESCRIPTION
Removing Codex routing instructions previously left the invariant checks green. The validator now requires the exact `developer_instructions` key in both baselines. It checks all four base model and reasoning bindings plus the conditional Astra `xhigh` binding, then compares the decoded instructions after whitespace normalization. The existing TOML dependency performs the decoding.

Regression tests reject missing instructions, keys with different letter case, missing bindings, and divergent prompts. Routing tokens in comments cannot satisfy the guard. Both shipped baselines must pass. The `xhigh` guard requires the model/effort text pair used by the existing exceptional-task guidance; it does not add a default tier or require using `xhigh`. The checks permit synchronized wording changes. They do not interpret negation or task-category assignments, or prove model behavior. Policy meaning remains subject to independent review.

The PR lifecycle skill also waits for automatic Codex review after a ready transition. This records the delayed-review lesson from [PR 631](https://github.com/omkhar/workcell/pull/631#discussion_r3939788771).

Validation: focused Go tests, vet, CLI checks of both baselines, shell checks, and documentation lint passed. Independent agent review found no remaining issue. Full local PR parity passed for signed head `90c42e06` and `main` base `d9dac5f8`.

The Copilot release verifier used its supported authenticated host path after unauthenticated asset requests returned HTTP 403. The optional freshness hook used its documented per-command exception for separate Claude, Codex, and Copilot pin updates. The official Codex 0.153.2–0.153.3 comparison changes neither the validated routing controls nor the configuration schema.
