### PR TITLE
Bound injection input reads and direct-mount counts

### DIFF
--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -371,6 +371,23 @@ credentials, and copies.
 
 ## Explicit limits
 
+### Selected input trust boundary
+
+These limits apply to the host material that a policy selects.
+They apply to `[documents]`, `[credentials]`, `[ssh]`, `[[copies]]`, and direct
+mounts.
+
+Workcell accepts at most 16 MiB for one selected file.
+Workcell accepts at most 64 MiB and 4,096 entries for one render.
+One direct-mount staging pass has the same 64 MiB and 4,096-entry allowance.
+The byte and entry counts are the total of all selected inputs in that pass.
+A selected directory counts each descendant against the entry allowance.
+Workcell rejects the render when a selected input passes an allowance.
+
+Workcell accepts at most 4,096 bytes for a direct-mount source path.
+Workcell accepts at most 4,096 bytes for a direct-mount mount path.
+Workcell accepts at most 4,096 entries in one direct-mount specification.
+
 ### Policy reader trust boundary
 
 The policy reader accepts at most 16 MiB for one policy file.

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -384,9 +384,11 @@ The byte and entry counts are the total of all selected inputs in that pass.
 A selected directory counts each descendant against the entry allowance.
 Workcell rejects the render when a selected input passes an allowance.
 
-Workcell fingerprints a selected directory for the manifest.
-That fingerprint reads the tree again with the same file, byte, and entry
-allowance, because the host material can change after the first check.
+Workcell fingerprints each selected input for the manifest.
+The fingerprint reads the material again, because the host material can change
+after the first check.
+That second read has its own 64 MiB and 4,096-entry allowance for the whole
+manifest, and the same 16 MiB per-file limit.
 
 Workcell accepts at most 4,096 bytes for a direct-mount source path.
 Workcell accepts at most 4,096 bytes for a direct-mount mount path.

--- a/docs/injection-policy.md
+++ b/docs/injection-policy.md
@@ -384,6 +384,10 @@ The byte and entry counts are the total of all selected inputs in that pass.
 A selected directory counts each descendant against the entry allowance.
 Workcell rejects the render when a selected input passes an allowance.
 
+Workcell fingerprints a selected directory for the manifest.
+That fingerprint reads the tree again with the same file, byte, and entry
+allowance, because the host material can change after the first check.
+
 Workcell accepts at most 4,096 bytes for a direct-mount source path.
 Workcell accepts at most 4,096 bytes for a direct-mount mount path.
 Workcell accepts at most 4,096 entries in one direct-mount specification.

--- a/internal/injection/input_limits.go
+++ b/internal/injection/input_limits.go
@@ -4,12 +4,9 @@
 package injection
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/omkhar/workcell/internal/runtimeutil"
 )
 
 // Injection inputs are operator-selected host material. These limits bound
@@ -18,11 +15,8 @@ const (
 	maxInjectionFileBytes      int64 = 16 * 1024 * 1024
 	maxInjectionTreeBytes      int64 = 64 * 1024 * 1024
 	maxInjectionTreeEntries          = 4096
-	maxInjectionMounts               = runtimeutil.MaxDirectMountEntries
 	maxInjectionMountPathBytes       = 4096
 )
-
-var errInjectionInputTooLarge = errors.New("injection input exceeds its read limit")
 
 // injectionTreeBudget accumulates the bytes and entries consumed by every
 // selected input in one bundle render or one direct-mount staging pass, so a
@@ -86,23 +80,10 @@ func accountInjectionSourceSize(source Path, budget *injectionTreeBudget) error 
 	return accountInjectionFileSize(info.Size(), source.String(), budget)
 }
 
-func readBounded(reader io.Reader, limit int64) ([]byte, error) {
-	if limit < 0 {
-		return nil, errInjectionInputTooLarge
-	}
-	data, err := io.ReadAll(io.LimitReader(reader, limit+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > limit {
-		return nil, errInjectionInputTooLarge
-	}
-	return data, nil
-}
-
 // readInjectionFile reads an already-opened injection input under the smaller
-// of the per-file limit and the budget's remaining bytes. The read itself is
-// bounded, so an oversize input is refused without being buffered whole.
+// of the per-file limit and the budget's remaining bytes. The read stops one
+// byte past that limit, so an oversize input is refused without being buffered
+// whole.
 func readInjectionFile(reader io.Reader, source string, budget *injectionTreeBudget) ([]byte, error) {
 	limit := maxInjectionFileBytes
 	limitDescription := fmt.Sprintf("the per-file limit of %d bytes", maxInjectionFileBytes)
@@ -110,12 +91,12 @@ func readInjectionFile(reader io.Reader, source string, budget *injectionTreeBud
 		limit = budget.remainingBytes()
 		limitDescription = fmt.Sprintf("the aggregate tree limit of %d bytes", maxInjectionTreeBytes)
 	}
-	data, err := readBounded(reader, limit)
-	if errors.Is(err, errInjectionInputTooLarge) {
-		return nil, fmt.Errorf("injection input %s exceeds %s", source, limitDescription)
-	}
+	data, err := io.ReadAll(io.LimitReader(reader, limit+1))
 	if err != nil {
 		return nil, fmt.Errorf("read injection input %s: %w", source, err)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("injection input %s exceeds %s", source, limitDescription)
 	}
 	if budget != nil {
 		budget.bytes += int64(len(data))

--- a/internal/injection/input_limits.go
+++ b/internal/injection/input_limits.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omkhar/workcell/internal/runtimeutil"
+)
+
+// Injection inputs are operator-selected host material. These limits bound
+// memory, disk, and metadata work when a selected file or directory is staged.
+const (
+	maxInjectionFileBytes      int64 = 16 * 1024 * 1024
+	maxInjectionTreeBytes      int64 = 64 * 1024 * 1024
+	maxInjectionTreeEntries          = 4096
+	maxInjectionMounts               = runtimeutil.MaxDirectMountEntries
+	maxInjectionMountPathBytes       = 4096
+)
+
+var errInjectionInputTooLarge = errors.New("injection input exceeds its read limit")
+
+// injectionTreeBudget accumulates the bytes and entries consumed by every
+// selected input in one bundle render or one direct-mount staging pass, so a
+// set of individually legal inputs cannot add up to an unbounded copy.
+type injectionTreeBudget struct {
+	bytes   int64
+	entries int
+}
+
+func newInjectionTreeBudget() *injectionTreeBudget {
+	return &injectionTreeBudget{}
+}
+
+func (budget *injectionTreeBudget) remainingBytes() int64 {
+	return maxInjectionTreeBytes - budget.bytes
+}
+
+func (budget *injectionTreeBudget) remainingEntries() int {
+	return maxInjectionTreeEntries - budget.entries
+}
+
+func (budget *injectionTreeBudget) addEntries(source string, count int) error {
+	if count > budget.remainingEntries() {
+		return fmt.Errorf("injection tree %s exceeds the aggregate entry limit of %d", source, maxInjectionTreeEntries)
+	}
+	budget.entries += count
+	return nil
+}
+
+// accountInjectionFileSize charges a known file size against the per-file and
+// aggregate limits without reading the file. Copy paths that stream bytes use
+// this instead of buffering the whole input.
+func accountInjectionFileSize(size int64, source string, budget *injectionTreeBudget) error {
+	if size < 0 || size > maxInjectionFileBytes {
+		return fmt.Errorf("injection input %s exceeds the per-file limit of %d bytes", source, maxInjectionFileBytes)
+	}
+	if budget == nil {
+		return nil
+	}
+	if size > budget.remainingBytes() {
+		return fmt.Errorf("injection input %s exceeds the aggregate tree limit of %d bytes", source, maxInjectionTreeBytes)
+	}
+	budget.bytes += size
+	return nil
+}
+
+// accountInjectionSourceSize charges one already-validated regular file that is
+// bind-mounted rather than copied. Direct mounts skip the read paths, so this is
+// where their material enters the shared budget.
+func accountInjectionSourceSize(source Path, budget *injectionTreeBudget) error {
+	if budget == nil {
+		return nil
+	}
+	info, err := os.Stat(source.String())
+	if err != nil {
+		return err
+	}
+	if err := budget.addEntries(source.String(), 1); err != nil {
+		return err
+	}
+	return accountInjectionFileSize(info.Size(), source.String(), budget)
+}
+
+func readBounded(reader io.Reader, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, errInjectionInputTooLarge
+	}
+	data, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, errInjectionInputTooLarge
+	}
+	return data, nil
+}
+
+// readInjectionFile reads an already-opened injection input under the smaller
+// of the per-file limit and the budget's remaining bytes. The read itself is
+// bounded, so an oversize input is refused without being buffered whole.
+func readInjectionFile(reader io.Reader, source string, budget *injectionTreeBudget) ([]byte, error) {
+	limit := maxInjectionFileBytes
+	limitDescription := fmt.Sprintf("the per-file limit of %d bytes", maxInjectionFileBytes)
+	if budget != nil && budget.remainingBytes() < limit {
+		limit = budget.remainingBytes()
+		limitDescription = fmt.Sprintf("the aggregate tree limit of %d bytes", maxInjectionTreeBytes)
+	}
+	data, err := readBounded(reader, limit)
+	if errors.Is(err, errInjectionInputTooLarge) {
+		return nil, fmt.Errorf("injection input %s exceeds %s", source, limitDescription)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read injection input %s: %w", source, err)
+	}
+	if budget != nil {
+		budget.bytes += int64(len(data))
+	}
+	return data, nil
+}
+
+// readInjectionPath opens one regular file through the no-follow direct-mount
+// opener and reads it under the injection input limits.
+func readInjectionPath(source Path, budget *injectionTreeBudget) ([]byte, error) {
+	file, _, kind, err := openDirectMountSource(source.String())
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	if kind != directMountSourceRegular {
+		return nil, fmt.Errorf("injection source must be a regular file: %s", source)
+	}
+	return readInjectionFile(file, source.String(), budget)
+}

--- a/internal/injection/input_limits.go
+++ b/internal/injection/input_limits.go
@@ -4,9 +4,12 @@
 package injection
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 // Injection inputs are operator-selected host material. These limits bound
@@ -99,6 +102,42 @@ func readInjectionFile(reader io.Reader, source string, budget *injectionTreeBud
 		budget.bytes += int64(len(data))
 	}
 	return data, nil
+}
+
+// walkInjectionTree visits every descendant of root and charges it against the
+// budget as it goes. It is the bounded replacement for filepath.WalkDir on an
+// injection input: each level is read one entry past the remaining allowance,
+// so an oversized directory level is refused before it is materialised. It does
+// not follow symbolic links.
+func walkInjectionTree(root string, budget *injectionTreeBudget, visit func(string, fs.DirEntry) error) error {
+	directory, err := os.Open(root)
+	if err != nil {
+		return err
+	}
+	entries, err := directory.ReadDir(budget.remainingEntries() + 1)
+	// Close before recursing so a deep tree does not hold one descriptor per level.
+	closeErr := directory.Close()
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if err := budget.addEntries(root, len(entries)); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		current := filepath.Join(root, entry.Name())
+		if err := visit(current, entry); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if err := walkInjectionTree(current, budget, visit); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // readInjectionPath opens one regular file through the no-follow direct-mount

--- a/internal/injection/input_limits.go
+++ b/internal/injection/input_limits.go
@@ -67,9 +67,6 @@ func accountInjectionFileSize(size int64, source string, budget *injectionTreeBu
 // bind-mounted rather than copied. Direct mounts skip the read paths, so this is
 // where their material enters the shared budget.
 func accountInjectionSourceSize(source Path, budget *injectionTreeBudget) error {
-	if budget == nil {
-		return nil
-	}
 	info, err := os.Stat(source.String())
 	if err != nil {
 		return err

--- a/internal/injection/input_limits_test.go
+++ b/internal/injection/input_limits_test.go
@@ -367,7 +367,7 @@ func TestBoundedValidationReadersRejectOversize(t *testing.T) {
 			return validateSSHConfigSafety(path, false)
 		}},
 		{name: "material hash", call: func(path Path) error {
-			_, err := pathMaterialSHA256(path)
+			_, err := pathMaterialSHA256(path, newInjectionTreeBudget())
 			return err
 		}},
 	}
@@ -479,7 +479,7 @@ func TestPathMaterialSHA256BoundsDirectoryMaterial(t *testing.T) {
 	t.Run("per-file limit", func(t *testing.T) {
 		source := t.TempDir()
 		writeSparseInjectionFile(t, filepath.Join(source, "oversize"), maxInjectionFileBytes+1)
-		if _, err := pathMaterialSHA256(Path(source)); err == nil || !strings.Contains(err.Error(), "per-file limit") {
+		if _, err := pathMaterialSHA256(Path(source), newInjectionTreeBudget()); err == nil || !strings.Contains(err.Error(), "per-file limit") {
 			t.Fatalf("pathMaterialSHA256 error = %v, want per-file limit", err)
 		}
 	})
@@ -489,8 +489,25 @@ func TestPathMaterialSHA256BoundsDirectoryMaterial(t *testing.T) {
 		for index := 0; index <= maxInjectionTreeEntries; index++ {
 			writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.Itoa(index)), 0)
 		}
-		if _, err := pathMaterialSHA256(Path(source)); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		if _, err := pathMaterialSHA256(Path(source), newInjectionTreeBudget()); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
 			t.Fatalf("pathMaterialSHA256 error = %v, want aggregate entry limit", err)
+		}
+	})
+
+	t.Run("shares one budget across hashed paths", func(t *testing.T) {
+		root := t.TempDir()
+		first := filepath.Join(root, "first")
+		writeSparseInjectionFile(t, first, maxInjectionFileBytes)
+		second := filepath.Join(root, "second")
+		writeSparseInjectionFile(t, second, 1)
+
+		budget := newInjectionTreeBudget()
+		budget.bytes = maxInjectionTreeBytes - maxInjectionFileBytes
+		if _, err := pathMaterialSHA256(Path(first), budget); err != nil {
+			t.Fatalf("first hash: %v", err)
+		}
+		if _, err := pathMaterialSHA256(Path(second), budget); err == nil || !strings.Contains(err.Error(), "aggregate tree limit") {
+			t.Fatalf("second hash error = %v, want aggregate tree limit", err)
 		}
 	})
 
