### PR TITLE
^R Replace hosted-controls AST audit with raw-byte digest (ponytail audit batch 3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,9 @@ go 1.27.0
 
 toolchain go1.27.1
 
-require github.com/BurntSushi/toml v1.6.0
-
-require golang.org/x/sys v0.47.0
-
-require golang.org/x/text v0.41.0
-
-require gopkg.in/yaml.v3 v3.0.1
-
-require mvdan.cc/sh/v3 v3.14.0
+require (
+	github.com/BurntSushi/toml v1.6.0
+	golang.org/x/sys v0.47.0
+	golang.org/x/text v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,5 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=
-github.com/go-quicktest/qt v1.102.0/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
-github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
@@ -18,5 +8,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-mvdan.cc/sh/v3 v3.14.0 h1:wsPjcfrSXLJomdxwhVZqZ5j5Cue68l549Aj/DCqzbpc=
-mvdan.cc/sh/v3 v3.14.0/go.mod h1:syYCoFET8w9tvevxiXUtY8/ICrU+l26jHmhJDra3Vwo=

--- a/internal/metadatautil/pinnedinputs_shell.go
+++ b/internal/metadatautil/pinnedinputs_shell.go
@@ -4,250 +4,30 @@
 package metadatautil
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"errors"
 	"fmt"
 	"strings"
-
-	"mvdan.cc/sh/v3/syntax"
 )
 
-const (
-	canonicalHostedAPIInvocation = `gh api --hostname github.com -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" "$@"`
-	canonicalHostedShellSHA256   = "6c4a55e4bc53a854fa4100f2683d787a949898c7f83d79a5063da4cd989a006f"
-	canonicalHostedToolFunction  = `require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}`
-	canonicalHostedAPIFunction = `github_api() {
-  gh api --hostname github.com -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" "$@"
-}`
-	canonicalHostedCleanupFunction = `cleanup() {
-  rm -rf "${TMP_DIR}"
-  if [[ -n "${CITOOLS_BIN}" && -e "${CITOOLS_BIN}" ]]; then
-    rm -f "${CITOOLS_BIN}"
-  fi
-}`
-)
+// canonicalHostedShellFileSHA256 pins the exact reviewed bytes of
+// scripts/verify-github-hosted-controls.sh. Any edit to the script changes
+// the reviewed hosted-controls command graph: re-review the script and
+// update this digest in the same change. The raw-byte digest subsumes the
+// former mvdan.cc/sh AST audit (command allowlist, call counts, and
+// canonical function bodies): every structural drift those checks caught
+// also changes the file bytes.
+const canonicalHostedShellFileSHA256 = "3acb99675027bf0d1fa625f34b7464a0754a40a48def0b08b1644367812561e9"
 
-var (
-	errHostedShellRouting   = errors.New("scripts/verify-github-hosted-controls.sh must use the exact reviewed command graph and versioned github_api wrapper")
-	allowedHostedShellCalls = map[string]int{
-		`set -euo pipefail`: 1,
-		`ROOT_DIR="$(CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.." && pwd -P)"`: 1,
-		`CDPATH='' cd -- "${BASH_SOURCE[0]%/*}/.."`:                         1,
-		`pwd -P`: 1,
-		`source "${ROOT_DIR}/scripts/lib/canonical-build-env.sh"`:    1,
-		`workcell_require_modern_privileged_bash "$@"`:               1,
-		`workcell_require_canonical_build_environment`:               1,
-		`echo "Hosted controls reject ambient GH_HOST and GH_REPO."`: 1,
-		`exit 2`: 1,
-		`POLICY_PATH="${WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH:-${ROOT_DIR}/policy/github-hosted-controls.toml}"`: 1,
-		`source "${ROOT_DIR}/scripts/lib/go-run-env.sh"`:                                                               1,
-		`require_tool gh`: 1,
-		`require_tool jq`: 1,
-		`REPO="${1:-}"`:   1,
-		`REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"`:      1,
-		`gh repo view --json nameWithOwner --jq .nameWithOwner`:                1,
-		`TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/workcell-gh-controls.XXXXXX")"`: 1,
-		`mktemp -d "${TMPDIR:-/tmp}/workcell-gh-controls.XXXXXX"`:              1,
-		`CITOOLS_BIN=""`:    1,
-		`trap cleanup EXIT`: 1,
-		`CITOOLS_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-citools.XXXXXX")"`:           1,
-		`mktemp "${TMPDIR:-/tmp}/workcell-citools.XXXXXX"`:                            1,
-		`build_go_tool_in_repo "${ROOT_DIR}" "${CITOOLS_BIN}" ./cmd/workcell-citools`: 1,
-		`github_api "repos/${REPO}"`:                                                  1,
-		`github_api "repos/${REPO}/actions/permissions"`:                              1,
-		`github_api "repos/${REPO}/actions/permissions/selected-actions"`:             1,
-		`:`: 3,
-		`status="$(jq -r '.status // empty' "${TMP_DIR}/actions-selected-actions.json" 2>/dev/null || true)"`: 1,
-		`jq -r '.status // empty' "${TMP_DIR}/actions-selected-actions.json"`:                                 1,
-		`true`: 1,
-		`cat "${TMP_DIR}/actions-selected-actions.err"`:  1,
-		`cat "${TMP_DIR}/actions-selected-actions.json"`: 1,
-		`exit 1`: 3,
-		`github_api "repos/${REPO}/actions/permissions/workflow"`:                                                                1,
-		`github_api "repos/${REPO}/immutable-releases"`:                                                                          1,
-		`github_api --paginate "repos/${REPO}/actions/variables?per_page=100"`:                                                   1,
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages variables`:                                                           2,
-		`github_api "repos/${REPO}/collaborators?affiliation=direct&per_page=100"`:                                               1,
-		`github_api --paginate "repos/${REPO}/rulesets?per_page=100"`:                                                            1,
-		`"${CITOOLS_BIN}" merge-hosted-control-array-pages`:                                                                      1,
-		`"${CITOOLS_BIN}" fetch-rulesets "${TMP_DIR}" "${REPO}"`:                                                                 1,
-		`github_api --paginate "repos/${REPO}/environments?per_page=100"`:                                                        1,
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages environments`:                                                        1,
-		`github_api "repos/${REPO}/environments/release"`:                                                                        1,
-		`echo "Missing required release environment on ${REPO}"`:                                                                 1,
-		`IFS= read -r environment_name`:                                                                                          1,
-		`continue`:                                                                                                               1,
-		`encoded_environment_name="$(jq -rn --arg value "${environment_name}" '$value | @uri')"`:                                 1,
-		`jq -rn --arg value "${environment_name}" '$value | @uri'`:                                                               1,
-		`safe_environment_name="${encoded_environment_name}"`:                                                                    1,
-		`github_api "repos/${REPO}/environments/${encoded_environment_name}"`:                                                    1,
-		`echo "Missing required ${environment_name} environment on ${REPO}"`:                                                     1,
-		`github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/deployment-branch-policies?per_page=100"`: 1,
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages branch_policies`:                                                     1,
-		`github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100"`:                  1,
-		`github_api --paginate "repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100"`:                    1,
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages secrets`:                                                             1,
-		`"${CITOOLS_BIN}" list-hosted-control-environments "${POLICY_PATH}"`:                                                     1,
-		`"${CITOOLS_BIN}" verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`:                                 1,
-	}
-)
-
-type hostedShellRouteAudit struct {
-	script           string
-	toolFunctions    int
-	apiFunctions     int
-	cleanupFunctions int
-	callCounts       map[string]int
-	err              error
-}
+var errHostedShellRouting = errors.New("scripts/verify-github-hosted-controls.sh must use the exact reviewed command graph and versioned github_api wrapper")
 
 func validateCanonicalHostedControlsScript(script string) error {
 	if !strings.HasPrefix(script, "#!/bin/bash -p\n") {
 		return errors.New("scripts/verify-github-hosted-controls.sh must use the exact privileged Bash shebang")
 	}
-	for _, needle := range []string{
-		`readonly GITHUB_API_VERSION="2026-03-10"`,
-		"  " + canonicalHostedAPIInvocation,
-		"github_api --paginate \"repos/${REPO}/actions/variables?per_page=100\"",
-		"repos/${REPO}/actions/permissions/selected-actions",
-		"repos/${REPO}/actions/permissions/workflow",
-		"repos/${REPO}/immutable-releases",
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages variables >"${TMP_DIR}/actions-variables.json"`,
-		"github_api --paginate \"repos/${REPO}/rulesets?per_page=100\"",
-		`"${CITOOLS_BIN}" merge-hosted-control-array-pages >"${TMP_DIR}/rulesets-summary.json"`,
-		"github_api --paginate \"repos/${REPO}/environments?per_page=100\"",
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages environments >"${TMP_DIR}/environments.json"`,
-		`list-hosted-control-environments "${POLICY_PATH}"`,
-		"safe_environment_name=\"${encoded_environment_name}\"",
-		"environment-${safe_environment_name}.json",
-		"repos/${REPO}/environments/${encoded_environment_name}/variables?per_page=100",
-		"repos/${REPO}/environments/${encoded_environment_name}/secrets?per_page=100",
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages branch_policies >"${TMP_DIR}/environment-${safe_environment_name}-deployment-branch-policies.json"`,
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages variables >"${TMP_DIR}/environment-${safe_environment_name}-variables.json"`,
-		`"${CITOOLS_BIN}" merge-hosted-control-object-pages secrets >"${TMP_DIR}/environment-${safe_environment_name}-secrets.json"`,
-		`verify-github-hosted-controls "${TMP_DIR}" "${REPO}" "${POLICY_PATH}"`,
-	} {
-		if !strings.Contains(script, needle) {
-			return fmt.Errorf("scripts/verify-github-hosted-controls.sh must contain %q", needle)
-		}
-	}
-	return validateHostedControlsAPIRouting(script)
-}
-
-func validateHostedControlsAPIRouting(script string) error {
-	file, err := syntax.NewParser(syntax.Variant(syntax.LangBash)).Parse(strings.NewReader(script), "scripts/verify-github-hosted-controls.sh")
-	if err != nil {
-		return fmt.Errorf("parse scripts/verify-github-hosted-controls.sh: %w", err)
-	}
-	audit := hostedShellRouteAudit{script: script, callCounts: make(map[string]int)}
-	syntax.Walk(file, audit.visit)
-	if err := audit.result(); err != nil {
-		return err
-	}
-	return requireCanonicalHostedShell(file)
-}
-
-func requireCanonicalHostedShell(file *syntax.File) error {
-	var canonical bytes.Buffer
-	if err := syntax.NewPrinter().Print(&canonical, file); err != nil {
-		return fmt.Errorf("print scripts/verify-github-hosted-controls.sh: %w", err)
-	}
-	digest := sha256.Sum256(canonical.Bytes())
-	if fmt.Sprintf("%x", digest) != canonicalHostedShellSHA256 {
+	digest := sha256.Sum256([]byte(script))
+	if fmt.Sprintf("%x", digest) != canonicalHostedShellFileSHA256 {
 		return fmt.Errorf("%w: unexpected shell structure", errHostedShellRouting)
 	}
 	return nil
-}
-
-func (audit *hostedShellRouteAudit) visit(node syntax.Node) bool {
-	if audit.err != nil {
-		return false
-	}
-	switch node := node.(type) {
-	case *syntax.CallExpr:
-		audit.err = audit.validateCall(node)
-	case *syntax.FuncDecl:
-		audit.err = audit.validateFunction(node)
-		return false
-	}
-	return audit.err == nil
-}
-
-func (audit *hostedShellRouteAudit) validateCall(call *syntax.CallExpr) error {
-	text := audit.nodeText(call)
-	if _, ok := allowedHostedShellCalls[text]; !ok {
-		return fmt.Errorf("%w: unexpected command %q", errHostedShellRouting, text)
-	}
-	audit.callCounts[text]++
-	return nil
-}
-
-func (audit *hostedShellRouteAudit) validateFunction(function *syntax.FuncDecl) error {
-	switch function.Name.Value {
-	case "require_tool":
-		audit.toolFunctions++
-		return requireHostedShellFunction(audit.nodeText(function), canonicalHostedToolFunction)
-	case "github_api":
-		audit.apiFunctions++
-		return requireHostedShellFunction(audit.nodeText(function), canonicalHostedAPIFunction)
-	case "cleanup":
-		audit.cleanupFunctions++
-		return requireHostedShellFunction(audit.nodeText(function), canonicalHostedCleanupFunction)
-	default:
-		return errHostedShellRouting
-	}
-}
-
-func requireHostedShellFunction(actual, expected string) error {
-	if actual != expected {
-		return errHostedShellRouting
-	}
-	return nil
-}
-
-func (audit hostedShellRouteAudit) result() error {
-	if audit.err != nil {
-		return audit.err
-	}
-	if !audit.hasCanonicalCounts() {
-		return errHostedShellRouting
-	}
-	return audit.requireCanonicalCallCounts()
-}
-
-func (audit hostedShellRouteAudit) hasCanonicalCounts() bool {
-	return allHostedShellCountsOne(
-		audit.toolFunctions,
-		audit.apiFunctions,
-		audit.cleanupFunctions,
-	)
-}
-
-func (audit hostedShellRouteAudit) requireCanonicalCallCounts() error {
-	for call, expected := range allowedHostedShellCalls {
-		actual := audit.callCounts[call]
-		if actual != expected {
-			return fmt.Errorf("%w: command %q appears %d times; expected %d", errHostedShellRouting, call, actual, expected)
-		}
-	}
-	return nil
-}
-
-func allHostedShellCountsOne(counts ...int) bool {
-	for _, count := range counts {
-		if count != 1 {
-			return false
-		}
-	}
-	return true
-}
-
-func (audit *hostedShellRouteAudit) nodeText(node syntax.Node) string {
-	return audit.script[int(node.Pos().Offset()):int(node.End().Offset())]
 }

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -172,7 +172,7 @@ func TestCheckPinnedInputsRejectsHostedControlAPIVersionDrift(t *testing.T) {
 	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
 		return strings.Replace(content, `readonly GITHUB_API_VERSION="2026-03-10"`, `readonly GITHUB_API_VERSION="2022-11-28"`, 1)
 	})
-	requirePinnedInputsErrorContains(t, cfg, `readonly GITHUB_API_VERSION=\"2026-03-10\"`)
+	requirePinnedInputsErrorContains(t, cfg, "unexpected shell structure")
 }
 
 func TestCheckPinnedInputsRejectsHostedControlShebangDrift(t *testing.T) {
@@ -283,14 +283,14 @@ func TestCheckPinnedInputsRejectsUnpaginatedHostedRulesets(t *testing.T) {
 	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
 		return strings.Replace(content, `github_api --paginate "repos/${REPO}/rulesets?per_page=100"`, `github_api "repos/${REPO}/rulesets"`, 1)
 	})
-	requirePinnedInputsErrorContains(t, cfg, `github_api --paginate \"repos/${REPO}/rulesets?per_page=100\"`)
+	requirePinnedInputsErrorContains(t, cfg, "unexpected shell structure")
 }
 
 func TestCheckPinnedInputsRejectsFailOpenHostedRulesetAggregation(t *testing.T) {
 	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
 		return strings.Replace(content, `"${CITOOLS_BIN}" merge-hosted-control-array-pages`, `jq -s 'add'`, 1)
 	})
