### PR TITLE
Bind privileged workflow dispatch to main

### DIFF
--- a/.github/workflows/hosted-controls.yml
+++ b/.github/workflows/hosted-controls.yml
@@ -22,6 +22,7 @@ jobs:
   verify-hosted-controls:
     name: Hosted controls verification
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     timeout-minutes: 20
     environment:
       name: hosted-controls-audit

--- a/.github/workflows/upstream-refresh.yml
+++ b/.github/workflows/upstream-refresh.yml
@@ -24,6 +24,7 @@ jobs:
   refresh:
     name: Refresh pinned upstreams
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     timeout-minutes: 20
     environment:
       name: upstream-refresh

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -461,17 +461,7 @@ func (check *pinnedInputsCheck) validateHostedControlsWorkflow() error {
 	if err != nil {
 		return err
 	}
-	for _, needle := range []string{
-		`name: hosted-controls-audit`,
-		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
-		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
-		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
-	} {
-		if !strings.Contains(workflow, needle) {
-			return fmt.Errorf(".github/workflows/hosted-controls.yml must contain %q", needle)
-		}
-	}
-	return nil
+	return ValidateHostedControlsWorkflow(workflow)
 }
 
 func (check *pinnedInputsCheck) validateReleaseVerificationJobs() error {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -152,6 +152,20 @@ func requirePinnedInputsErrorContains(tb testing.TB, cfg metadatautil.PinnedInpu
 	}
 }
 
