### PR TITLE
Separate observation identity from process identity

### DIFF
--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -163,8 +163,7 @@ thread states with stable identifiers.
 
 ### Observation Identity and Polling
 
-Record the observation owner, tool, session handle, and OS PID as separate
-fields.
+Record observation owner, tool, session handle, and OS PID as separate fields.
 Let the originating agent poll its agent-scoped session handle.
 Let peers inspect an OS process only after they resolve its PID and provenance.
 

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -161,6 +161,17 @@ Do not include credentials, tokens, or raw comment bodies. Reconstruct remote
 state before a mutation. Record reviewed heads, checks, reactions, replies, and
 thread states with stable identifiers.
 
+### Observation Identity and Polling
+
+Record the observation owner, tool, session handle, and OS PID as separate fields.
+Treat a tool session ID as distinct from an OS PID.
+Let the originating agent poll its agent-scoped session handle.
+Let peers inspect an OS process only after they resolve its PID and provenance.
+
+Treat an unknown cross-agent handle or quiet output as non-terminal evidence.
+Do not restart a workload only because observation timed out.
+Inspect the target filesystem capacity when disk state affects the observation.
+
 ## Check and Merge Workflow
 
 1. Confirm that the worktree contains only intended changes.

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -163,8 +163,8 @@ thread states with stable identifiers.
 
 ### Observation Identity and Polling
 
-Record the observation owner, tool, session handle, and OS PID as separate fields.
-Treat a tool session ID as distinct from an OS PID.
+Record the observation owner, tool, session handle, and OS PID as separate
+fields.
 Let the originating agent poll its agent-scoped session handle.
 Let peers inspect an OS process only after they resolve its PID and provenance.
 


### PR DESCRIPTION
Add an Observation Identity and Polling subsection to the `workcell-pr-lifecycle` skill, under Parallel Work.

Summary:

- Record observation owner, tool, session handle, and OS PID as separate fields, so a tool session handle is never conflated with an OS PID.
- Scope polling by role: the originating agent polls its agent-scoped session handle; a peer inspects an OS process only after it resolves the PID and its provenance.
- Treat an unknown cross-agent handle or quiet output as non-terminal evidence, and do not restart a workload only because observation timed out.
- Inspect target filesystem capacity when disk state affects the observation.

Documentation only. No code, contract, or workflow behavior changes.

Testing:

- `./scripts/check-doc-links.sh` — OK (107 markdown files; relative links and docs/ orphans clean).
- `./scripts/check-pr-shape.sh` — passed (files=1 lines=11 areas=1 binary_files=0).
- `./scripts/check-public-repo-hygiene.sh` — passed.

Focused documentation validators were used per the skill's own rule for narrow documentation changes. No Go package was touched, so no `go test` lane applies.
