### PR TITLE
^R Derive pinned-input paths from the repo root (ponytail audit batch 4d)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -103,7 +103,7 @@ func subcommands() []subcommand {
 		{"apply-debian-bootstrap", "PLAN_PATH REPO_ROOT", 2, 2, cmdApplyDebianBootstrap},
 		{"generate-build-input-manifest", "DOCKERFILE PACKAGE_JSON PACKAGE_LOCK OUTPUT BUILD_REF SOURCE_DATE_EPOCH REQUIRE_TRACKED", 7, 7, cmdGenerateBuildInputManifest},
 		{"generate-builder-environment-manifest", "OUTPUT BUILDKIT_IMAGE BUILDX_VERSION_TARGET COSIGN_VERSION_TARGET QEMU_IMAGE SYFT_VERSION_TARGET BUILDX_VERSION BUILDX_INSPECT DOCKER_VERSION_JSON QEMU_VERSION COSIGN_VERSION CURL_VERSION GIT_VERSION GZIP_VERSION SYFT_VERSION TAR_VERSION", 16, 16, cmdGenerateBuilderEnvironmentManifest},
-		{"check-pinned-inputs", "DOCKERFILE VALIDATOR_DOCKERFILE PROVIDERS_PACKAGE_JSON PROVIDERS_PACKAGE_LOCK WORKFLOWS_DIR CI_WORKFLOW RELEASE_WORKFLOW PIN_HYGIENE_WORKFLOW CODEOWNERS CODEX_REQUIREMENTS CODEX_MCP_CONFIG HOSTED_CONTROLS_POLICY HOSTED_CONTROLS_SCRIPT PROVIDER_BUMP_POLICY MAX_DEBIAN_SNAPSHOT_AGE_DAYS", 15, 15, cmdCheckPinnedInputs},
+		{"check-pinned-inputs", "REPO_ROOT MAX_DEBIAN_SNAPSHOT_AGE_DAYS", 2, 2, cmdCheckPinnedInputs},
 		{"verify-reproducible-build", "OCI_EXPORT_A OCI_EXPORT_B REPRO_PLATFORMS REPRO_MANIFEST_PATH SOURCE_DATE_EPOCH", 5, 5, cmdVerifyReproducibleBuild},
 		{"generate-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS OUTPUT_PATH SOURCE_DATE_EPOCH", 4, 4, cmdGenerateReproducibleBuildManifest},
 		{"verify-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS MANIFEST_PATH", 3, 3, cmdVerifyReproducibleBuildManifest},
@@ -512,27 +512,11 @@ func cmdGenerateBuilderEnvironmentManifest(args []string) error {
 }
 
 func cmdCheckPinnedInputs(args []string) error {
-	maxAge, err := strconv.Atoi(args[14])
+	maxAge, err := strconv.Atoi(args[1])
 	if err != nil {
 		return err
 	}
-	return metadatautil.CheckPinnedInputs(metadatautil.PinnedInputsConfig{
-		RuntimeDockerfilePath:    args[0],
-		ValidatorDockerfilePath:  args[1],
-		ProvidersPackageJSONPath: args[2],
-		ProvidersPackageLockPath: args[3],
-		WorkflowsDir:             args[4],
-		CIWorkflowPath:           args[5],
-		ReleaseWorkflowPath:      args[6],
-		PinHygieneWorkflowPath:   args[7],
-		CodeownersPath:           args[8],
-		CodexRequirementsPath:    args[9],
-		CodexMCPConfigPath:       args[10],
-		HostedControlsPolicyPath: args[11],
-		HostedControlsScriptPath: args[12],
-		ProviderBumpPolicyPath:   args[13],
-		MaxDebianSnapshotAgeDays: maxAge,
-	})
+	return metadatautil.CheckPinnedInputs(metadatautil.NewPinnedInputsConfig(args[0], maxAge))
 }
 
 func cmdVerifyReproducibleBuild(args []string) error {

--- a/internal/metadatautil/pinnedinputs.go
+++ b/internal/metadatautil/pinnedinputs.go
@@ -5,6 +5,7 @@ package metadatautil
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -32,6 +33,30 @@ type PinnedInputsConfig struct {
 	HostedControlsScriptPath string
 	ProviderBumpPolicyPath   string
 	MaxDebianSnapshotAgeDays int
+}
+
+// NewPinnedInputsConfig derives the repo-standard pinned-input paths
+// from repoRoot. The path layout is fixed by the repository; only the
+// root and the snapshot-age budget vary between the live tree and test
+// fixtures.
+func NewPinnedInputsConfig(repoRoot string, maxDebianSnapshotAgeDays int) PinnedInputsConfig {
+	return PinnedInputsConfig{
+		RuntimeDockerfilePath:    filepath.Join(repoRoot, "runtime", "container", "Dockerfile"),
+		ValidatorDockerfilePath:  filepath.Join(repoRoot, "tools", "validator", "Dockerfile"),
+		ProvidersPackageJSONPath: filepath.Join(repoRoot, "runtime", "container", "providers", "package.json"),
+		ProvidersPackageLockPath: filepath.Join(repoRoot, "runtime", "container", "providers", "package-lock.json"),
+		WorkflowsDir:             filepath.Join(repoRoot, ".github", "workflows"),
+		CIWorkflowPath:           filepath.Join(repoRoot, ".github", "workflows", "ci.yml"),
+		ReleaseWorkflowPath:      filepath.Join(repoRoot, ".github", "workflows", "release.yml"),
+		PinHygieneWorkflowPath:   filepath.Join(repoRoot, ".github", "workflows", "pin-hygiene.yml"),
+		CodeownersPath:           filepath.Join(repoRoot, ".github", "CODEOWNERS"),
+		CodexRequirementsPath:    filepath.Join(repoRoot, "adapters", "codex", "requirements.toml"),
+		CodexMCPConfigPath:       filepath.Join(repoRoot, "adapters", "codex", "mcp", "config.toml"),
+		HostedControlsPolicyPath: filepath.Join(repoRoot, "policy", "github-hosted-controls.toml"),
+		HostedControlsScriptPath: filepath.Join(repoRoot, "scripts", "verify-github-hosted-controls.sh"),
+		ProviderBumpPolicyPath:   filepath.Join(repoRoot, "policy", "provider-bumps.toml"),
+		MaxDebianSnapshotAgeDays: maxDebianSnapshotAgeDays,
+	}
 }
 
 type markdownlintPackageJSON struct {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -92,23 +92,7 @@ func writePinnedInputsFixture(tb testing.TB) metadatautil.PinnedInputsConfig {
 		copyFixtureFile(tb, srcRoot, dstRoot, relativePath)
 	}
 
-	return metadatautil.PinnedInputsConfig{
-		RuntimeDockerfilePath:    filepath.Join(dstRoot, "runtime", "container", "Dockerfile"),
-		ValidatorDockerfilePath:  filepath.Join(dstRoot, "tools", "validator", "Dockerfile"),
-		ProvidersPackageJSONPath: filepath.Join(dstRoot, "runtime", "container", "providers", "package.json"),
-		ProvidersPackageLockPath: filepath.Join(dstRoot, "runtime", "container", "providers", "package-lock.json"),
-		WorkflowsDir:             filepath.Join(dstRoot, ".github", "workflows"),
-		CIWorkflowPath:           filepath.Join(dstRoot, ".github", "workflows", "ci.yml"),
-		ReleaseWorkflowPath:      filepath.Join(dstRoot, ".github", "workflows", "release.yml"),
-		PinHygieneWorkflowPath:   filepath.Join(dstRoot, ".github", "workflows", "pin-hygiene.yml"),
-		CodeownersPath:           filepath.Join(dstRoot, ".github", "CODEOWNERS"),
-		CodexRequirementsPath:    filepath.Join(dstRoot, "adapters", "codex", "requirements.toml"),
-		CodexMCPConfigPath:       filepath.Join(dstRoot, "adapters", "codex", "mcp", "config.toml"),
-		HostedControlsPolicyPath: filepath.Join(dstRoot, "policy", "github-hosted-controls.toml"),
-		HostedControlsScriptPath: filepath.Join(dstRoot, "scripts", "verify-github-hosted-controls.sh"),
-		ProviderBumpPolicyPath:   filepath.Join(dstRoot, "policy", "provider-bumps.toml"),
-		MaxDebianSnapshotAgeDays: 60,
-	}
+	return metadatautil.NewPinnedInputsConfig(dstRoot, 60)
 }
 
 func rewriteFile(tb testing.TB, path string, rewrite func(string) string) {

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -9,20 +9,6 @@ if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
 fi
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DOCKERFILE_PATH="${ROOT_DIR}/runtime/container/Dockerfile"
-VALIDATOR_DOCKERFILE_PATH="${ROOT_DIR}/tools/validator/Dockerfile"
-PROVIDERS_PACKAGE_JSON_PATH="${ROOT_DIR}/runtime/container/providers/package.json"
-PROVIDERS_PACKAGE_LOCK_PATH="${ROOT_DIR}/runtime/container/providers/package-lock.json"
-WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
-CI_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/ci.yml"
-RELEASE_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/release.yml"
-PIN_HYGIENE_WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/pin-hygiene.yml"
-CODEOWNERS_PATH="${ROOT_DIR}/.github/CODEOWNERS"
-CODEX_REQUIREMENTS_PATH="${ROOT_DIR}/adapters/codex/requirements.toml"
-CODEX_MCP_CONFIG_PATH="${ROOT_DIR}/adapters/codex/mcp/config.toml"
-HOSTED_CONTROLS_POLICY_PATH="${ROOT_DIR}/policy/github-hosted-controls.toml"
-HOSTED_CONTROLS_SCRIPT_PATH="${ROOT_DIR}/scripts/verify-github-hosted-controls.sh"
-PROVIDER_BUMP_POLICY_PATH="${ROOT_DIR}/policy/provider-bumps.toml"
 MAX_DEBIAN_SNAPSHOT_AGE_DAYS="${WORKCELL_MAX_DEBIAN_SNAPSHOT_AGE_DAYS:-60}"
 
 GO_BIN="${WORKCELL_GO_BIN:-}"
@@ -50,4 +36,4 @@ resolve_go_bin() {
 
 resolve_go_bin
 
-(cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-citools check-pinned-inputs "${DOCKERFILE_PATH}" "${VALIDATOR_DOCKERFILE_PATH}" "${PROVIDERS_PACKAGE_JSON_PATH}" "${PROVIDERS_PACKAGE_LOCK_PATH}" "${WORKFLOWS_DIR}" "${CI_WORKFLOW_PATH}" "${RELEASE_WORKFLOW_PATH}" "${PIN_HYGIENE_WORKFLOW_PATH}" "${CODEOWNERS_PATH}" "${CODEX_REQUIREMENTS_PATH}" "${CODEX_MCP_CONFIG_PATH}" "${HOSTED_CONTROLS_POLICY_PATH}" "${HOSTED_CONTROLS_SCRIPT_PATH}" "${PROVIDER_BUMP_POLICY_PATH}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}")
+(cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-citools check-pinned-inputs "${ROOT_DIR}" "${MAX_DEBIAN_SNAPSHOT_AGE_DAYS}")


### PR DESCRIPTION
Batch 4d (final batch) of the ponytail-audit remediation: derive the pinned-input paths from the repo root.

check-pinned-inputs.sh hardcoded 14 fixed repo-relative paths into a 15-field config, and the test fixture rebuilt the same 14 joins. The layout is fixed by the repository; only the root and the snapshot-age budget vary. NewPinnedInputsConfig(repoRoot, maxAge) is now the single derivation; the citools subcommand takes 2 positional args instead of 15; the shell path block and fixture path block are gone. The struct and every internal consumer are unchanged.

Evidence: go test ./... 47 packages ok; live check-pinned-inputs.sh passes; testkit (script-text pin) suite green; pre-merge --profile pr-parity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBuWTCc8rBa6gbNzpqpTYJ