+func TestCheckPinnedInputsRejectsManualPrivilegedWorkflowWithoutMainGuard(t *testing.T) {
+	for _, workflowPath := range []string{
+		".github/workflows/hosted-controls.yml",
+		".github/workflows/upstream-refresh.yml",
+	} {
+		t.Run(workflowPath, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, workflowPath, func(content string) string {
+				return strings.Replace(content, "    if: github.ref == 'refs/heads/main'\n", "", 1)
+			})
+			requirePinnedInputsErrorContains(t, cfg, "github.ref == 'refs/heads/main'")
+		})
+	}
+}
+
 func TestCheckPinnedInputsRejectsHostedControlAPIVersionDrift(t *testing.T) {
 	cfg := rewritePinnedInputsFixtureFile(t, "scripts/verify-github-hosted-controls.sh", func(content string) string {
 		return strings.Replace(content, `readonly GITHUB_API_VERSION="2026-03-10"`, `readonly GITHUB_API_VERSION="2022-11-28"`, 1)

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -894,6 +894,7 @@ env:
 
 jobs:
   refresh:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: upstream-refresh
     permissions:
@@ -940,6 +941,91 @@ jobs:
 
 	if err := metadatautil.ValidateUpstreamRefreshWorkflow(workflow); err != nil {
 		t.Fatalf("metadatautil.ValidateUpstreamRefreshWorkflow() error = %v", err)
+	}
+	assertManualWorkflowMainRefGuard(t, workflow, metadatautil.ValidateUpstreamRefreshWorkflow)
+}
+
+func TestValidateHostedControlsWorkflowRequiresMainRef(t *testing.T) {
+	t.Parallel()
+	workflow := `name: Hosted controls
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify-hosted-controls:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: hosted-controls-audit
+    steps:
+      - name: Verify GitHub-hosted controls
+        env:
+          WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
+          WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
+        run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"
+`
+
+	if err := metadatautil.ValidateHostedControlsWorkflow(workflow); err != nil {
+		t.Fatalf("metadatautil.ValidateHostedControlsWorkflow() error = %v", err)
+	}
+	assertManualWorkflowMainRefGuard(t, workflow, metadatautil.ValidateHostedControlsWorkflow)
+}
+
+func TestValidateHostedControlsWorkflowRejectsAmbiguousJobMappings(t *testing.T) {
+	t.Parallel()
+	const workflow = `name: Hosted controls
+jobs:
+  verify-hosted-controls:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: hosted-controls-audit
+    steps:
+      - env:
+          WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
+          WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
+        run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"
+`
+	mutations := []struct {
+		name        string
+		old         string
+		replacement string
+	}{
+		{name: "duplicate jobs", old: "jobs:\n", replacement: "jobs: {}\njobs:\n"},
+		{name: "duplicate target job", old: "  verify-hosted-controls:\n", replacement: "  verify-hosted-controls: {}\n  verify-hosted-controls:\n"},
+		{name: "target job is not a mapping", old: "  verify-hosted-controls:\n", replacement: "  verify-hosted-controls: true\n  unrelated:\n"},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			mutated := strings.Replace(workflow, mutation.old, mutation.replacement, 1)
+			if err := metadatautil.ValidateHostedControlsWorkflow(mutated); err == nil {
+				t.Fatal("metadatautil.ValidateHostedControlsWorkflow() unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func assertManualWorkflowMainRefGuard(t *testing.T, workflow string, validate func(string) error) {
+	t.Helper()
+	const guard = "    if: github.ref == 'refs/heads/main'"
+	mutations := []struct {
+		name        string
+		replacement string
+	}{
+		{name: "missing", replacement: ""},
+		{name: "wrong ref", replacement: "    if: github.ref == 'refs/heads/release'"},
+		{name: "fail open", replacement: "    if: always()"},
+		{name: "duplicate", replacement: guard + "\n" + guard},
+		{name: "boolean", replacement: "    if: true"},
+		{name: "mapping", replacement: "    if: {ref: main}"},
+		{name: "sibling text", replacement: "    note: \"github.ref == 'refs/heads/main'\""},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			mutated := strings.Replace(workflow, guard, mutation.replacement, 1)
+			if err := validate(mutated); err == nil || !strings.Contains(err.Error(), guard[8:]) {
+				t.Fatalf("validator error = %v, want main-ref guard rejection", err)
+			}
+		})
 	}
 }
 

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -464,7 +464,11 @@ func validateManualPrivilegedWorkflowRef(workflowText, workflowPath, jobName str
 	if err != nil {
 		return err
 	}
-	return validateWorkflowMainRef(job, workflowPath, jobName)
+	guards := yamlMappingValues(job, "if")
+	if len(guards) != 1 || guards[0].Tag != "!!str" || yamlScalarValue(guards[0]) != "github.ref == 'refs/heads/main'" {
+		return fmt.Errorf("%s %s job must require github.ref == 'refs/heads/main'", workflowPath, jobName)
+	}
+	return nil
 }
 
 func requireWorkflowMapping(parent *yaml.Node, key, message string) (*yaml.Node, error) {
@@ -473,25 +477,6 @@ func requireWorkflowMapping(parent *yaml.Node, key, message string) (*yaml.Node,
 		return nil, errors.New(message)
 	}
 	return values[0], nil
-}
-
-func validateWorkflowMainRef(job *yaml.Node, workflowPath, jobName string) error {
-	guards := yamlMappingValues(job, "if")
-	if len(guards) != 1 {
-		return mainRefGuardError(workflowPath, jobName)
-	}
-	guard := guards[0]
-	if guard.Kind != yaml.ScalarNode || guard.Tag != "!!str" {
-		return mainRefGuardError(workflowPath, jobName)
-	}
-	if strings.TrimSpace(guard.Value) != "github.ref == 'refs/heads/main'" {
-		return mainRefGuardError(workflowPath, jobName)
-	}
-	return nil
-}
-
-func mainRefGuardError(workflowPath, jobName string) error {
-	return fmt.Errorf("%s %s job must require github.ref == 'refs/heads/main'", workflowPath, jobName)
 }
 
 // readText lives in core.go.

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -434,7 +434,64 @@ func ValidateUpstreamRefreshWorkflow(workflowText string) error {
 			return fmt.Errorf(".github/workflows/upstream-refresh.yml must not contain %q", forbidden)
 		}
 	}
+	return validateManualPrivilegedWorkflowRef(workflowText, ".github/workflows/upstream-refresh.yml", "refresh")
+}
+
+func ValidateHostedControlsWorkflow(workflowText string) error {
+	for _, needle := range []string{
+		`name: hosted-controls-audit`,
+		`run: ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		`WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}`,
+		`WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"`,
+	} {
+		if !strings.Contains(workflowText, needle) {
+			return fmt.Errorf(".github/workflows/hosted-controls.yml must contain %q", needle)
+		}
+	}
+	return validateManualPrivilegedWorkflowRef(workflowText, ".github/workflows/hosted-controls.yml", "verify-hosted-controls")
+}
+
+func validateManualPrivilegedWorkflowRef(workflowText, workflowPath, jobName string) error {
+	root, err := parseWorkflowRoot(workflowText, workflowPath)
+	if err != nil {
+		return err
+	}
+	jobs, err := requireWorkflowMapping(root, "jobs", workflowPath+" must define exactly one jobs mapping")
+	if err != nil {
+		return err
+	}
+	job, err := requireWorkflowMapping(jobs, jobName, workflowPath+" must define exactly one "+jobName+" job mapping")
+	if err != nil {
+		return err
+	}
+	return validateWorkflowMainRef(job, workflowPath, jobName)
+}
+
+func requireWorkflowMapping(parent *yaml.Node, key, message string) (*yaml.Node, error) {
+	values := yamlMappingValues(parent, key)
+	if len(values) != 1 || values[0].Kind != yaml.MappingNode {
+		return nil, errors.New(message)
+	}
+	return values[0], nil
+}
+
+func validateWorkflowMainRef(job *yaml.Node, workflowPath, jobName string) error {
+	guards := yamlMappingValues(job, "if")
+	if len(guards) != 1 {
+		return mainRefGuardError(workflowPath, jobName)
+	}
+	guard := guards[0]
+	if guard.Kind != yaml.ScalarNode || guard.Tag != "!!str" {
+		return mainRefGuardError(workflowPath, jobName)
+	}
+	if strings.TrimSpace(guard.Value) != "github.ref == 'refs/heads/main'" {
+		return mainRefGuardError(workflowPath, jobName)
+	}
 	return nil
+}
+
+func mainRefGuardError(workflowPath, jobName string) error {
+	return fmt.Errorf("%s %s job must require github.ref == 'refs/heads/main'", workflowPath, jobName)
 }
 
 // readText lives in core.go.


