### PR TITLE
^R Remove duplicate workflow lint runs and mutation-copy waste

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -102,8 +102,10 @@ jobs:
         env:
           WORKCELL_VALIDATOR_IMAGE: workcell-validator:${{ github.sha }}
           WORKCELL_VALIDATOR_BUILDX_CACHE_MODE: gha
-          # docs.yml-scoped cache namespace to avoid colliding with the
-          # validator-main / validator-pr-* scopes used by ci.yml.
-          WORKCELL_VALIDATOR_BUILDX_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('validator-docs-pr-{0}', github.event.pull_request.number) || 'validator-docs-main' }}
+          # Shares the validator-main / validator-pr-* cache scopes with
+          # ci.yml so this build reuses the layers ci.yml already built for
+          # the same commit. Concurrent writes to one scope are safe: cache
+          # entries are content-addressed and reads never block.
+          WORKCELL_VALIDATOR_BUILDX_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('validator-pr-{0}', github.event.pull_request.number) || 'validator-main' }}
           WORKCELL_VALIDATOR_BUILDX_CACHE_WRITE_MODE: ${{ github.event_name == 'push' && 'max' || 'min' }}
         run: ./scripts/ci/job-docs.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,37 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   plane.
 - Ship invariant checks with new controls whenever practical.
 
+## Code Review Rules
+
+### Security boundaries
+
+- Flag any change that widens the VM or container boundary, adds a host
+  mount, or passes a host credential, socket, or auth state into the runtime.
+- Flag any file access that trusts a path across a check/use gap: opens
+  without `O_NOFOLLOW` parent-descriptor discipline, containment checks on
+  non-canonical paths, or symlinked parents.
+- Flag any state write without staged rename, fsync of the file and its
+  created parents, and owner-only modes.
+
+### Contract lockstep
+
+- Flag any edit to one of `adapters/codex/.codex/config.toml`,
+  `adapters/codex/managed_config.toml`, `adapters/codex/requirements.toml`,
+  or `adapters/codex/.codex/rules/default.rules` without the matching edits
+  and validator updates in the aligned files.
+- Flag any control-plane file change without a regenerated
+  `runtime/container/control-plane-manifest.json` and updated contract
+  fixtures.
+
+### Validation honesty
+
+- Flag any documentation claim of an enforcement that no test or control
+  proves.
+- Flag any new validator that matches bare substrings instead of anchored,
+  comment-stripped syntax, or that ships without a negative fixture.
+- Flag any external lookup or parser that treats an error as absence or
+  success instead of failing closed.
+
 ## Pull request workflow
 
 - For publish, PR follow-up, or merge requests in this repository, use the

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -336,9 +336,12 @@ func runRustGuardMutations(repoRoot string) (killed, total int, survivors []stri
 			}
 			defer os.RemoveAll(tempRoot)
 
