### PR TITLE
^R Deduplicate smoke wrappers and delete redundant host probes (ponytail audit batch 2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Use the bootstrap helper:
 ```
 
 That script installs the common local toolchain, configures `.githooks` as the
-repo hook path, and leaves you ready to run the local gates.
+repo hook path, and runs `./scripts/dev-quick-check.sh` to verify the setup.
 
 ## Prerequisites
 

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -2,67 +2,15 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-INSTALL_TOOLS=1
-CONFIGURE_HOOKS=1
-RUN_QUICK_CHECK=0
 
-usage() {
-  cat <<'EOF'
-Usage: ./scripts/bootstrap-dev.sh [options]
-
-Bootstrap a local contributor environment for Workcell.
-
-Options:
-  --skip-tools        Do not install or validate the common local toolchain
-  --skip-hooks        Do not configure .githooks as core.hooksPath
-  --quick-check       Run ./scripts/dev-quick-check.sh after setup
-  -h, --help          Show this help text
-EOF
-}
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --skip-tools)
-      INSTALL_TOOLS=0
-      shift
-      ;;
-    --skip-hooks)
-      CONFIGURE_HOOKS=0
-      shift
-      ;;
-    --quick-check)
-      RUN_QUICK_CHECK=1
-      shift
-      ;;
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unsupported bootstrap option: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ "${INSTALL_TOOLS}" -eq 1 ]]; then
-  "${ROOT_DIR}/scripts/install-dev-tools.sh"
-fi
-
-if [[ "${CONFIGURE_HOOKS}" -eq 1 ]]; then
-  git -C "${ROOT_DIR}" config core.hooksPath .githooks
-  echo "Configured repo hooks: .githooks"
-fi
-
-if [[ "${RUN_QUICK_CHECK}" -eq 1 ]]; then
-  "${ROOT_DIR}/scripts/dev-quick-check.sh"
-fi
+"${ROOT_DIR}/scripts/install-dev-tools.sh"
+git -C "${ROOT_DIR}" config core.hooksPath .githooks
+echo "Configured repo hooks: .githooks"
+"${ROOT_DIR}/scripts/dev-quick-check.sh"
 
 cat <<'EOF'
 Bootstrap complete.
 
-Suggested next steps:
-  ./scripts/dev-quick-check.sh
+Suggested next step:
   ./scripts/pre-merge.sh
 EOF

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -499,10 +499,6 @@ cleanup() {
   fi
 }
 
-select_docker_context() {
-  select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
-}
-
 docker_cmd() {
   if [[ -n "${DOCKER_CONTEXT_NAME}" ]]; then
     docker --context "${DOCKER_CONTEXT_NAME}" "$@"
@@ -645,16 +641,43 @@ populate_workspace_import_mounts() {
   done < <(workspace_import_mounts)
 }
 
-run_container() {
+# Shared docker-run core for the nine run_* smoke helpers below. Each
+# wrapper resets the SMOKE_RUN_* controls, sets only what differs, and
+# delegates. smoke_run_container consumes: SMOKE_RUN_DOCKER_FLAGS (extra
+# docker-run flags), SMOKE_RUN_MUTABILITY (security profile + env value),
+# SMOKE_RUN_PROFILE (CODEX_PROFILE value), SMOKE_RUN_ENV_ARGS (variant env;
+# defaults to the workspace-mutable-exec skip knob, which the injection
+# variants intentionally omit), SMOKE_RUN_PRE_WORKSPACE_MOUNT_ARGS,
+# SMOKE_RUN_POST_WORKSPACE_MOUNT_ARGS, SMOKE_RUN_ENTRYPOINT (1 = first
+# command word becomes --entrypoint).
+smoke_run_reset() {
+  SMOKE_RUN_DOCKER_FLAGS=()
+  SMOKE_RUN_MUTABILITY=ephemeral
+  SMOKE_RUN_PROFILE=strict
+  SMOKE_RUN_ENV_ARGS=(-e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}")
+  SMOKE_RUN_PRE_WORKSPACE_MOUNT_ARGS=()
+  SMOKE_RUN_POST_WORKSPACE_MOUNT_ARGS=()
+  SMOKE_RUN_ENTRYPOINT=0
+}
+
+smoke_run_container() {
   local agent="$1"
   local docker_workspace=""
   shift
 
   docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
   populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
+  populate_runtime_security_args "${SMOKE_RUN_MUTABILITY}"
+
+  local -a entrypoint_args=()
+  local -a command_args=("$@")
+  if [[ "${SMOKE_RUN_ENTRYPOINT}" -eq 1 ]]; then
+    entrypoint_args=(--entrypoint "$1")
+    command_args=("${@:2}")
+  fi
 
   docker_cmd run --rm \
+    ${SMOKE_RUN_DOCKER_FLAGS[@]+"${SMOKE_RUN_DOCKER_FLAGS[@]}"} \
     ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
     --user 0:0 \
     --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
@@ -662,325 +685,101 @@ run_container() {
     --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
     -e AGENT_NAME="${agent}" \
     -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
+    -e WORKCELL_CONTAINER_MUTABILITY="${SMOKE_RUN_MUTABILITY}" \
     -e WORKCELL_HOST_UID="${HOST_UID}" \
     -e WORKCELL_HOST_GID="${HOST_GID}" \
     -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
+    -e CODEX_PROFILE="${SMOKE_RUN_PROFILE}" \
     -e HOME=/state/agent-home \
     -e CODEX_HOME=/state/agent-home/.codex \
     -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
+    ${SMOKE_RUN_ENV_ARGS[@]+"${SMOKE_RUN_ENV_ARGS[@]}"} \
     -e WORKCELL_RUNTIME=1 \
     -e WORKSPACE=/workspace \
     -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
+    ${SMOKE_RUN_PRE_WORKSPACE_MOUNT_ARGS[@]+"${SMOKE_RUN_PRE_WORKSPACE_MOUNT_ARGS[@]}"} \
     -v "${docker_workspace}:/workspace" \
     ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    --entrypoint "$1" \
-    "${IMAGE_TAG}" "${@:2}"
+    ${SMOKE_RUN_POST_WORKSPACE_MOUNT_ARGS[@]+"${SMOKE_RUN_POST_WORKSPACE_MOUNT_ARGS[@]}"} \
+    ${entrypoint_args[@]+"${entrypoint_args[@]}"} \
+    "${IMAGE_TAG}" \
+    ${command_args[@]+"${command_args[@]}"}
+}
+
+smoke_run_injection_bundle_setup() {
+  local agent="$1"
+  local bundle_root="$2"
+  local docker_bundle_root=""
+
+  populate_injection_bundle_credential_mounts "${agent}" "${bundle_root}"
+  docker_bundle_root="$(workcell_docker_host_path "${bundle_root}")"
+  SMOKE_RUN_ENV_ARGS=(-e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json)
+  SMOKE_RUN_PRE_WORKSPACE_MOUNT_ARGS=(${COPILOT_HANDOFF_MOUNT_ARGS[@]+"${COPILOT_HANDOFF_MOUNT_ARGS[@]}"})
+  SMOKE_RUN_POST_WORKSPACE_MOUNT_ARGS=(
+    ${CREDENTIAL_MOUNT_ARGS[@]+"${CREDENTIAL_MOUNT_ARGS[@]}"}
+    -v "${docker_bundle_root}:/opt/workcell/host-injections:ro"
+  )
+  SMOKE_RUN_ENTRYPOINT=1
+}
+
+run_container() {
+  smoke_run_reset
+  SMOKE_RUN_ENTRYPOINT=1
+  smoke_run_container "$@"
 }
 
 run_container_stdin() {
-  local agent="$1"
-  local docker_workspace=""
-  shift
-
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm -i \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    -v "${docker_workspace}:/workspace" \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    --entrypoint "$1" \
-    "${IMAGE_TAG}" "${@:2}"
+  smoke_run_reset
+  SMOKE_RUN_DOCKER_FLAGS=(-i)
+  SMOKE_RUN_ENTRYPOINT=1
+  smoke_run_container "$@"
 }
 
 run_container_with_mutability() {
-  local agent="$1"
-  local mutability="$2"
-  local docker_workspace=""
-  shift 2
-
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args "${mutability}"
-
-  docker_cmd run --rm \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY="${mutability}" \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    -v "${docker_workspace}:/workspace" \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    --entrypoint "$1" \
-    "${IMAGE_TAG}" "${@:2}"
+  smoke_run_reset
+  SMOKE_RUN_MUTABILITY="$2"
+  SMOKE_RUN_ENTRYPOINT=1
+  smoke_run_container "$1" "${@:3}"
 }
 
 run_entrypoint() {
-  local agent="$1"
-  local docker_workspace=""
-  shift
-
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    -v "${docker_workspace}:/workspace" \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    "${IMAGE_TAG}" "$@"
+  smoke_run_reset
+  smoke_run_container "$@"
 }
 
 run_entrypoint_with_profile() {
-  local agent="$1"
-  local profile="$2"
-  local docker_workspace=""
-  shift 2
-
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE="${profile}" \
-    -e WORKCELL_MODE="${profile}" \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    -v "${docker_workspace}:/workspace" \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    "${IMAGE_TAG}" "$@"
+  smoke_run_reset
+  SMOKE_RUN_PROFILE="$2"
+  SMOKE_RUN_ENV_ARGS+=(-e WORKCELL_MODE="$2")
+  smoke_run_container "$1" "${@:3}"
 }
 
 run_entrypoint_with_init_profile() {
-  local agent="$1"
-  local profile="$2"
-  local docker_workspace=""
-  shift 2
-
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm \
-    --init \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE="${profile}" \
-    -e WORKCELL_MODE="${profile}" \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    -v "${docker_workspace}:/workspace" \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    "${IMAGE_TAG}" "$@"
+  smoke_run_reset
+  SMOKE_RUN_DOCKER_FLAGS=(--init)
+  SMOKE_RUN_PROFILE="$2"
+  SMOKE_RUN_ENV_ARGS+=(-e WORKCELL_MODE="$2")
+  smoke_run_container "$1" "${@:3}"
 }
 
 run_entrypoint_with_autonomy_and_bind() {
-  local agent="$1"
-  local autonomy="$2"
-  local bind_source="$3"
-  local bind_target="$4"
-  local docker_workspace=""
-  local docker_bind_source=""
-  shift 4
-
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  docker_bind_source="$(workcell_docker_host_path "${bind_source}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
-    -e WORKCELL_AGENT_AUTONOMY="${autonomy}" \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC="${WORKCELL_CONTAINER_SMOKE_SKIP_WORKSPACE_MUTABLE_EXEC-}" \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    -v "${docker_workspace}:/workspace" \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    -v "${docker_bind_source}:${bind_target}:ro" \
-    "${IMAGE_TAG}" "$@"
+  smoke_run_reset
+  SMOKE_RUN_ENV_ARGS+=(-e WORKCELL_AGENT_AUTONOMY="$2")
+  SMOKE_RUN_POST_WORKSPACE_MOUNT_ARGS=(-v "$(workcell_docker_host_path "$3"):$4:ro")
+  smoke_run_container "$1" "${@:5}"
 }
 
 run_container_with_injection_bundle() {
-  local agent="$1"
-  local bundle_root="$2"
-  shift 2
-  local docker_workspace=""
-  local docker_bundle_root=""
-
-  populate_injection_bundle_credential_mounts "${agent}" "${bundle_root}"
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  docker_bundle_root="$(workcell_docker_host_path "${bundle_root}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    ${COPILOT_HANDOFF_MOUNT_ARGS[@]+"${COPILOT_HANDOFF_MOUNT_ARGS[@]}"} \
-    -v "${docker_workspace}:/workspace" \
-    ${CREDENTIAL_MOUNT_ARGS[@]+"${CREDENTIAL_MOUNT_ARGS[@]}"} \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    -v "${docker_bundle_root}:/opt/workcell/host-injections:ro" \
-    --entrypoint "$1" \
-    "${IMAGE_TAG}" "${@:2}"
+  smoke_run_reset
+  smoke_run_injection_bundle_setup "$1" "$2"
+  smoke_run_container "$1" "${@:3}"
 }
 
 run_container_with_injection_bundle_stdin() {
-  local agent="$1"
-  local bundle_root="$2"
-  shift 2
-  local docker_workspace=""
-  local docker_bundle_root=""
-
-  populate_injection_bundle_credential_mounts "${agent}" "${bundle_root}"
-  docker_workspace="$(workcell_docker_host_path "${SMOKE_WORKSPACE}")"
-  docker_bundle_root="$(workcell_docker_host_path "${bundle_root}")"
-  populate_workspace_import_mounts
-  populate_runtime_security_args ephemeral
-
-  docker_cmd run --rm -i \
-    ${RUNTIME_SECURITY_ARGS[@]+"${RUNTIME_SECURITY_ARGS[@]}"} \
-    --user 0:0 \
-    --tmpfs "/tmp:nosuid,nodev,noexec,size=1g,mode=1777" \
-    --tmpfs "/run:nosuid,nodev,size=64m,mode=755" \
-    --tmpfs "/state:exec,nosuid,nodev,size=1g,mode=1777" \
-    -e AGENT_NAME="${agent}" \
-    -e AGENT_UI=cli \
-    -e WORKCELL_CONTAINER_MUTABILITY=ephemeral \
-    -e WORKCELL_HOST_UID="${HOST_UID}" \
-    -e WORKCELL_HOST_GID="${HOST_GID}" \
-    -e WORKCELL_HOST_USER="${HOST_USER}" \
-    -e CODEX_PROFILE=strict \
-    -e HOME=/state/agent-home \
-    -e CODEX_HOME=/state/agent-home/.codex \
-    -e TMPDIR=/state/tmp \
-    -e WORKCELL_RUNTIME=1 \
-    -e WORKSPACE=/workspace \
-    -e WORKCELL_INJECTION_MANIFEST=/opt/workcell/host-injections/manifest.json \
-    -e WORKCELL_WORKSPACE_IMPORT_ROOT=/opt/workcell/workspace-control-plane \
-    ${COPILOT_HANDOFF_MOUNT_ARGS[@]+"${COPILOT_HANDOFF_MOUNT_ARGS[@]}"} \
-    -v "${docker_workspace}:/workspace" \
-    ${CREDENTIAL_MOUNT_ARGS[@]+"${CREDENTIAL_MOUNT_ARGS[@]}"} \
-    ${WORKSPACE_IMPORT_ARGS[@]+"${WORKSPACE_IMPORT_ARGS[@]}"} \
-    -v "${docker_bundle_root}:/opt/workcell/host-injections:ro" \
-    --entrypoint "$1" \
-    "${IMAGE_TAG}" "${@:2}"
+  smoke_run_reset
+  smoke_run_injection_bundle_setup "$1" "$2"
+  SMOKE_RUN_DOCKER_FLAGS=(-i)
+  smoke_run_container "$1" "${@:3}"
 }
 
 if [[ "${1:-}" == "--self-docker-probe" ]]; then
@@ -988,7 +787,7 @@ if [[ "${1:-}" == "--self-docker-probe" ]]; then
   require_tool script
   setup_workcell_trusted_docker_client
   if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
-    select_docker_context
+    select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
   fi
   buildx_cmd version >/dev/null
   echo "container-smoke-docker-probe-ok"
@@ -1006,7 +805,7 @@ trap cleanup EXIT
 cleanup_workspace_scratch "${ROOT_DIR}"
 prepare_smoke_workspace
 setup_workcell_trusted_docker_client
-select_docker_context
+select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
 
 printf 'container smoke workspace\n' >"${SMOKE_WORKSPACE}/README.md"
 cat <<'EOF' >"${SMOKE_WORKSPACE}/AGENTS.md"

--- a/scripts/generate-builder-environment-manifest.sh
+++ b/scripts/generate-builder-environment-manifest.sh
@@ -41,10 +41,6 @@ require_tool() {
   }
 }
 
-select_docker_context() {
-  select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
-}
-
 docker_cmd() {
   if [[ -n "${DOCKER_CONTEXT_NAME}" ]]; then
     docker --context "${DOCKER_CONTEXT_NAME}" "$@"
@@ -63,7 +59,7 @@ if [[ "${1:-}" == "--self-docker-probe" ]]; then
   require_tool docker
   setup_workcell_trusted_docker_client
   if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
-    select_docker_context
+    select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
   fi
   buildx_cmd version >/dev/null
   echo "generate-builder-environment-manifest-docker-probe-ok"
@@ -78,7 +74,7 @@ fi
 require_tool docker
 require_tool go
 setup_workcell_trusted_docker_client
-select_docker_context
+select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
 
 docker_version_json="$(docker_cmd version --format '{{json .}}')"
 buildx_version="$(buildx_cmd version)"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -3269,78 +3269,6 @@ if ! grep -q 'Duplicate release asset basename: asset.txt' /tmp/workcell-release
   exit 1
 fi
 
-CONTAINER_SMOKE_BASH_ENV_MARKER="${BARRIER_VERIFY_ROOT}/container-smoke-bashenv-ran"
-if ! HOST_BASH_ENV_MARKER="${CONTAINER_SMOKE_BASH_ENV_MARKER}" \
-  BASH_ENV="${HOST_BASH_ENV_PAYLOAD}" \
-  "${ROOT_DIR}/scripts/container-smoke.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/container-smoke.sh self-entrypoint probe to succeed under a hostile BASH_ENV" >&2
-  exit 1
-fi
-if [[ -e "${CONTAINER_SMOKE_BASH_ENV_MARKER}" ]]; then
-  echo "scripts/container-smoke.sh executed hostile BASH_ENV content before launcher setup" >&2
-  exit 1
-fi
-
-RELEASE_BUNDLE_BASH_ENV_MARKER="${BARRIER_VERIFY_ROOT}/verify-release-bundle-bashenv-ran"
-if ! HOST_BASH_ENV_MARKER="${RELEASE_BUNDLE_BASH_ENV_MARKER}" \
-  BASH_ENV="${HOST_BASH_ENV_PAYLOAD}" \
-  "${ROOT_DIR}/scripts/verify-release-bundle.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/verify-release-bundle.sh self-entrypoint probe to succeed under a hostile BASH_ENV" >&2
-  exit 1
-fi
-if [[ -e "${RELEASE_BUNDLE_BASH_ENV_MARKER}" ]]; then
-  echo "scripts/verify-release-bundle.sh executed hostile BASH_ENV content before launcher setup" >&2
-  exit 1
-fi
-
-REPRO_BUILD_BASH_ENV_MARKER="${BARRIER_VERIFY_ROOT}/verify-reproducible-build-bashenv-ran"
-if ! HOST_BASH_ENV_MARKER="${REPRO_BUILD_BASH_ENV_MARKER}" \
-  BASH_ENV="${HOST_BASH_ENV_PAYLOAD}" \
-  "${ROOT_DIR}/scripts/verify-reproducible-build.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/verify-reproducible-build.sh self-entrypoint probe to succeed under a hostile BASH_ENV" >&2
-  exit 1
-fi
-if [[ -e "${REPRO_BUILD_BASH_ENV_MARKER}" ]]; then
-  echo "scripts/verify-reproducible-build.sh executed hostile BASH_ENV content before launcher setup" >&2
-  exit 1
-fi
-
-CONTAINER_SMOKE_BASH_FUNC_MARKER="${BARRIER_VERIFY_ROOT}/container-smoke-bash-func-ran"
-if ! env \
-  "BASH_FUNC_head%%=() { /usr/bin/touch '${CONTAINER_SMOKE_BASH_FUNC_MARKER}'; }" \
-  "${ROOT_DIR}/scripts/container-smoke.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/container-smoke.sh self-entrypoint probe to succeed under a hostile imported Bash function" >&2
-  exit 1
-fi
-if [[ -e "${CONTAINER_SMOKE_BASH_FUNC_MARKER}" ]]; then
-  echo "scripts/container-smoke.sh imported hostile Bash functions before launcher setup" >&2
-  exit 1
-fi
-
-RELEASE_BUNDLE_BASH_FUNC_MARKER="${BARRIER_VERIFY_ROOT}/verify-release-bundle-bash-func-ran"
-if ! env \
-  "BASH_FUNC_head%%=() { /usr/bin/touch '${RELEASE_BUNDLE_BASH_FUNC_MARKER}'; }" \
-  "${ROOT_DIR}/scripts/verify-release-bundle.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/verify-release-bundle.sh self-entrypoint probe to succeed under a hostile imported Bash function" >&2
-  exit 1
-fi
-if [[ -e "${RELEASE_BUNDLE_BASH_FUNC_MARKER}" ]]; then
-  echo "scripts/verify-release-bundle.sh imported hostile Bash functions before launcher setup" >&2
-  exit 1
-fi
-
-REPRO_BUILD_BASH_FUNC_MARKER="${BARRIER_VERIFY_ROOT}/verify-reproducible-build-bash-func-ran"
-if ! env \
-  "BASH_FUNC_head%%=() { /usr/bin/touch '${REPRO_BUILD_BASH_FUNC_MARKER}'; }" \
-  "${ROOT_DIR}/scripts/verify-reproducible-build.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/verify-reproducible-build.sh self-entrypoint probe to succeed under a hostile imported Bash function" >&2
-  exit 1
-fi
-if [[ -e "${REPRO_BUILD_BASH_FUNC_MARKER}" ]]; then
-  echo "scripts/verify-reproducible-build.sh imported hostile Bash functions before launcher setup" >&2
-  exit 1
-fi
-
 HOST_BASH_FUNC_MARKER="${BARRIER_VERIFY_ROOT}/bash-func-ran"
 if ! env \
   "BASH_FUNC_compgen%%=() { /usr/bin/touch '${HOST_BASH_FUNC_MARKER}'; }" \
@@ -3758,26 +3686,6 @@ EOF
 chmod 0755 "${DOCKER_CLIENT_EMPTY_ARGV_HARNESS}"
 ROOT_DIR="${ROOT_DIR}" /bin/bash "${DOCKER_CLIENT_EMPTY_ARGV_HARNESS}"
 
-CONTAINER_SMOKE_PATH_OVERRIDE_DIR="${BARRIER_VERIFY_ROOT}/container-smoke-path-override-bin"
-CONTAINER_SMOKE_PATH_MARKER="${BARRIER_VERIFY_ROOT}/container-smoke-path-ran"
-mkdir -p "${CONTAINER_SMOKE_PATH_OVERRIDE_DIR}"
-cat >"${CONTAINER_SMOKE_PATH_OVERRIDE_DIR}/head" <<EOF
-#!/bin/sh
-touch "${CONTAINER_SMOKE_PATH_MARKER:?}"
-exit 99
-EOF
-chmod 0755 "${CONTAINER_SMOKE_PATH_OVERRIDE_DIR}/head"
-if ! CONTAINER_SMOKE_PATH_MARKER="${CONTAINER_SMOKE_PATH_MARKER}" \
-  PATH="${CONTAINER_SMOKE_PATH_OVERRIDE_DIR}:${PATH}" \
-  "${ROOT_DIR}/scripts/container-smoke.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/container-smoke.sh self-entrypoint probe to succeed under a hostile PATH" >&2
-  exit 1
-fi
-if [[ -e "${CONTAINER_SMOKE_PATH_MARKER}" ]]; then
-  echo "scripts/container-smoke.sh trusted caller PATH before launcher setup" >&2
-  exit 1
-fi
-
 # Assert the container-smoke chown/tar invariants on scripts/container-smoke.sh:
 # no raw recursive chown on host-managed paths, and no tar-based smoke workspace
 # staging or extraction.  Migrated to Go (D3): internal/workcellhardening behind
@@ -3794,46 +3702,6 @@ if ! "${ROOT_DIR}/scripts/container-smoke.sh" --self-test-host-path-hardening \
   exit 1
 fi
 grep -q '^container-smoke-host-path-hardening-ok$' /tmp/workcell-container-smoke-host-path-hardening.out
-
-RELEASE_BUNDLE_PATH_OVERRIDE_DIR="${BARRIER_VERIFY_ROOT}/verify-release-bundle-path-override-bin"
-RELEASE_BUNDLE_PATH_MARKER="${BARRIER_VERIFY_ROOT}/verify-release-bundle-path-ran"
-mkdir -p "${RELEASE_BUNDLE_PATH_OVERRIDE_DIR}"
-cat >"${RELEASE_BUNDLE_PATH_OVERRIDE_DIR}/head" <<EOF
-#!/bin/sh
-touch "${RELEASE_BUNDLE_PATH_MARKER:?}"
-exit 99
-EOF
-chmod 0755 "${RELEASE_BUNDLE_PATH_OVERRIDE_DIR}/head"
-if ! RELEASE_BUNDLE_PATH_MARKER="${RELEASE_BUNDLE_PATH_MARKER}" \
-  PATH="${RELEASE_BUNDLE_PATH_OVERRIDE_DIR}:${PATH}" \
-  "${ROOT_DIR}/scripts/verify-release-bundle.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/verify-release-bundle.sh self-entrypoint probe to succeed under a hostile PATH" >&2
-  exit 1
-fi
-if [[ -e "${RELEASE_BUNDLE_PATH_MARKER}" ]]; then
-  echo "scripts/verify-release-bundle.sh trusted caller PATH before launcher setup" >&2
-  exit 1
-fi
-
-REPRO_BUILD_PATH_OVERRIDE_DIR="${BARRIER_VERIFY_ROOT}/verify-reproducible-build-path-override-bin"
-REPRO_BUILD_PATH_MARKER="${BARRIER_VERIFY_ROOT}/verify-reproducible-build-path-ran"
-mkdir -p "${REPRO_BUILD_PATH_OVERRIDE_DIR}"
-cat >"${REPRO_BUILD_PATH_OVERRIDE_DIR}/head" <<EOF
-#!/bin/sh
-touch "${REPRO_BUILD_PATH_MARKER:?}"
-exit 99
-EOF
-chmod 0755 "${REPRO_BUILD_PATH_OVERRIDE_DIR}/head"
-if ! REPRO_BUILD_PATH_MARKER="${REPRO_BUILD_PATH_MARKER}" \
-  PATH="${REPRO_BUILD_PATH_OVERRIDE_DIR}:${PATH}" \
-  "${ROOT_DIR}/scripts/verify-reproducible-build.sh" --self-entrypoint-probe >/dev/null 2>&1; then
-  echo "Expected scripts/verify-reproducible-build.sh self-entrypoint probe to succeed under a hostile PATH" >&2
-  exit 1
-fi
-if [[ -e "${REPRO_BUILD_PATH_MARKER}" ]]; then
-  echo "scripts/verify-reproducible-build.sh trusted caller PATH before launcher setup" >&2
-  exit 1
-fi
 
 if PATH="${HOST_PATH_OVERRIDE_DIR}:${PATH}" "${ROOT_DIR}/scripts/colima-egress-allowlist.sh" >/dev/null 2>&1; then
   echo "Expected scripts/colima-egress-allowlist.sh without arguments to fail under a hostile PATH" >&2

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -121,10 +121,6 @@ cleanup() {
 
 trap cleanup EXIT
 
-select_docker_context() {
-  select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
-}
-
 prepare_sanitized_clone() {
   local source_repo="$1"
   local clone_dir="$2"
@@ -163,7 +159,7 @@ if [[ "${1:-}" == "--self-docker-probe" ]]; then
   require_tool docker
   setup_workcell_trusted_docker_client
   if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
-    select_docker_context
+    select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
   fi
   buildx_cmd version >/dev/null
   echo "verify-release-bundle-docker-probe-ok"
@@ -269,7 +265,7 @@ fi
 
 if command -v docker >/dev/null 2>&1; then
   setup_workcell_trusted_docker_client
-  select_docker_context
+  select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
   if [[ -z "${BUILDX_BUILDER:-}" ]]; then
     safe_builder_context="${DOCKER_CONTEXT_NAME//[^[:alnum:]_.-]/-}"
     BUILDX_BUILDER="workcell-release-${safe_builder_context}"

--- a/scripts/verify-reproducible-build.sh
+++ b/scripts/verify-reproducible-build.sh
@@ -49,10 +49,6 @@ require_tool() {
   }
 }
 
-select_docker_context() {
-  select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
-}
-
 docker_cmd() {
   if [[ -n "${DOCKER_CONTEXT_NAME}" ]]; then
     docker --context "${DOCKER_CONTEXT_NAME}" "$@"
@@ -127,7 +123,7 @@ if [[ "${1:-}" == "--self-docker-probe" ]]; then
   require_tool docker
   setup_workcell_trusted_docker_client
   if [[ -n "${DOCKER_CONTEXT_NAME:-}" ]]; then
-    select_docker_context
+    select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
   fi
   buildx_cmd version >/dev/null
   echo "verify-reproducible-build-docker-probe-ok"
@@ -137,7 +133,7 @@ fi
 require_tool docker
 require_tool go
 setup_workcell_trusted_docker_client
-select_docker_context
+select_workcell_docker_context "Requested Docker context" "No healthy Docker context found" colima default
 if [[ -z "${BUILDX_BUILDER:-}" ]]; then
   safe_builder_context="${DOCKER_CONTEXT_NAME//[^[:alnum:]_.-]/-}"
   BUILDX_BUILDER="workcell-repro-${safe_builder_context}"


### PR DESCRIPTION
Batch 2 of the ponytail-audit remediation: the four verified-safe shell cuts.

- container-smoke.sh: the nine run_* docker-run wrappers (30 identical lines each) collapse into one smoke_run_container core plus thin named wrappers. All nine public names, argument contracts, and flag/env/mount semantics are unchanged, including the deliberate absence of the workspace-mutable-exec skip knob in the injection-bundle variants.
- verify-invariants.sh: the nine standalone hostile-BASH_ENV/BASH_FUNC/PATH probe blocks are deleted; all three probed scripts are HOST_GATE_SCRIPTS members, so the gate loops already run byte-identical probes plus a hostile-bash probe the standalone blocks lacked. The script's own self-probes stay.
- bootstrap-dev.sh: the 68-line flag parser no caller uses is gone; the script now runs dev-quick-check.sh to verify the setup.
- The four identical select_docker_context() wrappers are inlined at their call sites.

The re-scope that produced this short list is deliberate: the audit's larger shell-dedup items (require_tool, env -i preambles, resolve_go_bin, runtime wrapper env scrubs) were all verified to be enforced hardening architecture and were rejected, not deferred.

Evidence: go test ./... 47 packages ok (including the suites that pin these scripts' literal text); shellcheck -x and shfmt clean; pre-merge --profile pr-parity pass (runs the real container smoke through the consolidated wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBuWTCc8rBa6gbNzpqpTYJ
