### PR TITLE
!b Require the exact upstream-refresh workflow path (focused validation passes; fail-closed run provenance guard)

### DIFF
--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -1582,12 +1582,18 @@ func TestSafePathDocDocumentsRepoPublishWrapperBeforeLowerLevelHelper(t *testing
 func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 	t.Parallel()
 
-	scriptPath, script := readPublishUpstreamRefreshPR(t)
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "publish-upstream-refresh-pr.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(content)
 
 	for _, want := range []string{
 		`git -C "${ROOT_DIR}" status --short`,
 		`git -C "${ROOT_DIR}" fetch origin "${BASE_BRANCH}"`,
 		`refs/remotes/origin/${BASE_BRANCH}`,
+		`if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml" ]]; then`,
 		`gh run download "${RUN_ID}" --repo "${REPO}" --name upstream-refresh-candidate`,
 		`Candidate patch digest mismatch`,
 		`Candidate tree OID mismatch`,
@@ -1604,46 +1610,12 @@ func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)
 		}
 	}
-	if !hasExactUpstreamRefreshWorkflowPathGuard(script) {
-		t.Fatalf("%s must require the exact upstream-refresh workflow path", scriptPath)
-	}
 
 	const commitTemplateStart = `cat >"${commit_file}" <<'EOF'
 ^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)`
 	if !strings.Contains(script, commitTemplateStart) {
 		t.Fatalf("%s must generate the reviewed Risk-Aware upstream-refresh commit subject", scriptPath)
 	}
-}
-
-func TestPublishUpstreamRefreshPRRejectsWorkflowPathGuardMutations(t *testing.T) {
-	_, script := readPublishUpstreamRefreshPR(t)
-	const guard = `if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml" ]]; then`
-	for _, replacement := range []string{
-		`if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml"* ]]; then`,
-		`if [[ "${run_path}" != ".github/workflows/upstream-refresh.yaml" ]]; then`,
-		`if true; then`,
-	} {
-		mutated := strings.Replace(script, guard, replacement, 1)
-		if hasExactUpstreamRefreshWorkflowPathGuard(mutated) {
-			t.Fatalf("workflow path guard mutation passed: %s", replacement)
-		}
-	}
-}
-
-func readPublishUpstreamRefreshPR(t *testing.T) (string, string) {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "scripts", "publish-upstream-refresh-pr.sh")
-	content, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return path, string(content)
-}
-
-func hasExactUpstreamRefreshWorkflowPathGuard(script string) bool {
-	const exact = `if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml" ]]; then`
-	const prefix = `if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml"* ]]; then`
-	return strings.Count(script, exact) == 1 && !strings.Contains(script, prefix)
 }
 
 func TestUpdateProviderPinsStagesCodexNamespaceAndLockfileBeforePublishingBump(t *testing.T) {

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -1582,12 +1582,7 @@ func TestSafePathDocDocumentsRepoPublishWrapperBeforeLowerLevelHelper(t *testing
 func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 	t.Parallel()
 
-	scriptPath := filepath.Join(repoRoot(t), "scripts", "publish-upstream-refresh-pr.sh")
-	content, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	script := string(content)
+	scriptPath, script := readPublishUpstreamRefreshPR(t)
 
 	for _, want := range []string{
 		`git -C "${ROOT_DIR}" status --short`,
@@ -1609,12 +1604,46 @@ func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 			t.Fatalf("%s does not contain %q", scriptPath, want)
 		}
 	}
+	if !hasExactUpstreamRefreshWorkflowPathGuard(script) {
+		t.Fatalf("%s must require the exact upstream-refresh workflow path", scriptPath)
+	}
 
 	const commitTemplateStart = `cat >"${commit_file}" <<'EOF'
 ^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)`
 	if !strings.Contains(script, commitTemplateStart) {
 		t.Fatalf("%s must generate the reviewed Risk-Aware upstream-refresh commit subject", scriptPath)
 	}
+}
+
+func TestPublishUpstreamRefreshPRRejectsWorkflowPathGuardMutations(t *testing.T) {
+	_, script := readPublishUpstreamRefreshPR(t)
+	const guard = `if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml" ]]; then`
+	for _, replacement := range []string{
+		`if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml"* ]]; then`,
+		`if [[ "${run_path}" != ".github/workflows/upstream-refresh.yaml" ]]; then`,
+		`if true; then`,
+	} {
+		mutated := strings.Replace(script, guard, replacement, 1)
+		if hasExactUpstreamRefreshWorkflowPathGuard(mutated) {
+			t.Fatalf("workflow path guard mutation passed: %s", replacement)
+		}
+	}
+}
+
+func readPublishUpstreamRefreshPR(t *testing.T) (string, string) {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "scripts", "publish-upstream-refresh-pr.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path, string(content)
+}
+
+func hasExactUpstreamRefreshWorkflowPathGuard(script string) bool {
+	const exact = `if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml" ]]; then`
+	const prefix = `if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml"* ]]; then`
+	return strings.Count(script, exact) == 1 && !strings.Contains(script, prefix)
 }
 
 func TestUpdateProviderPinsStagesCodexNamespaceAndLockfileBeforePublishingBump(t *testing.T) {

--- a/scripts/publish-upstream-refresh-pr.sh
+++ b/scripts/publish-upstream-refresh-pr.sh
@@ -167,7 +167,7 @@ if [[ "${run_head_branch}" != "${BASE_BRANCH}" ]]; then
   echo "Workflow run ${RUN_ID} must target ${BASE_BRANCH}, found ${run_head_branch:-unknown}." >&2
   exit 2
 fi
-if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml"* ]]; then
+if [[ "${run_path}" != ".github/workflows/upstream-refresh.yml" ]]; then
   echo "Workflow run ${RUN_ID} does not come from the reviewed upstream-refresh workflow on ${BASE_BRANCH}." >&2
   exit 2
 fi


### PR DESCRIPTION
`publish-upstream-refresh-pr.sh` validated the workflow run provenance with a prefix glob, so any workflow whose path merely started with the reviewed one satisfied the guard.

## Summary

- Compare the workflow run path with an exact match instead of the `"…upstream-refresh.yml"*` prefix glob, so a look-alike path such as `.github/workflows/upstream-refresh.yml.bak` no longer passes the reviewed-workflow check. The run `.path` returned by the API is the exact workflow file path, so the tightening rejects only paths the guard was always meant to reject.
- Pin the tightened guard line in the existing `TestPublishUpstreamRefreshPRRequiresCleanWorktree` required-substring list, alongside the other publication guards this entrypoint test already covers.

## Testing

- `go test ./internal/testkit/ -run 'TestPublishUpstreamRefreshPR' -count=1` — pass.
- `go test ./internal/testkit/ -count=1` — pass (124.9s), the full package covering the script-text pins.
- Negative control: reverted the guard to the prefix glob in a scratch worktree and re-ran `TestPublishUpstreamRefreshPRRequiresCleanWorktree` — fails with `does not contain "if [[ \"${run_path}\" != \".github/workflows/upstream-refresh.yml\" ]]; then"`, then restored the script and confirmed the test passes again. This shows the assertion still kills the regression it is there to catch.
- `shellcheck -x scripts/publish-upstream-refresh-pr.sh` and `shfmt -ln=bash -i 2 -ci -d scripts/publish-upstream-refresh-pr.sh` — clean.
- `bash -n scripts/publish-upstream-refresh-pr.sh` — clean.
