### PR TITLE
^R Remove the unused Apple workspace copier

### DIFF
--- a/internal/applecontainer/target.go
+++ b/internal/applecontainer/target.go
@@ -5,13 +5,10 @@ package applecontainer
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"unicode"
 )
@@ -253,155 +250,6 @@ func validateAuditToken(label, value string) error {
 		}
 	}
 	return nil
-}
-
-// pathWithin reports whether child is inside parent (component-aware via
-// filepath.Rel, so /foobar is not inside /foo). Comparison is case-insensitive
-// because on a case-insensitive volume (APFS default) /Foo and /foo are the same
-// path; this is also the safe direction for the isolation/overlap boundary.
-func pathWithin(parent, child string) bool {
-	rel, err := filepath.Rel(strings.ToLower(parent), strings.ToLower(child))
-	if err != nil || rel == "." {
-		return false
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-// copyWorkspaceTree copies sourceRoot into destRoot, excluding the configured
-// paths, and returns a sorted manifest of the copied entries. Symlinks that are
-// absolute or escape the workspace (lexically or after kernel resolution) fail
-// closed so materialization cannot smuggle non-workspace content into the VM.
-func copyWorkspaceTree(sourceRoot, destRoot string, excluded []string) ([]WorkspaceEntry, error) {
-	entries := make([]WorkspaceEntry, 0)
-	// Dir chmods deferred to after the walk (deepest-first) so a read-only source dir stays writable while children copy.
-	var dirDests []string
-	var dirPerms []fs.FileMode
-	// Resolve the root first so a symlinked source-workspace root is walked as its real dir (WalkDir does not follow it).
-	resolvedRoot, err := filepath.EvalSymlinks(sourceRoot)
-	if err != nil {
-		return nil, err
-	}
-	// A non-directory source workspace (file, or symlink to one) is invalid: WalkDir would visit only the root.
-	if rootInfo, err := os.Stat(resolvedRoot); err != nil {
-		return nil, err
-	} else if !rootInfo.IsDir() {
-		return nil, fmt.Errorf("source workspace is not a directory: %s", sourceRoot)
-	}
-	// Absolute root for symlink-containment checks: a relative sourceRoot (e.g. ".")
-	// makes EvalSymlinks return relative paths, so compare resolved absolutes.
-	rootAbs, err := filepath.Abs(resolvedRoot)
-	if err != nil {
-		return nil, err
-	}
-	err = filepath.WalkDir(resolvedRoot, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if path == resolvedRoot {
-			return nil
-		}
-		rel, err := filepath.Rel(resolvedRoot, path)
-		if err != nil {
-			return err
-		}
-		rel = filepath.ToSlash(rel)
-		if isExcludedPath(rel, excluded) {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		info, err := os.Lstat(path)
-		if err != nil {
-			return err
-		}
-		destPath := filepath.Join(destRoot, filepath.FromSlash(rel))
-		switch {
-		case info.Mode()&os.ModeSymlink != 0:
-			target, err := os.Readlink(path)
-			if err != nil {
-				return err
-			}
-			if filepath.IsAbs(target) {
-				return fmt.Errorf("workspace symlink %s targets an absolute path: %s", rel, target)
-			}
-			resolved := filepath.ToSlash(filepath.Clean(filepath.Join(filepath.Dir(filepath.FromSlash(rel)), target)))
-			if resolved == ".." || strings.HasPrefix(resolved, "../") {
-				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
-			}
-			physical, err := filepath.EvalSymlinks(path)
-			if err != nil {
-				return fmt.Errorf("workspace symlink %s does not resolve inside the workspace: %v", rel, err)
-			}
-			physicalAbs, err := filepath.Abs(physical)
-			if err != nil {
-				return err
-			}
-			if !strings.EqualFold(physicalAbs, rootAbs) && !pathWithin(rootAbs, physicalAbs) {
-				return fmt.Errorf("workspace symlink %s escapes the workspace: %s", rel, target)
-			}
-			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-				return err
-			}
-			if err := os.Symlink(target, destPath); err != nil {
-				return err
-			}
-			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "symlink", Mode: info.Mode(), LinkTarget: target})
-		case info.IsDir():
-			if err := os.MkdirAll(destPath, 0o700); err != nil {
-				return err
-			}
-			dirDests = append(dirDests, destPath)
-			dirPerms = append(dirPerms, info.Mode().Perm())
-			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "dir", Mode: info.Mode()})
-		case info.Mode().IsRegular():
-			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-				return err
-			}
-			content, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			if err := os.WriteFile(destPath, content, info.Mode().Perm()); err != nil {
-				return err
-			}
-			if err := os.Chmod(destPath, info.Mode().Perm()); err != nil {
-				return err
-			}
-			sum := sha256.Sum256(content)
-			entries = append(entries, WorkspaceEntry{Path: rel, Kind: "file", Mode: info.Mode(), SHA256: hex.EncodeToString(sum[:])})
-		default:
-			return fmt.Errorf("unsupported workspace entry kind for %s", rel)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	// Restore directory modes deepest-first so a read-only parent can't block a child.
-	for i := len(dirDests) - 1; i >= 0; i-- {
-		if err := os.Chmod(dirDests[i], dirPerms[i]); err != nil {
-			return nil, err
-		}
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Path < entries[j].Path
-	})
-	return entries, nil
-}
-
-// isExcludedPath matches exclusions case-insensitively (component-boundary), so
-// on a case-insensitive volume (APFS default) `.GIT`/`.Git` are excluded just
-// like `.git` — git control state must never leak into the isolated workspace.
-func isExcludedPath(rel string, excluded []string) bool {
-	lower := strings.ToLower(rel)
-	for _, item := range excluded {
-		item = strings.ToLower(item)
-		if lower == item || strings.HasPrefix(lower, item+"/") {
-			return true
-		}
-	}
-	return false
 }
 
 func writeJSON(path string, value any) error {

--- a/internal/applecontainer/target_test.go
+++ b/internal/applecontainer/target_test.go
@@ -68,8 +68,9 @@ func TestCopyWorkspaceTreePreservesFileMode(t *testing.T) {
 	file := filepath.Join(src, "run.sh")
 	mustNil(t, os.WriteFile(file, []byte("#!/bin/sh\n"), 0o600))
 	mustNil(t, os.Chmod(file, 0o666))
-	dst := filepath.Join(t.TempDir(), "out")
-	entries, err := copyWorkspaceTree(src, dst, nil)
+	parent, parentFD := workspaceTestParent(t)
+	dst := filepath.Join(parent, "out")
+	entries, err := copyWorkspaceTreeDescriptor(src, parentFD, "out", nil)
 	mustNil(t, err)
 	info, err := os.Stat(filepath.Join(dst, "run.sh"))
 	mustNil(t, err)
@@ -95,7 +96,7 @@ func TestCopyWorkspaceTreeRelativeSourceSymlink(t *testing.T) {
 	mustNil(t, os.WriteFile(filepath.Join(ok, "real.txt"), []byte("x\n"), 0o644))
 	mustNil(t, os.Symlink("real.txt", filepath.Join(ok, "link")))
 	mustNil(t, os.Chdir(ok))
-	if _, err := copyWorkspaceTree(".", filepath.Join(t.TempDir(), "outa"), nil); err != nil {
+	if _, err := copyWorkspaceForTest(t, ".", nil, defaultWorkspaceCopyLimits(), systemWorkspaceOps()); err != nil {
 		t.Fatalf("relative source with internal symlink rejected: %v", err)
 	}
 
@@ -103,7 +104,7 @@ func TestCopyWorkspaceTreeRelativeSourceSymlink(t *testing.T) {
 	bad := t.TempDir()
 	mustNil(t, os.Symlink("../escape", filepath.Join(bad, "esc")))
 	mustNil(t, os.Chdir(bad))
-	if _, err := copyWorkspaceTree(".", filepath.Join(t.TempDir(), "outb"), nil); err == nil {
+	if _, err := copyWorkspaceForTest(t, ".", nil, defaultWorkspaceCopyLimits(), systemWorkspaceOps()); err == nil {
 		t.Fatalf("escaping symlink accepted")
 	}
 }
@@ -197,8 +198,9 @@ func TestCopyWorkspaceTreeExcludesGitCaseInsensitive(t *testing.T) {
 	mustNil(t, os.MkdirAll(filepath.Join(src, ".GIT"), 0o755))
 	mustNil(t, os.WriteFile(filepath.Join(src, ".GIT", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
 	mustNil(t, os.WriteFile(filepath.Join(src, "keep.txt"), []byte("x\n"), 0o644))
-	dst := filepath.Join(t.TempDir(), "out")
-	entries, err := copyWorkspaceTree(src, dst, []string{".git"})
+	parent, parentFD := workspaceTestParent(t)
+	dst := filepath.Join(parent, "out")
+	entries, err := copyWorkspaceTreeDescriptor(src, parentFD, "out", []string{".git"})
 	mustNil(t, err)
 	if _, err := os.Stat(filepath.Join(dst, ".GIT")); !os.IsNotExist(err) {
 		t.Fatalf(".GIT leaked into the materialized workspace")
@@ -213,26 +215,21 @@ func TestCopyWorkspaceTreeExcludesGitCaseInsensitive(t *testing.T) {
 	}
 }
 
-// TestPathAndExclusionCaseInsensitivity unit-tests the case-insensitive,
-// component-aware containment and exclusion comparisons.
-func TestPathAndExclusionCaseInsensitivity(t *testing.T) {
+// TestWorkspaceExclusionCaseInsensitivity checks the active exclusion policy.
+// Shared pathutil tests cover normalized containment and component boundaries.
+func TestWorkspaceExclusionCaseInsensitivity(t *testing.T) {
 	t.Parallel()
 
-	if !pathWithin("/foo/bar", "/FOO/BAR/baz") {
-		t.Fatalf("case-insensitive containment not detected")
-	}
-	if pathWithin("/foo", "/foobar") {
-		t.Fatalf("/foobar wrongly treated as inside /foo (component boundary)")
-	}
-	if pathWithin("/foo", "/foo") {
-		t.Fatalf("equal path wrongly treated as strictly within")
-	}
 	for _, name := range []string{".GIT", ".Git", ".git/config", ".GIT/hooks/pre-commit"} {
-		if !isExcludedPath(name, []string{".git"}) {
+		excluded, err := isExcludedPathSafe(name, []string{".git"})
+		mustNil(t, err)
+		if !excluded {
 			t.Fatalf("%q not excluded case-insensitively", name)
 		}
 	}
-	if isExcludedPath(".gitignore", []string{".git"}) {
+	excluded, err := isExcludedPathSafe(".gitignore", []string{".git"})
+	mustNil(t, err)
+	if excluded {
 		t.Fatalf(".gitignore wrongly excluded (component boundary)")
 	}
 }


### PR DESCRIPTION
Delete the dead pre-descriptor workspace copier from `internal/applecontainer`.

## Summary

- Remove `copyWorkspaceTree`, `pathWithin`, and `isExcludedPath` from `internal/applecontainer/target.go` (-152 lines). All three lost their last caller when the descriptor-based copier landed; nothing in the package referenced them.
- The live materialization path is unchanged: `copyWorkspaceTreeWithOps` / `copyWorkspaceTreeFromDescriptor` in `workspace_copy.go`, with `isExcludedPathSafe` as the exclusion policy.
- Repoint the four tests that still exercised the deleted code at the live implementation, so the behavior they guard keeps a real assertion instead of disappearing with the function:
  - `TestCopyWorkspaceTreePreservesFileMode` and `TestCopyWorkspaceTreeExcludesGitCaseInsensitive` now drive `copyWorkspaceTreeDescriptor` against a pinned parent FD.
  - `TestCopyWorkspaceTreeRelativeSourceSymlink` now drives `copyWorkspaceForTest`.
  - `TestPathAndExclusionCaseInsensitivity` becomes `TestWorkspaceExclusionCaseInsensitivity`, keeping the exclusion assertions against `isExcludedPathSafe`.
- The dropped `pathWithin` assertions (case-insensitive containment, `/foo` vs `/foobar` component boundary, equal-path) are not lost coverage: `pathutil.TestWithinOrEqualUnicodeAndBoundaries` covers case-fold containment and the sibling-prefix boundary (`/tmp/root` vs `/tmp/root-other/file`) against the shared implementation.
- The near-identical `copyWorkspaceTree` / `isExcludedPath` in `internal/remotevm/fake_target.go` are a separate live copy for the fake target and are deliberately untouched.

Net -155 lines, no production behavior change.

## Testing

- `go build ./...` — clean
- `go vet ./internal/applecontainer/` — clean
- `go test ./internal/applecontainer/ ./internal/pathutil/ -count=1` — both ok
- `go test ./internal/applecontainer/ -count=1 -v -run 'TestCopyWorkspaceTree|TestWorkspaceExclusionCaseInsensitivity'` — all 4 repointed tests RUN and PASS (confirmed not silently skipped)
- `go test ./internal/remotevm/ ./internal/injection/ -count=1` — both ok (packages holding their own copies of the deleted helpers)