@@ -502,7 +519,7 @@ func TestPathMaterialSHA256BoundsDirectoryMaterial(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(source, "nested", "file"), []byte("material"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		sum, err := pathMaterialSHA256(Path(source))
+		sum, err := pathMaterialSHA256(Path(source), newInjectionTreeBudget())
 		if err != nil || sum == "" {
 			t.Fatalf("pathMaterialSHA256 = %q, %v", sum, err)
 		}

--- a/internal/injection/input_limits_test.go
+++ b/internal/injection/input_limits_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -377,6 +378,77 @@ func TestBoundedValidationReadersRejectOversize(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The pre-copy validation walk reads its own listing, so it has to stop at the
+// entry allowance instead of materialising every entry for the copy to refuse.
+func TestValidateInjectionDirectoryDescendantsRejectsAggregateTreeEntryLimit(t *testing.T) {
+	root := t.TempDir()
+	for index := 0; index <= maxInjectionTreeEntries; index++ {
+		writeSparseInjectionFile(t, filepath.Join(root, "file-"+strconv.Itoa(index)), 0)
+	}
+	source, err := os.Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+
+	err = validateInjectionDirectoryDescendants(source, root, newInjectionTreeBudget())
+	if err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		t.Fatalf("validateInjectionDirectoryDescendants error = %v, want aggregate entry limit", err)
+	}
+}
+
+// A pseudo-file reports an undersized st_size, so the copy is the only place
+// that can charge and bound the bytes it actually reads.
+func TestCopyOpenFileWithModeBoundsUndersizedReportedSize(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("needs a pseudo-file that under-reports st_size")
+	}
+	open := func(t *testing.T) *os.File {
+		t.Helper()
+		file, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/status")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = file.Close() })
+		info, err := file.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Size() != 0 {
+			t.Skipf("pseudo-file reports size %d, not an under-report", info.Size())
+		}
+		return file
+	}
+
+	t.Run("charges the copied bytes", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "staged")
+		budget := newInjectionTreeBudget()
+		if err := copyOpenFileWithMode(open(t), destination, "status", 0o600, budget); err != nil {
+			t.Fatalf("copyOpenFileWithMode: %v", err)
+		}
+		info, err := os.Stat(destination)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Size() == 0 || budget.bytes != info.Size() {
+			t.Fatalf("budget charged %d bytes for a %d byte copy", budget.bytes, info.Size())
+		}
+	})
+
+	t.Run("rejects and removes output past the allowance", func(t *testing.T) {
+		destination := filepath.Join(t.TempDir(), "staged")
+		budget := newInjectionTreeBudget()
+		budget.bytes = maxInjectionTreeBytes - 8
+		err := copyOpenFileWithMode(open(t), destination, "status", 0o600, budget)
+		if err == nil || !strings.Contains(err.Error(), "byte limit") {
+			t.Fatalf("copyOpenFileWithMode error = %v, want a byte-limit error", err)
+		}
+		if _, err := os.Lstat(destination); !os.IsNotExist(err) {
+			t.Fatalf("over-limit copy left output, lstat error = %v", err)
+		}
+	})
 }
 
 func writeSparseInjectionFile(t *testing.T, path string, size int64) {

--- a/internal/injection/input_limits_test.go
+++ b/internal/injection/input_limits_test.go
@@ -494,6 +494,18 @@ func TestPathMaterialSHA256BoundsDirectoryMaterial(t *testing.T) {
 		}
 	})
 
+	t.Run("charges every hashed root", func(t *testing.T) {
+		root := t.TempDir()
+		source := filepath.Join(root, "input")
+		writeSparseInjectionFile(t, source, 0)
+
+		budget := newInjectionTreeBudget()
+		budget.entries = maxInjectionTreeEntries
+		if _, err := pathMaterialSHA256(Path(source), budget); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+			t.Fatalf("pathMaterialSHA256 error = %v, want aggregate entry limit", err)
+		}
+	})
+
 	t.Run("shares one budget across hashed paths", func(t *testing.T) {
 		root := t.TempDir()
 		first := filepath.Join(root, "first")

--- a/internal/injection/input_limits_test.go
+++ b/internal/injection/input_limits_test.go
@@ -451,6 +451,64 @@ func TestCopyOpenFileWithModeBoundsUndersizedReportedSize(t *testing.T) {
 	})
 }
 
