### PR TITLE
Normalize control script modes before making them executable

### DIFF
--- a/internal/testkit/dockerfile_control_modes_test.go
+++ b/internal/testkit/dockerfile_control_modes_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	runtimeBuilderPermissionsStart = "RUN mkdir -p /etc/claude-code \\\n"
+	readOnlyControlScriptsStart    = "  && chmod 0444 \\\n    /usr/local/libexec/workcell/assurance.sh \\\n"
+	executableControlScriptsStart  = "  && chmod +x \\\n"
+	runtimeBuilderPermissionsEnd   = "  && find /opt/workcell/adapters /etc/claude-code /usr/local/libexec/workcell"
+)
+
+var executableControlScripts = []string{
+	"/usr/local/libexec/workcell/home-control-plane.sh",
+	"/usr/local/libexec/workcell/public-node-guard.mjs",
+	"/usr/local/libexec/workcell/provider-policy.sh",
+}
+
+func runtimeBuilderPermissions(dockerfile string) (string, error) {
+	start := strings.Index(dockerfile, runtimeBuilderPermissionsStart)
+	if start < 0 {
+		return "", fmt.Errorf("runtime-builder permission block start is missing")
+	}
+	remainder := dockerfile[start:]
+	end := strings.Index(remainder, runtimeBuilderPermissionsEnd)
+	if end < 0 {
+		return "", fmt.Errorf("runtime-builder permission block end is missing")
+	}
+	return remainder[:end], nil
+}
+
+func validateControlScriptModes(dockerfile string) error {
+	permissions, err := runtimeBuilderPermissions(dockerfile)
+	if err != nil {
+		return err
+	}
+	readOnly := strings.Index(permissions, readOnlyControlScriptsStart)
+	executable := strings.Index(permissions, executableControlScriptsStart)
+	if readOnly < 0 || executable < 0 || readOnly >= executable {
+		return fmt.Errorf("control script mode commands are missing or out of order")
+	}
+	return requireControlScripts(permissions[readOnly:executable], permissions[executable:])
+}
+
+func requireControlScripts(readOnly string, executable string) error {
+	for _, path := range executableControlScripts {
+		line := "    " + path + " \\\n"
+		if count := strings.Count(readOnly, line); count != 1 {
+			return fmt.Errorf("read-only mode includes %s %d times, want 1", path, count)
+		}
+		if count := strings.Count(executable, line); count != 1 {
+			return fmt.Errorf("executable mode includes %s %d times, want 1", path, count)
+		}
+	}
+	return nil
+}
+
+func reorderControlScriptModeCommands(dockerfile string) (string, error) {
+	permissions, err := runtimeBuilderPermissions(dockerfile)
+	if err != nil {
+		return "", err
+	}
+	readOnly := strings.Index(permissions, readOnlyControlScriptsStart)
+	executable := strings.Index(permissions, executableControlScriptsStart)
+	if readOnly < 0 || executable < 0 || readOnly >= executable {
+		return "", fmt.Errorf("control script mode commands cannot be reordered")
+	}
+	reordered := permissions[:readOnly] + permissions[executable:] + permissions[readOnly:executable]
+	return strings.Replace(dockerfile, permissions, reordered, 1), nil
+}
+
+func readRuntimeDockerfile(t *testing.T) string {
+	t.Helper()
+	dockerfilePath := filepath.Join(repoRoot(t), "runtime", "container", "Dockerfile")
+	dockerfileBytes, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(dockerfileBytes)
+}
+
+func TestDockerfileNormalizesControlScriptModesBeforeMakingThemExecutable(t *testing.T) {
+	if err := validateControlScriptModes(readRuntimeDockerfile(t)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDockerfileControlScriptModeValidationRejectsMissingReadOnlyMode(t *testing.T) {
+	dockerfile := readRuntimeDockerfile(t)
+	for _, path := range executableControlScripts {
+		t.Run(filepath.Base(path)+" missing read-only mode", func(t *testing.T) {
+			mutant := strings.Replace(dockerfile, "    "+path+" \\\n", "", 1)
+			if err := validateControlScriptModes(mutant); err == nil {
+				t.Fatal("validation accepted a control script without read-only mode normalization")
+			}
+		})
+	}
+}
+
+func TestDockerfileControlScriptModeValidationRejectsDuplicateReadOnlyPath(t *testing.T) {
+	dockerfile := readRuntimeDockerfile(t)
+	for _, path := range executableControlScripts {
+		line := "    " + path + " \\\n"
+		mutant := strings.Replace(dockerfile, line, line+line, 1)
+		if err := validateControlScriptModes(mutant); err == nil {
+			t.Fatalf("validation accepted duplicate read-only path %s", path)
+		}
+	}
+}
+
+func TestDockerfileControlScriptModeValidationRejectsDuplicateExecutablePath(t *testing.T) {
+	dockerfile := readRuntimeDockerfile(t)
+	for _, path := range executableControlScripts {
+		line := "    " + path + " \\\n"
+		mutant := strings.Replace(dockerfile, executableControlScriptsStart, executableControlScriptsStart+line, 1)
+		if err := validateControlScriptModes(mutant); err == nil {
+			t.Fatalf("validation accepted duplicate executable path %s", path)
+		}
+	}
+}
+
+func TestDockerfileControlScriptModeValidationRejectsReorderedCommands(t *testing.T) {
+	dockerfile := readRuntimeDockerfile(t)
+	mutant, err := reorderControlScriptModeCommands(dockerfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateControlScriptModes(mutant); err == nil {
+		t.Fatal("validation accepted executable mode before read-only mode normalization")
+	}
+}

--- a/internal/testkit/dockerfile_control_modes_test.go
+++ b/internal/testkit/dockerfile_control_modes_test.go
@@ -13,9 +13,9 @@ import (
 
 const (
 	runtimeBuilderPermissionsStart = "RUN mkdir -p /etc/claude-code \\\n"
-	readOnlyControlScriptsStart    = "  && chmod 0444 \\\n    /usr/local/libexec/workcell/assurance.sh \\\n"
-	executableControlScriptsStart  = "  && chmod +x \\\n"
 	runtimeBuilderPermissionsEnd   = "  && find /opt/workcell/adapters /etc/claude-code /usr/local/libexec/workcell"
+	readOnlyModeStart              = "  && chmod 0444 \\\n"
+	executableModeStart            = "  && chmod +x \\\n"
 )
 
 var executableControlScripts = []string{
@@ -24,33 +24,36 @@ var executableControlScripts = []string{
 	"/usr/local/libexec/workcell/provider-policy.sh",
 }
 
-func runtimeBuilderPermissions(dockerfile string) (string, error) {
+// splitControlScriptModes cuts the runtime-builder permission block into the
+// text preceding the last read-only chmod, that read-only chmod, and the
+// executable chmod that must follow it.
+func splitControlScriptModes(dockerfile string) (prefix string, readOnly string, executable string, err error) {
 	start := strings.Index(dockerfile, runtimeBuilderPermissionsStart)
 	if start < 0 {
-		return "", fmt.Errorf("runtime-builder permission block start is missing")
+		return "", "", "", fmt.Errorf("runtime-builder permission block start is missing")
 	}
-	remainder := dockerfile[start:]
-	end := strings.Index(remainder, runtimeBuilderPermissionsEnd)
+	permissions := dockerfile[start:]
+	end := strings.Index(permissions, runtimeBuilderPermissionsEnd)
 	if end < 0 {
-		return "", fmt.Errorf("runtime-builder permission block end is missing")
+		return "", "", "", fmt.Errorf("runtime-builder permission block end is missing")
 	}
-	return remainder[:end], nil
+	permissions = permissions[:end]
+	executableAt := strings.Index(permissions, executableModeStart)
+	if executableAt < 0 {
+		return "", "", "", fmt.Errorf("executable mode command is missing")
+	}
+	readOnlyAt := strings.LastIndex(permissions[:executableAt], readOnlyModeStart)
+	if readOnlyAt < 0 {
+		return "", "", "", fmt.Errorf("read-only mode command is missing before the executable mode command")
+	}
+	return permissions[:readOnlyAt], permissions[readOnlyAt:executableAt], permissions[executableAt:], nil
 }
 
 func validateControlScriptModes(dockerfile string) error {
-	permissions, err := runtimeBuilderPermissions(dockerfile)
+	_, readOnly, executable, err := splitControlScriptModes(dockerfile)
 	if err != nil {
 		return err
 	}
-	readOnly := strings.Index(permissions, readOnlyControlScriptsStart)
-	executable := strings.Index(permissions, executableControlScriptsStart)
-	if readOnly < 0 || executable < 0 || readOnly >= executable {
-		return fmt.Errorf("control script mode commands are missing or out of order")
-	}
-	return requireControlScripts(permissions[readOnly:executable], permissions[executable:])
-}
-
-func requireControlScripts(readOnly string, executable string) error {
 	for _, path := range executableControlScripts {
 		line := "    " + path + " \\\n"
 		if count := strings.Count(readOnly, line); count != 1 {
@@ -64,17 +67,11 @@ func requireControlScripts(readOnly string, executable string) error {
 }
 
 func reorderControlScriptModeCommands(dockerfile string) (string, error) {
-	permissions, err := runtimeBuilderPermissions(dockerfile)
+	prefix, readOnly, executable, err := splitControlScriptModes(dockerfile)
 	if err != nil {
 		return "", err
 	}
-	readOnly := strings.Index(permissions, readOnlyControlScriptsStart)
-	executable := strings.Index(permissions, executableControlScriptsStart)
-	if readOnly < 0 || executable < 0 || readOnly >= executable {
-		return "", fmt.Errorf("control script mode commands cannot be reordered")
-	}
-	reordered := permissions[:readOnly] + permissions[executable:] + permissions[readOnly:executable]
-	return strings.Replace(dockerfile, permissions, reordered, 1), nil
+	return strings.Replace(dockerfile, prefix+readOnly+executable, prefix+executable+readOnly, 1), nil
 }
 
 func readRuntimeDockerfile(t *testing.T) string {
@@ -96,12 +93,10 @@ func TestDockerfileNormalizesControlScriptModesBeforeMakingThemExecutable(t *tes
 func TestDockerfileControlScriptModeValidationRejectsMissingReadOnlyMode(t *testing.T) {
 	dockerfile := readRuntimeDockerfile(t)
 	for _, path := range executableControlScripts {
-		t.Run(filepath.Base(path)+" missing read-only mode", func(t *testing.T) {
-			mutant := strings.Replace(dockerfile, "    "+path+" \\\n", "", 1)
-			if err := validateControlScriptModes(mutant); err == nil {
-				t.Fatal("validation accepted a control script without read-only mode normalization")
-			}
-		})
+		mutant := strings.Replace(dockerfile, "    "+path+" \\\n", "", 1)
+		if err := validateControlScriptModes(mutant); err == nil {
+			t.Fatalf("validation accepted %s without read-only mode normalization", path)
+		}
 	}
 }
 
@@ -120,7 +115,7 @@ func TestDockerfileControlScriptModeValidationRejectsDuplicateExecutablePath(t *
 	dockerfile := readRuntimeDockerfile(t)
 	for _, path := range executableControlScripts {
 		line := "    " + path + " \\\n"
-		mutant := strings.Replace(dockerfile, executableControlScriptsStart, executableControlScriptsStart+line, 1)
+		mutant := strings.Replace(dockerfile, executableModeStart, executableModeStart+line, 1)
 		if err := validateControlScriptModes(mutant); err == nil {
 			t.Fatalf("validation accepted duplicate executable path %s", path)
 		}

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -518,7 +518,10 @@ RUN mkdir -p /etc/claude-code \
     /usr/local/libexec/workcell/development-wrapper.sh \
     /usr/local/libexec/workcell/entrypoint.sh \
     /usr/local/libexec/workcell/git-wrapper.sh \
+    /usr/local/libexec/workcell/home-control-plane.sh \
     /usr/local/libexec/workcell/node-wrapper.sh \
+    /usr/local/libexec/workcell/public-node-guard.mjs \
+    /usr/local/libexec/workcell/provider-policy.sh \
     /usr/local/libexec/workcell/provider-wrapper.sh \
     /usr/local/libexec/workcell/sudo-wrapper.sh \
     /usr/local/libexec/workcell/runtime-user.sh \


### PR DESCRIPTION
Three control scripts were made executable in the runtime-builder stage without first being normalized to a known mode. Whatever mode they carried out of `COPY` was the mode they kept, plus `+x` — so the shipped permissions depended on the build host's umask and on the source file bits rather than on the Dockerfile.

## Summary

- Add `home-control-plane.sh`, `public-node-guard.mjs`, and `provider-policy.sh` to the `chmod 0444` list that precedes `chmod +x`, matching every other control script in the block. The scripts end up 0555 deterministically instead of inheriting whatever `COPY` produced.
- Add `internal/testkit/dockerfile_control_modes_test.go`, which pins the invariant: each of those paths appears exactly once in the read-only chmod and exactly once in the executable chmod, and the read-only chmod comes first. Mutation guards cover a dropped path, a duplicated path on either side, and the two commands swapped.

No behavioural change to the scripts themselves — this only makes the resulting file modes reproducible.

## Testing

- `gofmt -l internal/testkit/` — no output.
- `go vet ./internal/testkit/` — clean.
- `go test ./internal/testkit/ -run 'ControlScript' -count=1 -v` — 5/5 pass.
- Regression proof: deleted the `home-control-plane.sh` line from `runtime/container/Dockerfile` and re-ran the suite — `TestDockerfileNormalizesControlScriptModesBeforeMakingThemExecutable` failed with `read-only mode includes /usr/local/libexec/workcell/home-control-plane.sh 0 times, want 1`. Dockerfile restored, suite green again.