### PR DESCRIPTION
Both privileged `workflow_dispatch` workflows could be run from any branch. `hosted-controls.yml` reaches the `hosted-controls-audit` environment and `WORKCELL_HOSTED_CONTROLS_TOKEN`; `upstream-refresh.yml` reaches the `upstream-refresh` environment. A contributor with dispatch rights could therefore run privileged, environment-bound jobs against arbitrary branch content. Both jobs are now bound to `main`, and the invariant checks enforce the binding.

## Summary

- Add `if: github.ref == 'refs/heads/main'` to the `verify-hosted-controls` and `refresh` jobs.
- Extract `ValidateHostedControlsWorkflow` from `pinnedInputsCheck.validateHostedControlsWorkflow`, so the hosted-controls workflow has a testable validator like the upstream-refresh one. The existing needle checks move unchanged.
- Both validators now call `validateManualPrivilegedWorkflowRef`, which parses the workflow YAML and requires exactly one string `if:` on the named job, equal to `github.ref == 'refs/heads/main'`. It uses the existing `parseWorkflowRoot`, `yamlMappingValues`, and `yamlScalarValue` helpers, so a matching string in a comment, a sibling key, a second job, or a duplicated `jobs:` mapping cannot satisfy the guard.
- Mutation guards cover a missing guard, a wrong ref, `always()`, a duplicate `if:`, a bare boolean, a mapping value, and guard text moved to a sibling key. Ambiguity guards cover duplicate `jobs:`, a duplicate target job, and a non-mapping job. Fixture tests strip the guard from each real workflow file and require rejection.

The guard binds dispatch to the `main` ref only. It does not restrict who may dispatch; environment reviewers and repository permissions still govern that.

## Testing

- `gofmt -l internal/metadatautil/` — no output.
- `go vet ./internal/metadatautil/` — pass.
- `go test ./internal/metadatautil/ -count=1` — ok, 21.4s.
- `go test ./internal/metadatautil/ -count=1 -run 'MainRef|AmbiguousJobMappings|UpstreamRefreshWorkflow' -v` — pass; all 7 main-ref mutations and all 3 ambiguity mutations rejected for both workflows.