+// The secret-tree symlink scan used to run as a separate unbounded walk ahead
+// of the accounting, so it reached a symlink past the entry allowance. One
+// bounded walk now stops at the allowance first.
+func TestValidateSecretTreeBoundsTheWalkBeforeTheSymlinkScan(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "secret")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index <= maxInjectionTreeEntries; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.Itoa(index)), 0)
+	}
+	if err := os.Symlink("/etc/passwd", filepath.Join(source, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := validateSecretTree(Path(source), "copies.source")
+	if err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		t.Fatalf("validateSecretTree error = %v, want aggregate entry limit", err)
+	}
+}
+
+// The directory fingerprint reads host material that can change after
+// validation, so it enforces the limits itself.
+func TestPathMaterialSHA256BoundsDirectoryMaterial(t *testing.T) {
+	t.Run("per-file limit", func(t *testing.T) {
+		source := t.TempDir()
+		writeSparseInjectionFile(t, filepath.Join(source, "oversize"), maxInjectionFileBytes+1)
+		if _, err := pathMaterialSHA256(Path(source)); err == nil || !strings.Contains(err.Error(), "per-file limit") {
+			t.Fatalf("pathMaterialSHA256 error = %v, want per-file limit", err)
+		}
+	})
+
+	t.Run("aggregate entry limit", func(t *testing.T) {
+		source := t.TempDir()
+		for index := 0; index <= maxInjectionTreeEntries; index++ {
+			writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.Itoa(index)), 0)
+		}
+		if _, err := pathMaterialSHA256(Path(source)); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+			t.Fatalf("pathMaterialSHA256 error = %v, want aggregate entry limit", err)
+		}
+	})
+
+	t.Run("accepts a tree inside the limits", func(t *testing.T) {
+		source := t.TempDir()
+		if err := os.Mkdir(filepath.Join(source, "nested"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(source, "nested", "file"), []byte("material"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		sum, err := pathMaterialSHA256(Path(source))
+		if err != nil || sum == "" {
+			t.Fatalf("pathMaterialSHA256 = %q, %v", sum, err)
+		}
+	})
+}
+
 func writeSparseInjectionFile(t *testing.T, path string, size int64) {
 	t.Helper()
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)

--- a/internal/injection/input_limits_test.go
+++ b/internal/injection/input_limits_test.go
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package injection
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/host/hoststate"
+)
+
+func TestReadInjectionFileAllowsExactPerFileLimit(t *testing.T) {
+	data, err := readInjectionFile(bytes.NewReader(make([]byte, maxInjectionFileBytes)), "exact", nil)
+	if err != nil {
+		t.Fatalf("readInjectionFile exact-limit error: %v", err)
+	}
+	if int64(len(data)) != maxInjectionFileBytes {
+		t.Fatalf("readInjectionFile length = %d, want %d", len(data), maxInjectionFileBytes)
+	}
+}
+
+func TestReadInjectionFileRejectsOverPerFileLimit(t *testing.T) {
+	_, err := readInjectionFile(bytes.NewReader(make([]byte, maxInjectionFileBytes+1)), "oversize", nil)
+	if err == nil || !strings.Contains(err.Error(), "per-file limit") {
+		t.Fatalf("readInjectionFile error = %v, want per-file limit", err)
+	}
+}
+
+func TestCopySourceAllowsExactAggregateTreeLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// copySource charges one entry for the source directory itself, so the
+	// aggregate byte allowance is what this case has to land on exactly.
+	for index := int64(0); index < maxInjectionTreeBytes/maxInjectionFileBytes; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.FormatInt(index, 10)), maxInjectionFileBytes)
+	}
+
+	if _, err := copySource(Path(source), Path(filepath.Join(root, "output"))); err != nil {
+		t.Fatalf("copySource exact aggregate limit: %v", err)
+	}
+}
+
+func TestCopySourceRejectsAggregateTreeLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for index := int64(0); index < maxInjectionTreeBytes/maxInjectionFileBytes; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.FormatInt(index, 10)), maxInjectionFileBytes)
+	}
+	writeSparseInjectionFile(t, filepath.Join(source, "file-extra"), 1)
+
+	_, err := copySource(Path(source), Path(filepath.Join(root, "output")))
+	if err == nil || !strings.Contains(err.Error(), "aggregate tree limit") {
+		t.Fatalf("copySource error = %v, want aggregate tree limit", err)
+	}
+}
+
+func TestCopySourceRejectsAggregateTreeEntryLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index <= maxInjectionTreeEntries; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.Itoa(index)), 0)
+	}
+
+	_, err := copySource(Path(source), Path(filepath.Join(root, "output")))
+	if err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		t.Fatalf("copySource error = %v, want aggregate entry limit", err)
+	}
+}
+
+func TestStageDirectMountsAllowsExactPerFileLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	writeSparseInjectionFile(t, source, maxInjectionFileBytes)
+	spec := filepath.Join(root, "mounts.json")
+	writeMountSpec(t, spec, []map[string]any{{
+		"source":     source,
+		"mount_path": "/opt/workcell/host-inputs/source",
+	}})
+
+	if _, err := StageDirectMounts(root, spec); err != nil {
+		t.Fatalf("StageDirectMounts exact file limit: %v", err)
+	}
+	staged := filepath.Join(root, "direct-mounts", hoststate.DirectMountCacheKey(source, "/opt/workcell/host-inputs/source"))
+	info, err := os.Stat(staged)
+	if err != nil {
+		t.Fatalf("stat staged file: %v", err)
+	}
+	if info.Size() != maxInjectionFileBytes {
+		t.Fatalf("staged file size = %d, want %d", info.Size(), maxInjectionFileBytes)
+	}
+}
+
+func TestStageDirectMountsRejectsOverPerFileLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	writeSparseInjectionFile(t, source, maxInjectionFileBytes+1)
+	spec := filepath.Join(root, "mounts.json")
+	mountPath := "/opt/workcell/host-inputs/source"
+	writeMountSpec(t, spec, []map[string]any{{"source": source, "mount_path": mountPath}})
+
+	if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "per-file limit") {
+		t.Fatalf("StageDirectMounts error = %v, want per-file limit", err)
+	}
+	staged := filepath.Join(root, "direct-mounts", hoststate.DirectMountCacheKey(source, mountPath))
+	if _, err := os.Lstat(staged); !os.IsNotExist(err) {
+		t.Fatalf("oversize input left staged output, lstat error = %v", err)
+	}
+}
+
+func TestStageDirectMountsRejectsAggregateTreeLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for index := int64(0); index < maxInjectionTreeBytes/maxInjectionFileBytes; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.FormatInt(index, 10)), maxInjectionFileBytes)
+	}
+	writeSparseInjectionFile(t, filepath.Join(source, "file-extra"), 1)
+	spec := filepath.Join(root, "mounts.json")
+	mountPath := "/opt/workcell/host-inputs/source"
+	writeMountSpec(t, spec, []map[string]any{{"source": source, "mount_path": mountPath}})
+
+	if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "aggregate tree limit") {
+		t.Fatalf("StageDirectMounts error = %v, want aggregate tree limit", err)
+	}
+}
+
+func TestStageDirectMountsSharesAggregateLimitAcrossMounts(t *testing.T) {
+	root := t.TempDir()
+	entries := make([]map[string]any, 0, 5)
+	for index := 0; index < 5; index++ {
+		source := filepath.Join(root, "source-"+strconv.Itoa(index))
+		writeSparseInjectionFile(t, source, maxInjectionFileBytes)
+		entries = append(entries, map[string]any{
+			"source":     source,
+			"mount_path": "/opt/workcell/host-inputs/source-" + strconv.Itoa(index),
+		})
+	}
+	spec := filepath.Join(root, "mounts.json")
+	writeMountSpec(t, spec, entries)
+	if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "aggregate tree limit") {
+		t.Fatalf("StageDirectMounts error = %v, want aggregate tree limit across mounts", err)
+	}
+}
+
+func TestStageDirectMountsRejectsAggregateTreeEntryLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index <= maxInjectionTreeEntries; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.Itoa(index)), 0)
+	}
+	spec := filepath.Join(root, "mounts.json")
+	writeMountSpec(t, spec, []map[string]any{{
+		"source":     source,
+		"mount_path": "/opt/workcell/host-inputs/source",
+	}})
+
+	if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		t.Fatalf("StageDirectMounts error = %v, want aggregate entry limit", err)
+	}
+}
+
+func TestValidateSecretTreeAllowsExactPerFileLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "secret")
+	writeSparseInjectionFile(t, source, maxInjectionFileBytes)
+	if err := validateSecretTree(Path(source), "copies.source"); err != nil {
+		t.Fatalf("validateSecretTree exact file limit: %v", err)
+	}
+}
+
+func TestValidateSecretTreeRejectsOverPerFileLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "secret")
+	writeSparseInjectionFile(t, source, maxInjectionFileBytes+1)
+	if err := validateSecretTree(Path(source), "copies.source"); err == nil || !strings.Contains(err.Error(), "per-file limit") {
+		t.Fatalf("validateSecretTree error = %v, want per-file limit", err)
+	}
+}
+
+func TestValidateSecretTreeRejectsAggregateTreeEntryLimit(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "secret")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index <= maxInjectionTreeEntries; index++ {
+		writeSparseInjectionFile(t, filepath.Join(source, "file-"+strconv.Itoa(index)), 0)
+	}
+	if err := validateSecretTree(Path(source), "copies.source"); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		t.Fatalf("validateSecretTree error = %v, want aggregate entry limit", err)
+	}
+}
+
+func TestRenderMaterialSharesBundleAggregateByteLimit(t *testing.T) {
+	root := t.TempDir()
+	output := filepath.Join(root, "output")
+	if err := os.MkdirAll(output, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	paths := make([]string, 5)
+	for index := range paths {
+		paths[index] = filepath.Join(root, "input-"+strconv.Itoa(index))
+		writeSparseInjectionFile(t, paths[index], maxInjectionFileBytes)
+	}
+	budget := newInjectionTreeBudget()
+	if _, err := renderDocumentsWithBudget(map[string]any{
+		"documents": map[string]any{"common": paths[0]},
+	}, Path(output), Path(root), budget); err != nil {
+		t.Fatalf("render document: %v", err)
+	}
+	if _, err := renderCopiesWithBudget(map[string]any{
+		"copies": []any{map[string]any{
+			"source": paths[1], "target": "/state/injected/copy", "classification": "public",
+		}},
+	}, Path(output), Path(root), "codex", "strict", budget); err != nil {
+		t.Fatalf("render copy: %v", err)
+	}
+	if _, err := renderSSHWithBudget(map[string]any{
+		"ssh": map[string]any{"enabled": true, "known_hosts": paths[2]},
+	}, Path(output), Path(root), "codex", "strict", budget); err != nil {
+		t.Fatalf("render ssh: %v", err)
+	}
+	if _, err := renderCredentialsWithBudget(map[string]any{
+		"credentials": map[string]any{"codex_auth": paths[3]},
+	}, Path(root), "codex", "strict", budget); err != nil {
+		t.Fatalf("render credentials: %v", err)
+	}
+	if _, err := renderDocumentsWithBudget(map[string]any{
+		"documents": map[string]any{"codex": paths[4]},
+	}, Path(output), Path(root), budget); err == nil || !strings.Contains(err.Error(), "aggregate tree limit") {
+		t.Fatalf("fifth selected item error = %v, want aggregate tree limit", err)
+	}
+}
+
+func TestRenderMaterialSharesBundleAggregateEntryLimit(t *testing.T) {
+	root := t.TempDir()
+	output := filepath.Join(root, "output")
+	if err := os.MkdirAll(output, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	entries := make([]any, 0, maxInjectionTreeEntries+1)
+	for index := 0; index <= maxInjectionTreeEntries; index++ {
+		source := filepath.Join(root, "input-"+strconv.Itoa(index))
+		writeSparseInjectionFile(t, source, 0)
+		entries = append(entries, map[string]any{
+			"source":         source,
+			"target":         "/state/injected/item-" + strconv.Itoa(index),
+			"classification": "public",
+		})
+	}
+	if _, err := renderCopiesWithBudget(map[string]any{"copies": entries}, Path(output), Path(root), "codex", "strict", newInjectionTreeBudget()); err == nil || !strings.Contains(err.Error(), "aggregate entry limit") {
+		t.Fatalf("many selected items error = %v, want aggregate entry limit", err)
+	}
+}
+
+func TestStageDirectMountsBoundsMountSpecification(t *testing.T) {
+	t.Run("exact bytes", func(t *testing.T) {
+		root := t.TempDir()
+		spec := filepath.Join(root, "mounts.json")
+		data := append([]byte("[]"), bytes.Repeat([]byte{' '}, int(maxInjectionMountSpecBytes-2))...)
+		if err := os.WriteFile(spec, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := StageDirectMounts(root, spec); err != nil {
+			t.Fatalf("exact mount specification limit: %v", err)
+		}
+	})
+	t.Run("over bytes", func(t *testing.T) {
+		root := t.TempDir()
+		spec := filepath.Join(root, "mounts.json")
+		data := append([]byte("[]"), bytes.Repeat([]byte{' '}, int(maxInjectionMountSpecBytes-1))...)
+		if err := os.WriteFile(spec, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "byte limit") {
+			t.Fatalf("over-size mount specification error = %v", err)
+		}
+	})
+	t.Run("exact count", func(t *testing.T) {
+		root := t.TempDir()
+		spec := filepath.Join(root, "mounts.json")
+		entries := make([]map[string]any, maxInjectionMounts)
+		for index := range entries {
+			entries[index] = map[string]any{}
+		}
+		writeMountSpec(t, spec, entries)
+		if _, err := StageDirectMounts(root, spec); err != nil {
+			t.Fatalf("exact mount count: %v", err)
+		}
+	})
+	t.Run("over count", func(t *testing.T) {
+		root := t.TempDir()
+		spec := filepath.Join(root, "mounts.json")
+		entries := make([]map[string]any, maxInjectionMounts+1)
+		for index := range entries {
+			entries[index] = map[string]any{}
+		}
+		writeMountSpec(t, spec, entries)
+		if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "mount limit") {
+			t.Fatalf("over-count mount specification error = %v", err)
+		}
+	})
+	t.Run("path length", func(t *testing.T) {
+		root := t.TempDir()
+		spec := filepath.Join(root, "mounts.json")
+		writeMountSpec(t, spec, []map[string]any{{
+			"source":     strings.Repeat("a", maxInjectionMountPathBytes+1),
+			"mount_path": "/opt/workcell/host-inputs/x",
+		}})
+		if _, err := StageDirectMounts(root, spec); err == nil || !strings.Contains(err.Error(), "length limit") {
+			t.Fatalf("over-length mount path error = %v", err)
+		}
+	})
+	t.Run("exact path length", func(t *testing.T) {
+		root := t.TempDir()
+		source := filepath.Join(root, "source")
+		writeSparseInjectionFile(t, source, 0)
+		prefix := "/opt/workcell/host-inputs/"
+		mountPath := prefix + strings.Repeat("x", maxInjectionMountPathBytes-len(prefix))
+		spec := filepath.Join(root, "mounts.json")
+		writeMountSpec(t, spec, []map[string]any{{"source": source, "mount_path": mountPath}})
+		if _, err := StageDirectMounts(root, spec); err != nil {
+			t.Fatalf("exact mount path length: %v", err)
+		}
+	})
+}
+
+func TestBoundedValidationReadersRejectOversize(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "oversize")
+	writeSparseInjectionFile(t, source, maxInjectionFileBytes+1)
+
+	tests := []struct {
+		name string
+		call func(Path) error
+	}{
+		{name: "gemini env", call: func(path Path) error {
+			_, err := parseSimpleEnvFile(path)
+			return err
+		}},
+		{name: "json", call: func(path Path) error {
+			_, err := validateJSONObjFile(path, "oversize")
+			return err
+		}},
+		{name: "ssh config", call: func(path Path) error {
+			return validateSSHConfigSafety(path, false)
+		}},
+		{name: "material hash", call: func(path Path) error {
+			_, err := pathMaterialSHA256(path)
+			return err
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.call(Path(source)); err == nil || !strings.Contains(err.Error(), "limit") {
+				t.Fatalf("error = %v, want bounded-input error", err)
+			}
+		})
+	}
+}
+
+func writeSparseInjectionFile(t *testing.T, path string, size int64) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	if err := file.Truncate(size); err != nil {
+		file.Close()
+		t.Fatalf("truncate %s: %v", path, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close %s: %v", path, err)
+	}
+}

--- a/internal/injection/input_limits_test.go
+++ b/internal/injection/input_limits_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/omkhar/workcell/internal/host/hoststate"
+	"github.com/omkhar/workcell/internal/runtimeutil"
 )
 
 func TestReadInjectionFileAllowsExactPerFileLimit(t *testing.T) {
@@ -298,7 +299,7 @@ func TestStageDirectMountsBoundsMountSpecification(t *testing.T) {
 	t.Run("exact count", func(t *testing.T) {
 		root := t.TempDir()
 		spec := filepath.Join(root, "mounts.json")
-		entries := make([]map[string]any, maxInjectionMounts)
+		entries := make([]map[string]any, runtimeutil.MaxDirectMountEntries)
 		for index := range entries {
 			entries[index] = map[string]any{}
 		}
@@ -310,7 +311,7 @@ func TestStageDirectMountsBoundsMountSpecification(t *testing.T) {
 	t.Run("over count", func(t *testing.T) {
 		root := t.TempDir()
 		spec := filepath.Join(root, "mounts.json")
-		entries := make([]map[string]any, maxInjectionMounts+1)
+		entries := make([]map[string]any, runtimeutil.MaxDirectMountEntries+1)
 		for index := range entries {
 			entries[index] = map[string]any{}
 		}

--- a/internal/injection/render_credentials.go
+++ b/internal/injection/render_credentials.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -21,6 +20,18 @@ import (
 var allowedCredentialEntryKeys = mapKeysSet([]string{"source", "providers", "modes"})
 
 func renderCredentials(policy map[string]any, policyDir Path, agent, mode string) (map[string]map[string]string, error) {
+	return renderCredentialsWithBudget(policy, policyDir, agent, mode, newInjectionTreeBudget())
+}
+
+func renderCredentialsWithBudget(
+	policy map[string]any,
+	policyDir Path,
+	agent, mode string,
+	budget *injectionTreeBudget,
+) (map[string]map[string]string, error) {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	raw := policy["credentials"]
 	if raw == nil {
 		return map[string]map[string]string{}, nil
@@ -93,6 +104,9 @@ func renderCredentials(policy map[string]any, policyDir Path, agent, mode string
 		}
 		source, err = validateSecretFile(source, "credentials."+key)
 		if err != nil {
+			return nil, err
+		}
+		if err := accountInjectionSourceSize(source, budget); err != nil {
 			return nil, err
 		}
 		switch key {
@@ -202,7 +216,7 @@ func validateGeminiEnvFile(source Path) (map[string]any, error) {
 
 func parseSimpleEnvFile(source Path) (map[string]string, error) {
 	values := map[string]string{}
-	data, err := os.ReadFile(source.String())
+	data, err := readInjectionPath(source, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +304,7 @@ func normalizeVertexLocation(value string) string {
 }
 
 func validateJSONObjFile(source Path, label string) (map[string]any, error) {
-	data, err := os.ReadFile(source.String())
+	data, err := readInjectionPath(source, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/injection/render_credentials.go
+++ b/internal/injection/render_credentials.go
@@ -29,9 +29,6 @@ func renderCredentialsWithBudget(
 	agent, mode string,
 	budget *injectionTreeBudget,
 ) (map[string]map[string]string, error) {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	raw := policy["credentials"]
 	if raw == nil {
 		return map[string]map[string]string{}, nil

--- a/internal/injection/render_documents_copies.go
+++ b/internal/injection/render_documents_copies.go
@@ -28,9 +28,6 @@ func renderDocuments(policy map[string]any, outputRoot, policyDir Path) (map[str
 }
 
 func renderDocumentsWithBudget(policy map[string]any, outputRoot, policyDir Path, budget *injectionTreeBudget) (map[string]string, error) {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	raw := policy["documents"]
 	if raw == nil {
 		return map[string]string{}, nil
@@ -75,9 +72,6 @@ func renderCopiesWithBudget(
 	agent, mode string,
 	budget *injectionTreeBudget,
 ) ([]map[string]any, error) {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	raw := policy["copies"]
 	if raw == nil {
 		return []map[string]any{}, nil
@@ -170,9 +164,6 @@ func copySource(source, destination Path) (string, error) {
 }
 
 func copySourceWithBudget(source, destination Path, budget *injectionTreeBudget) (string, error) {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	sourceFile, _, kind, err := openDirectMountSource(source.String())
 	if err != nil {
 		return "", err
@@ -243,9 +234,6 @@ func copyOpenDirectoryToRootWithState(
 	state *injectionDestinationState,
 	budget *injectionTreeBudget,
 ) error {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	// Read one entry past the remaining allowance so an oversized directory is
 	// refused without materialising its whole listing.
 	entries, err := source.ReadDir(budget.remainingEntries() + 1)
@@ -354,10 +342,8 @@ func writeFileExclusive(root *os.Root, path string, data []byte, perm os.FileMod
 }
 
 func stageFile(source, outputRoot Path, relpath string, budget *injectionTreeBudget) error {
-	if budget != nil {
-		if err := budget.addEntries(source.String(), 1); err != nil {
-			return err
-		}
+	if err := budget.addEntries(source.String(), 1); err != nil {
+		return err
 	}
 	root, err := os.OpenRoot(outputRoot.String())
 	if err != nil {

--- a/internal/injection/render_documents_copies.go
+++ b/internal/injection/render_documents_copies.go
@@ -173,7 +173,7 @@ func copySourceWithBudget(source, destination Path, budget *injectionTreeBudget)
 		return "", err
 	}
 	if kind == directMountSourceDir {
-		if err := validateInjectionDirectoryDescendants(sourceFile); err != nil {
+		if err := validateInjectionDirectoryDescendants(sourceFile, source.String(), budget); err != nil {
 			return "", err
 		}
 		if err := os.MkdirAll(destination.Parent().String(), 0o755); err != nil {

--- a/internal/injection/render_documents_copies.go
+++ b/internal/injection/render_documents_copies.go
@@ -24,6 +24,13 @@ import (
 var allowedCopyEntryKeys = mapKeysSet([]string{"source", "target", "classification", "providers", "modes"})
 
 func renderDocuments(policy map[string]any, outputRoot, policyDir Path) (map[string]string, error) {
+	return renderDocumentsWithBudget(policy, outputRoot, policyDir, newInjectionTreeBudget())
+}
+
+func renderDocumentsWithBudget(policy map[string]any, outputRoot, policyDir Path, budget *injectionTreeBudget) (map[string]string, error) {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	raw := policy["documents"]
 	if raw == nil {
 		return map[string]string{}, nil
@@ -50,7 +57,7 @@ func renderDocuments(policy map[string]any, outputRoot, policyDir Path) (map[str
 		if err := ensureIsFile(source, fmt.Sprintf("documents.%s", key)); err != nil {
 			return nil, err
 		}
-		if err := stageFile(source, outputRoot, relpath); err != nil {
+		if err := stageFile(source, outputRoot, relpath, budget); err != nil {
 			return nil, err
 		}
 		rendered[key] = relpath
@@ -59,6 +66,18 @@ func renderDocuments(policy map[string]any, outputRoot, policyDir Path) (map[str
 }
 
 func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode string) ([]map[string]any, error) {
+	return renderCopiesWithBudget(policy, outputRoot, policyDir, agent, mode, newInjectionTreeBudget())
+}
+
+func renderCopiesWithBudget(
+	policy map[string]any,
+	outputRoot, policyDir Path,
+	agent, mode string,
+	budget *injectionTreeBudget,
+) ([]map[string]any, error) {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	raw := policy["copies"]
 	if raw == nil {
 		return []map[string]any{}, nil
@@ -118,7 +137,7 @@ func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode
 
 		var renderedSource any
 		if classification == "secret" {
-			if err := validateSecretTree(sourceValue, "copies.source"); err != nil {
+			if err := validateSecretTreeWithBudget(sourceValue, "copies.source", budget); err != nil {
 				return nil, err
 			}
 			kind = "file"
@@ -127,7 +146,7 @@ func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode
 			}
 			renderedSource = directMountEntry(sourceValue, mountPath)
 		} else {
-			kind, err = copySource(sourceValue, outputRoot.Join(relpath))
+			kind, err = copySourceWithBudget(sourceValue, outputRoot.Join(relpath), budget)
 			if err != nil {
 				return nil, err
 			}
@@ -147,11 +166,21 @@ func renderCopies(policy map[string]any, outputRoot, policyDir Path, agent, mode
 }
 
 func copySource(source, destination Path) (string, error) {
+	return copySourceWithBudget(source, destination, newInjectionTreeBudget())
+}
+
+func copySourceWithBudget(source, destination Path, budget *injectionTreeBudget) (string, error) {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	sourceFile, _, kind, err := openDirectMountSource(source.String())
 	if err != nil {
 		return "", err
 	}
 	defer sourceFile.Close()
+	if err := budget.addEntries(source.String(), 1); err != nil {
+		return "", err
+	}
 	if kind == directMountSourceDir {
 		if err := validateInjectionDirectoryDescendants(sourceFile); err != nil {
 			return "", err
@@ -167,7 +196,10 @@ func copySource(source, destination Path) (string, error) {
 			return "", err
 		}
 		defer destinationRoot.Close()
-		if err := copyOpenDirectoryToRoot(sourceFile, destinationRoot, source.String(), ".", openDirectMountChild); err != nil {
+		if err := copyOpenDirectoryToRootWithState(
+			sourceFile, destinationRoot, source.String(), ".",
+			openDirectMountChild, newInjectionDestinationState(), budget,
+		); err != nil {
 			return "", err
 		}
 		if err := os.Chmod(destination.String(), 0o700); err != nil {
@@ -186,7 +218,7 @@ func copySource(source, destination Path) (string, error) {
 		return "", err
 	}
 	defer parentRoot.Close()
-	data, err := io.ReadAll(sourceFile)
+	data, err := readInjectionFile(sourceFile, source.String(), budget)
 	if err != nil {
 		return "", err
 	}
@@ -199,26 +231,28 @@ func copySource(source, destination Path) (string, error) {
 	return "file", nil
 }
 
-// copyOpenDirectoryToRoot copies an already-open source directory. Each
-// descendant is opened from its parent descriptor without following links.
-func copyOpenDirectoryToRoot(
-	source *os.File,
-	destination *os.Root,
-	sourceDisplay, relative string,
-	openChild func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error),
-) error {
-	return copyOpenDirectoryToRootWithState(source, destination, sourceDisplay, relative, openChild, newInjectionDestinationState())
-}
-
+// copyOpenDirectoryToRootWithState copies an already-open source directory.
+// Each descendant is opened from its parent descriptor without following links,
+// and both the destination reservations and the input budget are shared with
+// every recursive level.
 func copyOpenDirectoryToRootWithState(
 	source *os.File,
 	destination *os.Root,
 	sourceDisplay, relative string,
 	openChild func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error),
 	state *injectionDestinationState,
+	budget *injectionTreeBudget,
 ) error {
-	entries, err := source.ReadDir(-1)
-	if err != nil {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
+	// Read one entry past the remaining allowance so an oversized directory is
+	// refused without materialising its whole listing.
+	entries, err := source.ReadDir(budget.remainingEntries() + 1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if err := budget.addEntries(sourceDisplay, len(entries)); err != nil {
 		return err
 	}
 	for _, entry := range entries {
@@ -245,11 +279,11 @@ func copyOpenDirectoryToRootWithState(
 				err = destination.Mkdir(childRelative, 0o700)
 			}
 			if err == nil {
-				err = copyOpenDirectoryToRootWithState(child, destination, displayPath, childRelative, openChild, state)
+				err = copyOpenDirectoryToRootWithState(child, destination, displayPath, childRelative, openChild, state, budget)
 			}
 		case directMountSourceRegular:
 			var data []byte
-			data, err = io.ReadAll(child)
+			data, err = readInjectionFile(child, displayPath, budget)
 			if err == nil {
 				err = state.reserve(childRelative, "regular file")
 			}
@@ -319,7 +353,12 @@ func writeFileExclusive(root *os.Root, path string, data []byte, perm os.FileMod
 	return nil
 }
 
-func stageFile(source, outputRoot Path, relpath string) error {
+func stageFile(source, outputRoot Path, relpath string, budget *injectionTreeBudget) error {
+	if budget != nil {
+		if err := budget.addEntries(source.String(), 1); err != nil {
+			return err
+		}
+	}
 	root, err := os.OpenRoot(outputRoot.String())
 	if err != nil {
 		return err
@@ -339,7 +378,7 @@ func stageFile(source, outputRoot Path, relpath string) error {
 	if kind != directMountSourceRegular {
 		return fmt.Errorf("injection source must be a file: %s", source)
 	}
-	data, err := io.ReadAll(sourceFile)
+	data, err := readInjectionFile(sourceFile, source.String(), budget)
 	if err != nil {
 		return err
 	}

--- a/internal/injection/render_documents_copies_security_test.go
+++ b/internal/injection/render_documents_copies_security_test.go
@@ -81,7 +81,7 @@ func TestCopyOpenDirectoryToRootWithStateRejectsLinuxInvalidUTF8Symlink(t *testi
 		t.Fatal(err)
 	}
 	defer destination.Close()
-	err = copyOpenDirectoryToRootWithState(source, destination, sourcePath, ".", openDirectMountChild, newInjectionDestinationState())
+	err = copyOpenDirectoryToRootWithState(source, destination, sourcePath, ".", openDirectMountChild, newInjectionDestinationState(), newInjectionTreeBudget())
 	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
 		t.Fatalf("copy error = %v", err)
 	}
@@ -119,7 +119,7 @@ func TestCopyOpenDirectoryToRootWithStateRejectsPreReservedUnicodeAlias(t *testi
 	if err := state.reserve("café", "reserved"); err != nil {
 		t.Fatal(err)
 	}
-	err = copyOpenDirectoryToRootWithState(source, destination, sourceRoot, ".", openDirectMountChild, state)
+	err = copyOpenDirectoryToRootWithState(source, destination, sourceRoot, ".", openDirectMountChild, state, newInjectionTreeBudget())
 	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
 		t.Fatalf("copy error = %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCopyOpenDirectoryToRootWithStateRejectsInvalidUTF8(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer destination.Close()
-	err = copyOpenDirectoryToRootWithState(source, destination, sourceRoot, "target", openDirectMountChild, newInjectionDestinationState())
+	err = copyOpenDirectoryToRootWithState(source, destination, sourceRoot, "target", openDirectMountChild, newInjectionDestinationState(), newInjectionTreeBudget())
 	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
 		t.Fatalf("copy error = %v", err)
 	}
@@ -180,7 +180,7 @@ func TestStageFileRejectsValidatedSourcePathReplacement(t *testing.T) {
 	}
 
 	output := t.TempDir()
-	err = stageFile(validated, Path(output), "documents/common.md")
+	err = stageFile(validated, Path(output), "documents/common.md", newInjectionTreeBudget())
 	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
 		t.Fatalf("stageFile error = %v, want symbolic-link rejection", err)
 	}
@@ -252,7 +252,7 @@ func TestStageDirectMountEntryRefusesExistingDestination(t *testing.T) {
 	if err := os.WriteFile(destination, []byte("preserve"), 0o600); err != nil {
 		t.Fatalf("write destination: %v", err)
 	}
-	if err := stageDirectMountEntry(source, destination); err == nil {
+	if err := stageDirectMountEntry(source, destination, newInjectionTreeBudget()); err == nil {
 		t.Fatal("stageDirectMountEntry accepted an existing destination")
 	}
 	data, err := os.ReadFile(destination)
@@ -310,7 +310,7 @@ func TestCopyOpenDirectoryRejectsChildReplacementAfterReadDir(t *testing.T) {
 		return openDirectMountChild(parent, name, displayPath)
 	}
 
-	err = copyOpenDirectoryToRoot(source, destination, sourcePath, ".", openChild)
+	err = copyOpenDirectoryToRootWithState(source, destination, sourcePath, ".", openChild, newInjectionDestinationState(), newInjectionTreeBudget())
 	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
 		t.Fatalf("copy directory error = %v, want symbolic-link rejection", err)
 	}

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -370,6 +370,11 @@ func pathMaterialSHA256(path Path, budget *injectionTreeBudget) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("lstat %s: %w", path, err)
 	}
+	// The root counts too. walkInjectionTree charges only descendants, so
+	// without this a manifest of many roots reads past the entry allowance.
+	if err := budget.addEntries(path.String(), 1); err != nil {
+		return "", err
+	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		target, err := os.Readlink(path.String())
 		if err != nil {

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -152,19 +152,22 @@ func runRenderInjectionBundle(policyPath, agent, mode, outputRoot, policyMetadat
 		return err
 	}
 
-	renderedDocuments, err := renderDocuments(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)))
+	// One budget spans the whole bundle so a set of individually legal
+	// selections cannot add up to an unbounded copy.
+	budget := newInjectionTreeBudget()
+	renderedDocuments, err := renderDocumentsWithBudget(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), budget)
 	if err != nil {
 		return err
 	}
-	renderedCopies, err := renderCopies(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), agent, mode)
+	renderedCopies, err := renderCopiesWithBudget(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), agent, mode, budget)
 	if err != nil {
 		return err
 	}
-	renderedCredentials, err := renderCredentials(policy, Path(filepath.Dir(resolvedPolicyPath)), agent, mode)
+	renderedCredentials, err := renderCredentialsWithBudget(policy, Path(filepath.Dir(resolvedPolicyPath)), agent, mode, budget)
 	if err != nil {
 		return err
 	}
-	renderedSSH, err := renderSSH(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), agent, mode)
+	renderedSSH, err := renderSSHWithBudget(policy, Path(resolvedOutputRoot), Path(filepath.Dir(resolvedPolicyPath)), agent, mode, budget)
 	if err != nil {
 		return err
 	}
@@ -369,7 +372,14 @@ func pathMaterialSHA256(path Path) (string, error) {
 		return hex.EncodeToString(sum[:]), nil
 	}
 	if info.Mode().IsRegular() {
-		data, err := os.ReadFile(path.String())
+		file, err := os.Open(path.String())
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", path, err)
+		}
+		data, err := readInjectionFile(file, path.String(), nil)
+		if closeErr := file.Close(); err == nil {
+			err = closeErr
+		}
 		if err != nil {
 			return "", fmt.Errorf("read %s: %w", path, err)
 		}

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -227,9 +227,13 @@ func effectivePolicySHA256(
 	renderedCredentials map[string]map[string]string,
 	renderedSSH map[string]any,
 ) (string, error) {
+	// One budget spans the whole fingerprint pass. Every hashed path is host
+	// material that can grow after the render checks, so a per-path allowance
+	// would let one manifest read past the documented aggregate limit.
+	budget := newInjectionTreeBudget()
 	documents := map[string]string{}
 	for _, key := range sortedKeys(renderedDocuments) {
-		hash, err := pathMaterialSHA256(outputRoot.Join(renderedDocuments[key]))
+		hash, err := pathMaterialSHA256(outputRoot.Join(renderedDocuments[key]), budget)
 		if err != nil {
 			return "", fmt.Errorf("hash document %q: %w", key, err)
 		}
@@ -255,7 +259,7 @@ func effectivePolicySHA256(
 				sourcePath = Path(hostSource)
 			}
 		}
-		hash, err := pathMaterialSHA256(sourcePath)
+		hash, err := pathMaterialSHA256(sourcePath, budget)
 		if err != nil {
 			return "", fmt.Errorf("hash copy %v: %w", entry["target"], err)
 		}
@@ -271,7 +275,7 @@ func effectivePolicySHA256(
 	credentials := map[string]map[string]any{}
 	for _, key := range sortedKeys(renderedCredentials) {
 		value := renderedCredentials[key]
-		hash, err := pathMaterialSHA256(Path(value["source"]))
+		hash, err := pathMaterialSHA256(Path(value["source"]), budget)
 		if err != nil {
 			return "", fmt.Errorf("hash credential %q: %w", key, err)
 		}
@@ -291,7 +295,7 @@ func effectivePolicySHA256(
 		// returns map[string]string — historically these missed both
 		// type assertions below and so were never hashed at all.
 		if source, mountPath, ok := sshMountSource(renderedSSH, "config"); ok {
-			hash, err := pathMaterialSHA256(Path(source))
+			hash, err := pathMaterialSHA256(Path(source), budget)
 			if err != nil {
 				return "", fmt.Errorf("hash ssh config: %w", err)
 			}
@@ -301,7 +305,7 @@ func effectivePolicySHA256(
 			}
 		}
 		if source, mountPath, ok := sshMountSource(renderedSSH, "known_hosts"); ok {
-			hash, err := pathMaterialSHA256(Path(source))
+			hash, err := pathMaterialSHA256(Path(source), budget)
 			if err != nil {
 				return "", fmt.Errorf("hash ssh known_hosts: %w", err)
 			}
@@ -326,7 +330,7 @@ func effectivePolicySHA256(
 		if identitiesFound {
 			renderedIdentities := make([]map[string]any, 0, len(identityEntries))
 			for _, entry := range identityEntries {
-				hash, err := pathMaterialSHA256(Path(entry["source"].(string)))
+				hash, err := pathMaterialSHA256(Path(entry["source"].(string)), budget)
 				if err != nil {
 					return "", fmt.Errorf("hash ssh identity %v: %w", entry["target_name"], err)
 				}
@@ -358,7 +362,10 @@ func effectivePolicySHA256(
 // to emit a manifest entry when the fingerprint cannot be computed — a
 // silent empty string here previously rounded-tripped as a valid hash and
 // defeated the integrity check the function exists to provide.
-func pathMaterialSHA256(path Path) (string, error) {
+//
+// The material is read again here, after the render checks accepted it, so the
+// caller's budget carries across every hashed path in one manifest.
+func pathMaterialSHA256(path Path, budget *injectionTreeBudget) (string, error) {
 	info, err := os.Lstat(path.String())
 	if err != nil {
 		return "", fmt.Errorf("lstat %s: %w", path, err)
@@ -376,7 +383,7 @@ func pathMaterialSHA256(path Path) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("read %s: %w", path, err)
 		}
-		data, err := readInjectionFile(file, path.String(), nil)
+		data, err := readInjectionFile(file, path.String(), budget)
 		if closeErr := file.Close(); err == nil {
 			err = closeErr
 		}
@@ -389,10 +396,6 @@ func pathMaterialSHA256(path Path) (string, error) {
 	if info.IsDir() {
 		hasher := sha256.New()
 		hasher.Write([]byte("dir\n"))
-		// The tree passed the input limits during validation, but it is host
-		// material that can change before this walk, so the fingerprint charges
-		// its own budget instead of trusting the earlier accounting.
-		budget := newInjectionTreeBudget()
 		children := []string{}
 		if err := walkInjectionTree(path.String(), budget, func(current string, _ fs.DirEntry) error {
 			children = append(children, current)

--- a/internal/injection/render_injection_bundle.go
+++ b/internal/injection/render_injection_bundle.go
@@ -389,14 +389,12 @@ func pathMaterialSHA256(path Path) (string, error) {
 	if info.IsDir() {
 		hasher := sha256.New()
 		hasher.Write([]byte("dir\n"))
+		// The tree passed the input limits during validation, but it is host
+		// material that can change before this walk, so the fingerprint charges
+		// its own budget instead of trusting the earlier accounting.
+		budget := newInjectionTreeBudget()
 		children := []string{}
-		if err := filepath.WalkDir(path.String(), func(current string, entry fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if current == path.String() {
-				return nil
-			}
+		if err := walkInjectionTree(path.String(), budget, func(current string, _ fs.DirEntry) error {
 			children = append(children, current)
 			return nil
 		}); err != nil {
@@ -426,7 +424,14 @@ func pathMaterialSHA256(path Path) (string, error) {
 				hasher.Write([]byte("dir:" + relative + "\n"))
 			case info.Mode().IsRegular():
 				hasher.Write([]byte("file:" + relative + "\n"))
-				data, err := os.ReadFile(child)
+				file, err := os.Open(child)
+				if err != nil {
+					return "", fmt.Errorf("read %s: %w", child, err)
+				}
+				data, err := readInjectionFile(file, child, budget)
+				if closeErr := file.Close(); err == nil {
+					err = closeErr
+				}
 				if err != nil {
 					return "", fmt.Errorf("read %s: %w", child, err)
 				}

--- a/internal/injection/render_ssh.go
+++ b/internal/injection/render_ssh.go
@@ -25,9 +25,6 @@ func renderSSHWithBudget(
 	agent, mode string,
 	budget *injectionTreeBudget,
 ) (map[string]any, error) {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	raw := policy["ssh"]
 	if raw == nil {
 		return map[string]any{}, nil

--- a/internal/injection/render_ssh.go
+++ b/internal/injection/render_ssh.go
@@ -16,6 +16,18 @@ import (
 var allowedSSHKeys = mapKeysSet([]string{"enabled", "config", "known_hosts", "identities", "providers", "modes", "allow_unsafe_config"})
 
 func renderSSH(policy map[string]any, outputRoot, policyDir Path, agent, mode string) (map[string]any, error) {
+	return renderSSHWithBudget(policy, outputRoot, policyDir, agent, mode, newInjectionTreeBudget())
+}
+
+func renderSSHWithBudget(
+	policy map[string]any,
+	outputRoot, policyDir Path,
+	agent, mode string,
+	budget *injectionTreeBudget,
+) (map[string]any, error) {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	raw := policy["ssh"]
 	if raw == nil {
 		return map[string]any{}, nil
@@ -88,6 +100,9 @@ func renderSSH(policy map[string]any, outputRoot, policyDir Path, agent, mode st
 		if _, err := validateSecretFile(source, "ssh.config"); err != nil {
 			return nil, err
 		}
+		if err := accountInjectionSourceSize(source, budget); err != nil {
+			return nil, err
+		}
 		if err := validateSSHConfigSafety(source, allowUnsafeConfig); err != nil {
 			return nil, err
 		}
@@ -100,6 +115,9 @@ func renderSSH(policy map[string]any, outputRoot, policyDir Path, agent, mode st
 			return nil, err
 		}
 		if _, err := validateKnownHostsFile(source, "ssh.known_hosts"); err != nil {
+			return nil, err
+		}
+		if err := accountInjectionSourceSize(source, budget); err != nil {
 			return nil, err
 		}
 		rendered["known_hosts"] = directMountEntry(source, directMountRoot+"/ssh/known_hosts")
@@ -125,6 +143,9 @@ func renderSSH(policy map[string]any, outputRoot, policyDir Path, agent, mode st
 			return nil, err
 		}
 		if _, err := validateSecretFile(source, fmt.Sprintf("ssh.identities[%d]", index)); err != nil {
+			return nil, err
+		}
+		if err := accountInjectionSourceSize(source, budget); err != nil {
 			return nil, err
 		}
 		if _, reserved := reservedSSHFilnames[source.Base()]; reserved {
@@ -182,7 +203,7 @@ func validateSSHConfigSafety(source Path, allowUnsafe bool) error {
 	if allowUnsafe {
 		return nil
 	}
-	data, err := os.ReadFile(source.String())
+	data, err := readInjectionPath(source, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -93,21 +93,6 @@ func anySlice(values any, label string) ([]any, error) {
 	}
 }
 
-func ensureNoSymlinksWithin(root Path) error {
-	return filepath.WalkDir(root.String(), func(current string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if current == root.String() {
-			return nil
-		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("directory injections must not contain symlinks: %s", current)
-		}
-		return nil
-	})
-}
-
 func directMountEntry(source Path, mountPath string) map[string]string {
 	return map[string]string{
 		"source":     source.String(),
@@ -260,24 +245,18 @@ func validateSecretTreeWithBudget(source Path, label string, budget *injectionTr
 	if err := requireSecretOwnerOnly(source, label); err != nil {
 		return err
 	}
-	if err := ensureNoSymlinksWithin(source); err != nil {
-		return err
-	}
-	return filepath.WalkDir(source.String(), func(current string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if current == source.String() {
-			return nil
+	// One bounded walk does the link, ownership, and budget checks together.
+	// A separate symlink pass ran unbounded ahead of the accounting, so a very
+	// large directory level was materialised before any limit applied.
+	return walkInjectionTree(source.String(), budget, func(current string, entry fs.DirEntry) error {
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("directory injections must not contain symlinks: %s", current)
 		}
 		child := Path(current)
 		if err := requireNoSymlink(child, label); err != nil {
 			return err
 		}
 		if err := requireSecretOwnerOnly(child, label); err != nil {
-			return err
-		}
-		if err := budget.addEntries(source.String(), 1); err != nil {
 			return err
 		}
 		if !entry.Type().IsRegular() {

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -238,9 +238,6 @@ func validateSecretTree(source Path, label string) error {
 // tree is bind-mounted rather than copied, but its size and entry count still
 // bound the fingerprint walk and the container's view of host material.
 func validateSecretTreeWithBudget(source Path, label string, budget *injectionTreeBudget) error {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	if err := requireNoSymlink(source, label); err != nil {
 		return err
 	}

--- a/internal/injection/render_validation.go
+++ b/internal/injection/render_validation.go
@@ -223,10 +223,24 @@ func validateSecretFile(source Path, label string) (Path, error) {
 	if err := requireSecretOwnerOnly(source, label); err != nil {
 		return Path(""), err
 	}
+	if err := accountInjectionFileSize(info.Size(), source.String(), nil); err != nil {
+		return Path(""), err
+	}
 	return source, nil
 }
 
 func validateSecretTree(source Path, label string) error {
+	return validateSecretTreeWithBudget(source, label, newInjectionTreeBudget())
+}
+
+// validateSecretTreeWithBudget checks ownership and link safety of a secret
+// source and charges its material against the injection input limits. A secret
+// tree is bind-mounted rather than copied, but its size and entry count still
+// bound the fingerprint walk and the container's view of host material.
+func validateSecretTreeWithBudget(source Path, label string, budget *injectionTreeBudget) error {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	if err := requireNoSymlink(source, label); err != nil {
 		return err
 	}
@@ -234,9 +248,14 @@ func validateSecretTree(source Path, label string) error {
 	if err != nil {
 		return err
 	}
-	if info.Mode().IsRegular() {
-		_, err = validateSecretFile(source, label)
+	if err := budget.addEntries(source.String(), 1); err != nil {
 		return err
+	}
+	if info.Mode().IsRegular() {
+		if _, err := validateSecretFile(source, label); err != nil {
+			return err
+		}
+		return accountInjectionFileSize(info.Size(), source.String(), budget)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("%s must point at a file or directory: %s", label, source)
@@ -258,7 +277,20 @@ func validateSecretTree(source Path, label string) error {
 		if err := requireNoSymlink(child, label); err != nil {
 			return err
 		}
-		return requireSecretOwnerOnly(child, label)
+		if err := requireSecretOwnerOnly(child, label); err != nil {
+			return err
+		}
+		if err := budget.addEntries(source.String(), 1); err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		return accountInjectionFileSize(info.Size(), current, budget)
 	})
 }
 

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -170,7 +170,7 @@ func stageDirectMountEntry(hostSource, stagedSource string, budget *injectionTre
 
 	switch kind {
 	case directMountSourceDir:
-		if err := validateInjectionDirectoryDescendants(source); err != nil {
+		if err := validateInjectionDirectoryDescendants(source, hostSource, budget); err != nil {
 			return err
 		}
 		if err := os.Mkdir(stagedSource, 0o700); err != nil {
@@ -189,7 +189,11 @@ func stageDirectMountEntry(hostSource, stagedSource string, budget *injectionTre
 
 // validateInjectionDirectoryDescendants checks each descendant through an
 // opened directory descriptor. It never builds a path from an unchecked name.
-func validateInjectionDirectoryDescendants(source *os.File) error {
+//
+// The walk runs before the copy that charges the shared budget, so it carries a
+// private counter seeded with the shared remaining allowance. That stops the
+// metadata walk at the same entry limit without charging the tree twice.
+func validateInjectionDirectoryDescendants(source *os.File, display string, budget *injectionTreeBudget) error {
 	fd, err := unix.Openat(int(source.Fd()), ".", unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return err
@@ -200,20 +204,27 @@ func validateInjectionDirectoryDescendants(source *os.File) error {
 		return errors.New("cannot inspect injection source directory")
 	}
 	defer copy.Close()
-	return validateInjectionDirectoryEntries(copy)
+	return validateInjectionDirectoryEntries(copy, display, &injectionTreeBudget{entries: budget.entries})
 }
 
-func validateInjectionDirectoryEntries(source *os.File) error {
-	return validateInjectionDirectoryEntriesWith(source, classifyDirectMountChild, openDirectMountChild)
+func validateInjectionDirectoryEntries(source *os.File, display string, walk *injectionTreeBudget) error {
+	return validateInjectionDirectoryEntriesWith(source, display, walk, classifyDirectMountChild, openDirectMountChild)
 }
 
 func validateInjectionDirectoryEntriesWith(
 	source *os.File,
+	display string,
+	walk *injectionTreeBudget,
 	classifyChild func(*os.File, string) (os.FileMode, directMountSourceKind, error),
 	openChild func(*os.File, string, string) (*os.File, os.FileMode, directMountSourceKind, error),
 ) error {
-	entries, err := source.ReadDir(-1)
-	if err != nil {
+	// Read one entry past the remaining allowance so an oversized directory is
+	// refused without materialising its whole listing.
+	entries, err := source.ReadDir(walk.remainingEntries() + 1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if err := walk.addEntries(display, len(entries)); err != nil {
 		return err
 	}
 	for _, entry := range entries {
@@ -239,7 +250,7 @@ func validateInjectionDirectoryEntriesWith(
 			return err
 		}
 		if kind == directMountSourceDir {
-			err = validateInjectionDirectoryEntriesWith(child, classifyChild, openChild)
+			err = validateInjectionDirectoryEntriesWith(child, display, walk, classifyChild, openChild)
 		}
 		closeErr := child.Close()
 		if err != nil {
@@ -362,6 +373,10 @@ func copyFileWithMode(src, dst string, _ os.FileMode) error {
 // copyOpenFileWithMode is the single choke point for every direct-mount file
 // copy, so the injection input limits are charged here — before the destination
 // is created, which keeps an over-limit input from leaving partial output.
+//
+// The reported size only pre-screens the input. A regular file can grow after
+// the stat, and a pseudo-file can report an undersized st_size, so the copy
+// itself stops one byte past the live allowance and removes partial output.
 func copyOpenFileWithMode(in *os.File, dst, source string, mode os.FileMode, budget *injectionTreeBudget) error {
 	info, err := in.Stat()
 	if err != nil {
@@ -370,16 +385,34 @@ func copyOpenFileWithMode(in *os.File, dst, source string, mode os.FileMode, bud
 	if err := accountInjectionFileSize(info.Size(), source, budget); err != nil {
 		return err
 	}
+	allowance := maxInjectionFileBytes
+	if budget != nil {
+		// accountInjectionFileSize already charged the reported size to this
+		// file, so the live allowance adds it back to what the tree has left.
+		if live := budget.remainingBytes() + info.Size(); live < allowance {
+			allowance = live
+		}
+	}
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return err
 	}
-	if _, err := io.Copy(out, in); err != nil {
+	written, err := io.Copy(out, io.LimitReader(in, allowance+1))
+	if err == nil && written > allowance {
+		err = fmt.Errorf("injection input %s exceeds the byte limit accounted for it of %d bytes", source, allowance)
+	}
+	if err == nil {
+		err = out.Close()
+	} else {
 		out.Close()
+	}
+	if err != nil {
+		_ = os.Remove(dst)
 		return err
 	}
-	if err := out.Close(); err != nil {
-		return err
+	if budget != nil {
+		// Charge what the copy actually read, not the stale reported size.
+		budget.bytes += written - info.Size()
 	}
 	return os.Chmod(dst, mode)
 }

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -187,25 +187,6 @@ func stageDirectMountEntry(hostSource, stagedSource string, budget *injectionTre
 	}
 }
 
-// copyDirContents mirrors "cp -R src/. dst" with one cautious-staging
-// divergence: symlinks under src are skipped with a log warning rather
-// than being dereferenced.  The legacy bash helper relied on `cp -R`
-// which would have followed the link target, but a symlink inside a
-// host-input source can escape the staging root entirely
-// (e.g. `~/.aws/credentials -> /etc/passwd`) and surface arbitrary
-// host files inside the container.  Skipping matches the cautious-
-// staging discipline applied elsewhere in injection: validate strictly
-// and refuse anything that cannot be vouched for.  The warning gives
-// the operator enough signal to notice that an expected file did not
-// land in the container.
-//
-// Source traversal is anchored to opened directory descriptors. Each child is
-// opened with openat(O_NOFOLLOW), so a parent path swapped after validation
-// cannot redirect staging to a different host tree.
-func copyDirContents(src *os.File, srcDisplay, dst string) error {
-	return copyDirContentsWithState(src, srcDisplay, dst, newInjectionDestinationState(), newInjectionTreeBudget())
-}
-
 // validateInjectionDirectoryDescendants checks each descendant through an
 // opened directory descriptor. It never builds a path from an unchecked name.
 func validateInjectionDirectoryDescendants(source *os.File) error {
@@ -271,6 +252,22 @@ func validateInjectionDirectoryEntriesWith(
 	return nil
 }
 
+// copyDirContentsWithState mirrors "cp -R src/. dst" with one cautious-staging
+// divergence: symlinks under src are skipped with a log warning rather
+// than being dereferenced.  The legacy bash helper relied on `cp -R`
+// which would have followed the link target, but a symlink inside a
+// host-input source can escape the staging root entirely
+// (e.g. `~/.aws/credentials -> /etc/passwd`) and surface arbitrary
+// host files inside the container.  Skipping matches the cautious-
+// staging discipline applied elsewhere in injection: validate strictly
+// and refuse anything that cannot be vouched for.  The warning gives
+// the operator enough signal to notice that an expected file did not
+// land in the container.
+//
+// Source traversal is anchored to opened directory descriptors. Each child is
+// opened with openat(O_NOFOLLOW), so a parent path swapped after validation
+// cannot redirect staging to a different host tree. The destination
+// reservations and the input budget are shared with every recursive level.
 func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState, budget *injectionTreeBudget) error {
 	// Read one entry past the remaining allowance so an oversized directory is
 	// refused without materialising its whole listing.

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -47,6 +47,9 @@ func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
 		return nil, err
 	}
 
+	// One budget spans every mount in the specification so a set of
+	// individually legal sources cannot add up to an unbounded staging copy.
+	budget := newInjectionTreeBudget()
 	args := make([]string, 0, len(mounts)*2)
 	for _, mount := range mounts {
 		if mount.Source == "" {
@@ -57,7 +60,7 @@ func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
 		}
 		entryHash := hoststate.DirectMountCacheKey(mount.Source, mount.MountPath)
 		stagedSource := filepath.Join(stagedRoot, entryHash)
-		if err := stageDirectMountEntry(mount.Source, stagedSource); err != nil {
+		if err := stageDirectMountEntry(mount.Source, stagedSource, budget); err != nil {
 			return nil, err
 		}
 		// bash: chmod -R go-rwx — best effort; ignore errors as bash did.
@@ -84,6 +87,14 @@ func StageDirectMounts(bundleRoot, mountSpecPath string) ([]string, error) {
 // slash); HasPrefix on the bare path would let an attacker mount the root
 // itself, which has no defensible meaning for a per-entry direct mount.
 func validateDirectMount(hostSource, mountPath string) error {
+	// Bound both pathnames before any filesystem work: every later step walks
+	// the source component by component and joins the mount path.
+	if len(hostSource) > maxInjectionMountPathBytes {
+		return fmt.Errorf("Direct input source exceeds the path length limit of %d bytes", maxInjectionMountPathBytes)
+	}
+	if len(mountPath) > maxInjectionMountPathBytes {
+		return fmt.Errorf("Direct input mount path exceeds the path length limit of %d bytes", maxInjectionMountPathBytes)
+	}
 	if !filepath.IsAbs(hostSource) {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
 	}
@@ -147,12 +158,18 @@ func validateDirectMount(hostSource, mountPath string) error {
 
 // stageDirectMountEntry copies a host source into stagedSource, replicating
 // "cp -R ${src}/." for directories and "cp -f ${src}" for files.
-func stageDirectMountEntry(hostSource, stagedSource string) error {
+func stageDirectMountEntry(hostSource, stagedSource string, budget *injectionTreeBudget) error {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
 	source, mode, kind, err := openDirectMountSource(hostSource)
 	if err != nil {
 		return err
 	}
 	defer source.Close()
+	if err := budget.addEntries(hostSource, 1); err != nil {
+		return err
+	}
 
 	switch kind {
 	case directMountSourceDir:
@@ -162,12 +179,12 @@ func stageDirectMountEntry(hostSource, stagedSource string) error {
 		if err := os.Mkdir(stagedSource, 0o700); err != nil {
 			return err
 		}
-		return copyDirContents(source, filepath.Clean(hostSource), stagedSource)
+		return copyDirContentsWithState(source, filepath.Clean(hostSource), stagedSource, newInjectionDestinationState(), budget)
 	case directMountSourceRegular:
 		if err := os.MkdirAll(filepath.Dir(stagedSource), 0o755); err != nil {
 			return err
 		}
-		return copyOpenFileWithMode(source, stagedSource, mode)
+		return copyOpenFileWithMode(source, stagedSource, hostSource, mode, budget)
 	default:
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", hostSource)
 	}
@@ -189,7 +206,7 @@ func stageDirectMountEntry(hostSource, stagedSource string) error {
 // opened with openat(O_NOFOLLOW), so a parent path swapped after validation
 // cannot redirect staging to a different host tree.
 func copyDirContents(src *os.File, srcDisplay, dst string) error {
-	return copyDirContentsWithState(src, srcDisplay, dst, newInjectionDestinationState())
+	return copyDirContentsWithState(src, srcDisplay, dst, newInjectionDestinationState(), newInjectionTreeBudget())
 }
 
 // validateInjectionDirectoryDescendants checks each descendant through an
@@ -257,9 +274,17 @@ func validateInjectionDirectoryEntriesWith(
 	return nil
 }
 
-func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState) error {
-	entries, err := src.ReadDir(-1)
-	if err != nil {
+func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState, budget *injectionTreeBudget) error {
+	if budget == nil {
+		budget = newInjectionTreeBudget()
+	}
+	// Read one entry past the remaining allowance so an oversized directory is
+	// refused without materialising its whole listing.
+	entries, err := src.ReadDir(budget.remainingEntries() + 1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if err := budget.addEntries(srcDisplay, len(entries)); err != nil {
 		return err
 	}
 	for _, entry := range entries {
@@ -299,7 +324,7 @@ func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injec
 				child.Close()
 				return err
 			}
-			if err := copyDirContentsWithState(child, displayPath, target, state); err != nil {
+			if err := copyDirContentsWithState(child, displayPath, target, state, budget); err != nil {
 				child.Close()
 				return err
 			}
@@ -315,7 +340,7 @@ func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injec
 				child.Close()
 				return err
 			}
-			if err := copyOpenFileWithMode(child, target, childMode); err != nil {
+			if err := copyOpenFileWithMode(child, target, displayPath, childMode, budget); err != nil {
 				child.Close()
 				return err
 			}
@@ -340,10 +365,20 @@ func copyFileWithMode(src, dst string, _ os.FileMode) error {
 	if kind != directMountSourceRegular {
 		return fmt.Errorf("Direct input source is missing, not absolute, or not a regular file/directory: %s", src)
 	}
-	return copyOpenFileWithMode(in, dst, sourceMode)
+	return copyOpenFileWithMode(in, dst, src, sourceMode, nil)
 }
 
-func copyOpenFileWithMode(in *os.File, dst string, mode os.FileMode) error {
+// copyOpenFileWithMode is the single choke point for every direct-mount file
+// copy, so the injection input limits are charged here — before the destination
+// is created, which keeps an over-limit input from leaving partial output.
+func copyOpenFileWithMode(in *os.File, dst, source string, mode os.FileMode, budget *injectionTreeBudget) error {
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if err := accountInjectionFileSize(info.Size(), source, budget); err != nil {
+		return err
+	}
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL|unix.O_NOFOLLOW, mode)
 	if err != nil {
 		return err

--- a/internal/injection/stage_direct_mounts.go
+++ b/internal/injection/stage_direct_mounts.go
@@ -159,9 +159,6 @@ func validateDirectMount(hostSource, mountPath string) error {
 // stageDirectMountEntry copies a host source into stagedSource, replicating
 // "cp -R ${src}/." for directories and "cp -f ${src}" for files.
 func stageDirectMountEntry(hostSource, stagedSource string, budget *injectionTreeBudget) error {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	source, mode, kind, err := openDirectMountSource(hostSource)
 	if err != nil {
 		return err
@@ -275,9 +272,6 @@ func validateInjectionDirectoryEntriesWith(
 }
 
 func copyDirContentsWithState(src *os.File, srcDisplay, dst string, state *injectionDestinationState, budget *injectionTreeBudget) error {
-	if budget == nil {
-		budget = newInjectionTreeBudget()
-	}
 	// Read one entry past the remaining allowance so an oversized directory is
 	// refused without materialising its whole listing.
 	entries, err := src.ReadDir(budget.remainingEntries() + 1)

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -826,8 +826,8 @@ func TestCopyDirContentsUsesOpenedDirectoryAfterPathSwap(t *testing.T) {
 	if err := os.MkdirAll(staged, 0o755); err != nil {
 		t.Fatalf("MkdirAll staged: %v", err)
 	}
-	if err := copyDirContents(source, sourceParent, staged); err != nil {
-		t.Fatalf("copyDirContents: %v", err)
+	if err := copyDirContentsWithState(source, sourceParent, staged, newInjectionDestinationState(), newInjectionTreeBudget()); err != nil {
+		t.Fatalf("copyDirContentsWithState: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(staged, "secret.txt"))
 	if err != nil {

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -36,7 +36,7 @@ func TestCopyDirContentsWithStateRejectsPreReservedUnicodeAlias(t *testing.T) {
 	if err := state.reserve(filepath.Join(destination, "straße"), "reserved"); err != nil {
 		t.Fatal(err)
 	}
-	err = copyDirContentsWithState(source, sourcePath, destination, state)
+	err = copyDirContentsWithState(source, sourcePath, destination, state, newInjectionTreeBudget())
 	if err == nil || !strings.Contains(err.Error(), "destination path collision") {
 		t.Fatalf("copy error = %v", err)
 	}
@@ -61,7 +61,7 @@ func TestCopyDirContentsWithStateRejectsInvalidUTF8Reservation(t *testing.T) {
 	}
 	defer source.Close()
 	destination := t.TempDir()
-	err = copyDirContentsWithState(source, sourcePath, destination, newInjectionDestinationState())
+	err = copyDirContentsWithState(source, sourcePath, destination, newInjectionDestinationState(), newInjectionTreeBudget())
 	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
 		t.Fatalf("copy error = %v", err)
 	}
@@ -113,7 +113,7 @@ func TestCopyDirContentsWithStateRejectsLinuxInvalidUTF8SpecialFile(t *testing.T
 	}
 	defer source.Close()
 	destination := t.TempDir()
-	err = copyDirContentsWithState(source, sourcePath, destination, newInjectionDestinationState())
+	err = copyDirContentsWithState(source, sourcePath, destination, newInjectionDestinationState(), newInjectionTreeBudget())
 	if !errors.Is(err, pathutil.ErrInvalidUTF8Path) || strings.Contains(err.Error(), "secret-prefix") {
 		t.Fatalf("copy error = %v", err)
 	}
@@ -139,7 +139,7 @@ func TestCopyDirContentsRejectsControlCharactersBeforeLogging(t *testing.T) {
 			previousOutput := log.Writer()
 			log.SetOutput(&output)
 			t.Cleanup(func() { log.SetOutput(previousOutput) })
-			err = copyDirContentsWithState(source, sourcePath, t.TempDir(), newInjectionDestinationState())
+			err = copyDirContentsWithState(source, sourcePath, t.TempDir(), newInjectionDestinationState(), newInjectionTreeBudget())
 			assertUnsafeInjectionDescendantError(t, err)
 			if output.Len() != 0 {
 				t.Fatalf("control name reached the log: %q", output.String())

--- a/internal/injection/stage_direct_mounts_test.go
+++ b/internal/injection/stage_direct_mounts_test.go
@@ -165,7 +165,7 @@ func TestValidateInjectionDirectoryEntriesWith(t *testing.T) {
 
 	t.Run("other skips opener", func(t *testing.T) {
 		opened := false
-		err := validateInjectionDirectoryEntriesWith(newSource(t),
+		err := validateInjectionDirectoryEntriesWith(newSource(t), "source", newInjectionTreeBudget(),
 			func(*os.File, string) (os.FileMode, directMountSourceKind, error) {
 				return 0, directMountSourceOther, nil
 			},
@@ -184,7 +184,7 @@ func TestValidateInjectionDirectoryEntriesWith(t *testing.T) {
 
 	t.Run("classifier error propagates", func(t *testing.T) {
 		sentinel := errors.New("classify sentinel")
-		err := validateInjectionDirectoryEntriesWith(newSource(t),
+		err := validateInjectionDirectoryEntriesWith(newSource(t), "source", newInjectionTreeBudget(),
 			func(*os.File, string) (os.FileMode, directMountSourceKind, error) {
 				return 0, directMountSourceOther, sentinel
 			},
@@ -208,7 +208,7 @@ func TestValidateInjectionDirectoryEntriesWith(t *testing.T) {
 		{name: "EIO propagates", err: unix.EIO},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := validateInjectionDirectoryEntriesWith(newSource(t),
+			err := validateInjectionDirectoryEntriesWith(newSource(t), "source", newInjectionTreeBudget(),
 				func(*os.File, string) (os.FileMode, directMountSourceKind, error) {
 					return 0, directMountSourceRegular, nil
 				},

--- a/internal/runtimeutil/runtimeutil.go
+++ b/internal/runtimeutil/runtimeutil.go
@@ -22,6 +22,10 @@ const (
 	maxRuntimeManifestBytes  = rootio.MaxManifestBytes
 	maxRuntimeMountSpecBytes = rootio.MaxDirectMountSpecBytes
 	resolveIPTimeout         = 5 * time.Second
+	// MaxDirectMountEntries bounds how many entries one direct-mount
+	// specification may declare. The byte limit alone still admits a spec of
+	// minimal entries that costs one stat and one bind mount each.
+	MaxDirectMountEntries = 4096
 )
 
 type lookupIPAddrFunc func(context.Context, string) ([]net.IPAddr, error)
@@ -72,6 +76,9 @@ func ListDirectMounts(mountSpecPath string) ([]DirectMount, error) {
 	var entries []map[string]any
 	if err := json.Unmarshal(data, &entries); err != nil {
 		return nil, err
+	}
+	if len(entries) > MaxDirectMountEntries {
+		return nil, fmt.Errorf("direct mount specification exceeds the mount limit of %d: %s", MaxDirectMountEntries, mountSpecPath)
 	}
 	directMounts := make([]DirectMount, 0, len(entries))
 	for _, entry := range entries {


### PR DESCRIPTION
Injection inputs are operator-selected host material, but the render and staging paths read them with unbounded `os.ReadFile` / `io.ReadAll` / `ReadDir(-1)` calls. A single large selection, or a set of individually reasonable ones, could drive memory, disk, and metadata work without a ceiling.

## Summary

- Add `internal/injection/input_limits.go`: a per-file limit (16 MiB) plus an aggregate `injectionTreeBudget` (64 MiB, 4096 entries) that one bundle render or one direct-mount staging pass shares, so individually legal selections cannot add up to an unbounded copy.
- Bound reads at read time via `io.LimitReader` one byte past the applicable limit, so an oversize input is refused without ever being buffered whole. This replaces the unbounded reads in `stageFile`, `copySource`, the recursive directory copies, `parseSimpleEnvFile`, `validateJSONObjFile`, `validateSSHConfigSafety`, and `pathMaterialSHA256`.
- Read directory listings one entry past the remaining allowance instead of `ReadDir(-1)`, so an oversized directory is refused without materialising its whole listing.
- Charge bind-mounted secret material (`ssh.config`, `ssh.known_hosts`, `ssh.identities`, credentials, secret copies) against the same budget. Those paths skip the copy readers, so they need their own accounting to bound the fingerprint walk.
- Charge the file size in `copyOpenFileWithMode` before the destination is created, so an over-limit input leaves no partial output behind.
- Cap direct-mount specifications by entry count (`runtimeutil.MaxDirectMountEntries`, 4096) alongside the existing byte cap: the byte limit alone still admits a spec of minimal entries that each cost a stat and a bind mount.
- Bound both pathnames in `validateDirectMount` to 4096 bytes before any filesystem work, since every later step walks the source component by component.

## Testing

- `go test ./internal/injection/ ./internal/runtimeutil/ -count=1` — ok (both packages)
- `go test ./... -count=1` — 47 packages ok
- `go vet ./...` — clean
- `gofmt -l .` — clean

New tests cover both sides of each limit: exact-size acceptance and one-byte-over rejection for the per-file limit, aggregate byte and entry exhaustion across `copySource`, `StageDirectMounts`, and `validateSecretTree`, budget sharing across mounts in one specification and across documents/copies/ssh/credentials in one bundle render, mount-spec byte and count boundaries, mount-path length boundaries, and oversize rejection through each bounded validation reader.