-	requirePinnedInputsErrorContains(t, cfg, "merge-hosted-control-array-pages")
+	requirePinnedInputsErrorContains(t, cfg, "unexpected shell structure")
 }
 
 func TestCheckPinnedInputsRejectsFailOpenHostedEmptyCollectionAggregation(t *testing.T) {
@@ -302,7 +302,7 @@ func TestCheckPinnedInputsRejectsFailOpenHostedEmptyCollectionAggregation(t *tes
 			1,
 		)
 	})
-	requirePinnedInputsErrorContains(t, cfg, "merge-hosted-control-object-pages secrets")
+	requirePinnedInputsErrorContains(t, cfg, "unexpected shell structure")
 }
 
 func TestCheckPinnedInputsRejectsCommentedDebianBootstrapGuard(t *testing.T) {


### PR DESCRIPTION
Batch 3 of the ponytail-audit remediation: drop the mvdan.cc/sh/v3 dependency.

The AST audit of scripts/verify-github-hosted-controls.sh (80-entry command allowlist, canonical function bodies, call counts) ended in an AST-print sha256 pin that already subsumed every other check. This replaces the whole apparatus with a sha256 pin over the raw file bytes: strictly stricter (comments and whitespace are now pinned too), one constant, and the module loses its only mvdan importer, so the dependency is removed.

- The shebang check keeps its distinct error message.
- Every drift-rejection mutation test still rejects (any byte change fails the digest); the four needle-specific expectations now assert the generic structure error.
- The digest constant carries the re-review instruction for future edits.

Evidence: go test ./... 47 packages ok; scripts/check-pinned-inputs.sh passes against the live tree; pre-merge --profile pr-parity pass; repo-wide grep shows zero remaining mvdan references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBuWTCc8rBa6gbNzpqpTYJ