+			// Local target/ trees hold hundreds of megabytes of build
+			// artifacts that no scoped test reads.
 			if err := copyTree(
 				filepath.Join(repoRoot, "runtime", "container", "rust"),
 				filepath.Join(tempRoot, "runtime", "container", "rust"),
+				"target",
 			); err != nil {
 				results <- result{label: tc.label, err: err}
 				return
@@ -440,10 +443,17 @@ func applyMutation(path string, original string, replacement string) error {
 	return os.WriteFile(path, []byte(updated), info.Mode().Perm())
 }
 
-func copyTree(sourceRoot string, destinationRoot string) error {
+func copyTree(sourceRoot string, destinationRoot string, skipDirNames ...string) error {
 	return filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if d.IsDir() {
+			for _, skip := range skipDirNames {
+				if d.Name() == skip && path != sourceRoot {
+					return fs.SkipDir
+				}
+			}
 		}
 		relative, err := filepath.Rel(sourceRoot, path)
 		if err != nil {

--- a/internal/mutation/runner_test.go
+++ b/internal/mutation/runner_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package mutation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyTreeSkipsNamedDirectories(t *testing.T) {
+	source := t.TempDir()
+	destination := filepath.Join(t.TempDir(), "copy")
+	for _, dir := range []string{"src", "target/debug", "fuzz/target", "fuzz/artifacts"} {
+		if err := os.MkdirAll(filepath.Join(source, dir), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	for _, file := range []string{"Cargo.toml", "src/lib.rs", "target/debug/artifact.bin", "fuzz/target/artifact.bin", "fuzz/artifacts/crash-1"} {
+		if err := os.WriteFile(filepath.Join(source, file), []byte("content\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+
+	if err := copyTree(source, destination, "target", "artifacts"); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+
+	for _, file := range []string{"Cargo.toml", "src/lib.rs"} {
+		if _, err := os.Stat(filepath.Join(destination, file)); err != nil {
+			t.Errorf("expected %s in the copy: %v", file, err)
+		}
+	}
+	for _, path := range []string{"target", "fuzz/target", "fuzz/artifacts"} {
+		if _, err := os.Stat(filepath.Join(destination, path)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be skipped, stat err = %v", path, err)
+		}
+	}
+}
+
+func TestCopyTreeWithoutSkipsCopiesEverything(t *testing.T) {
+	source := t.TempDir()
+	destination := filepath.Join(t.TempDir(), "copy")
+	if err := os.MkdirAll(filepath.Join(source, "target"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "target", "keep.txt"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := copyTree(source, destination); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, "target", "keep.txt")); err != nil {
+		t.Errorf("expected unskipped copy to keep target/keep.txt: %v", err)
+	}
+}

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -16,12 +16,9 @@ require_tool() {
 require_tool actionlint
 require_tool zizmor
 
-(
-  cd "${ROOT_DIR}"
-  actionlint
-)
-zizmor --persona auditor --config "${ROOT_DIR}/.github/zizmor.yml" "${ROOT_DIR}/.github/workflows/"*.yml
-
+# workcell-citools check-workflows runs actionlint and the zizmor scan
+# (persona auditor, .github/zizmor.yml, all workflow files) itself, so no
+# direct actionlint or zizmor call runs here.
 run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools check-workflows "${ROOT_DIR}" "${POLICY_PATH}"
 "${ROOT_DIR}/scripts/verify-workflow-lanes.sh"
 run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools check-retention-policy "${ROOT_DIR}" "${ROOT_DIR}/policy/retention-policy.json"

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -6,19 +6,8 @@ POLICY_PATH="${ROOT_DIR}/policy/github-hosted-controls.toml"
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
 
-require_tool() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required tool: $1" >&2
-    exit 1
-  }
-}
-
-require_tool actionlint
-require_tool zizmor
-
-# workcell-citools check-workflows runs actionlint and the zizmor scan
-# (persona auditor, .github/zizmor.yml, all workflow files) itself, so no
-# direct actionlint or zizmor call runs here.
+# check-workflows requires actionlint and zizmor, and runs both itself
+# (zizmor with persona auditor, .github/zizmor.yml, every workflow file).
 run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools check-workflows "${ROOT_DIR}" "${POLICY_PATH}"
 "${ROOT_DIR}/scripts/verify-workflow-lanes.sh"
 run_go_in_repo "${ROOT_DIR}" run ./cmd/workcell-citools check-retention-policy "${ROOT_DIR}" "${ROOT_DIR}/policy/retention-policy.json"


### PR DESCRIPTION
Loop-waste reduction: three independent cuts to repeated work, plus the reviewer rules that keep the cuts honest.

## Summary

- `scripts/check-workflows.sh`: drop the direct `actionlint` and `zizmor` invocations. `workcell-citools check-workflows` already calls `metadatautil.EnsureWorkflowTools`, which runs `actionlint` from the repo root and `zizmor --persona auditor --config .github/zizmor.yml` over every `.github/workflows/*.yml`. The scan is identical; it just ran twice per check. The script's `require_tool actionlint` / `require_tool zizmor` preflight went with it — `EnsureWorkflowTools` does its own `exec.LookPath` and fails with the same "is required for workflow validation" message.
- `.github/workflows/docs.yml`: share the `validator-main` / `validator-pr-*` buildx cache scopes with `ci.yml` instead of keeping a private `validator-docs-*` namespace, so the docs job reuses the layers `ci.yml` already built for the same commit. Cache entries are content-addressed, so concurrent writes to one scope are safe.
- `internal/mutation/runner.go`: `copyTree` takes optional `skipDirNames`, and the Rust guard-mutation copy skips `target`. Those trees hold hundreds of megabytes of build artifacts that no scoped test reads, recopied per mutation case. The other `copyTree` caller is unchanged.
- `AGENTS.md`: add the Code Review Rules section (security boundaries, contract lockstep, validation honesty) so the review invariants are stated where reviewers read them.

## Testing

- `go test ./internal/mutation/ -count=1` — ok (0.257s), including the two new `copyTree` skip/no-skip cases.
- `go test ./internal/testkit/ ./internal/metadatautil/ -count=1` — both ok (63.5s / 8.6s); these are the suites that pin script text and workflow validation.
- `./scripts/check-workflows.sh` — "Workcell workflow checks passed." end to end with the direct lint calls removed.
- `shellcheck scripts/check-workflows.sh` and `shfmt -d scripts/check-workflows.sh` — clean.
