### PR TITLE
Block the Claude subagent prompt-file override

### DIFF
--- a/internal/metadatautil/codex_install_ownership_test.go
+++ b/internal/metadatautil/codex_install_ownership_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckPinnedInputsAcceptsRootOwnedCodexArtifacts(t *testing.T) {
+	if err := metadatautil.CheckPinnedInputs(writePinnedInputsFixture(t)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckPinnedInputsRequiresRootOwnedCodexArtifacts(t *testing.T) {
+	artifacts := []struct {
+		name  string
+		label string
+	}{
+		{"codex", "root-owned Codex runtime artifact install"},
+		{"codex-code-mode-host", "root-owned Codex code-mode host runtime artifact install"},
+	}
+	for _, artifact := range artifacts {
+		for _, command := range []string{"mv", "install -m 0755", "install -o 1001 -g 0 -m 0755", "install -o 0 -g 1001 -m 0755", "install -o 0 -g 0 -m 0775", "# install -o 0 -g 0 -m 0755", "echo install -o 0 -g 0 -m 0755"} {
+			t.Run(artifact.name+"/"+command, func(t *testing.T) {
+				source := `"/tmp/` + artifact.name + `-${CODEX_ARCH}"`
+				original := "install -o 0 -g 0 -m 0755 " + source
+				cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(content string) string {
+					if strings.Count(content, original) != 1 {
+						t.Fatalf("expected one installation of %s", artifact.name)
+					}
+					return strings.Replace(content, original, command+" "+source, 1)
+				})
+				requirePinnedInputsErrorContains(t, cfg, artifact.label)
+			})
+		}
+	}
+}

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -166,7 +166,8 @@ func (validator *dockerPinnedInputValidator) validateProviderInstallCommands() e
 		{`install -m 0755 /tmp/copilot /usr/local/libexec/workcell/real/copilot`, "executable Copilot runtime artifact install"},
 		{`codex-code-mode-host-\$\{CODEX_ARCH\}\.tar\.gz`, "Codex code-mode host release download URL"},
 		{`echo "\$\{CODEX_CODE_MODE_HOST_SHA256\}  /tmp/codex-code-mode-host\.tar\.gz" \| sha256sum -c -`, "Codex code-mode host archive checksum verification"},
-		{`/usr/local/libexec/workcell/real/codex-code-mode-host`, "Codex code-mode host runtime artifact install"},
+		{`(?m)^[\t ]*&& install -o 0 -g 0 -m 0755 "/tmp/codex-\$\{CODEX_ARCH\}" /usr/local/libexec/workcell/real/codex[\t ]+\\[\t ]*$`, "root-owned Codex runtime artifact install"},
+		{`(?m)^[\t ]*&& install -o 0 -g 0 -m 0755 "/tmp/codex-code-mode-host-\$\{CODEX_ARCH\}" /usr/local/libexec/workcell/real/codex-code-mode-host[\t ]+\\[\t ]*$`, "root-owned Codex code-mode host runtime artifact install"},
 	}
 	for _, requirement := range requirements {
 		if _, _, err := requireRegex(validator.runtimeDockerfile, requirement.pattern, requirement.label, validator.cfg.RuntimeDockerfilePath); err != nil {

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -377,7 +377,7 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
      fi \
   && echo "${CODEX_SHA256}  /tmp/codex.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/codex.tar.gz -C /tmp \
-  && mv "/tmp/codex-${CODEX_ARCH}" /usr/local/libexec/workcell/real/codex \
+  && install -o 0 -g 0 -m 0755 "/tmp/codex-${CODEX_ARCH}" /usr/local/libexec/workcell/real/codex \
   && if [[ -n "${CODEX_CODE_MODE_HOST_RELEASE_URL}" ]]; then \
        curl --ipv4 -fsSL "${CODEX_CODE_MODE_HOST_RELEASE_URL}" \
          --retry 8 \
@@ -395,12 +395,11 @@ RUN TARGET_ARCH="${TARGETARCH:-}" \
      fi \
   && echo "${CODEX_CODE_MODE_HOST_SHA256}  /tmp/codex-code-mode-host.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/codex-code-mode-host.tar.gz -C /tmp \
-  && mv "/tmp/codex-code-mode-host-${CODEX_ARCH}" /usr/local/libexec/workcell/real/codex-code-mode-host \
-  && chmod 0755 /usr/local/libexec/workcell/real/codex \
-    /usr/local/libexec/workcell/real/codex-code-mode-host \
+  && install -o 0 -g 0 -m 0755 "/tmp/codex-code-mode-host-${CODEX_ARCH}" /usr/local/libexec/workcell/real/codex-code-mode-host \
   && touch -d "@${SOURCE_DATE_EPOCH}" /usr/local/libexec/workcell/real/codex \
     /usr/local/libexec/workcell/real/codex-code-mode-host \
-  && rm -f /tmp/codex.tar.gz /tmp/codex-code-mode-host.tar.gz
+  && rm -f /tmp/codex.tar.gz /tmp/codex-code-mode-host.tar.gz \
+    "/tmp/codex-${CODEX_ARCH}" "/tmp/codex-code-mode-host-${CODEX_ARCH}"
 
 RUN TARGET_ARCH="${TARGETARCH:-}" \
   && if [[ -z "${TARGET_ARCH}" ]]; then \

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -248,7 +248,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-policy.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-policy.sh",
-      "sha256": "62d4e7a8f017cb57468bcfda1aecbee8b0e018d4e6a03fc25dcd6a2307114c7e"
+      "sha256": "6fed5ab21a4c5fa1e16138bebe73fd6c384302299a6ae2beff57892e1e10ac0f"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/provider-policy.sh
+++ b/runtime/container/provider-policy.sh
@@ -384,13 +384,13 @@ reject_unsafe_claude_args() {
     fi
 
     case "${arg}" in
-      --dangerously-skip-permissions | --allow-dangerously-skip-permissions | --add-dir | --allowedTools | --allowed-tools | --mcp-config | --plugin-dir | --plugin-url | --settings | --setting-sources | --system-prompt | --system-prompt-file | --append-system-prompt | --append-system-prompt-file | --append-subagent-system-prompt | --agents)
+      --dangerously-skip-permissions | --allow-dangerously-skip-permissions | --add-dir | --allowedTools | --allowed-tools | --mcp-config | --plugin-dir | --plugin-url | --settings | --setting-sources | --system-prompt | --system-prompt-file | --append-system-prompt | --append-system-prompt-file | --append-subagent-system-prompt | --append-subagent-system-prompt-file | --agents)
         workcell_die "Workcell blocked unsafe Claude override: ${arg}"
         ;;
       --permission-mode | --permission-mode=*)
         workcell_die "Workcell blocked Claude autonomy override: use the host workcell --agent-autonomy option instead."
         ;;
-      --add-dir=* | --allowedTools=* | --allowed-tools=* | --mcp-config=* | --plugin-dir=* | --plugin-url=* | --settings=* | --setting-sources=* | --system-prompt=* | --system-prompt-file=* | --append-system-prompt=* | --append-system-prompt-file=* | --append-subagent-system-prompt=* | --agents=*)
+      --add-dir=* | --allowedTools=* | --allowed-tools=* | --mcp-config=* | --plugin-dir=* | --plugin-url=* | --settings=* | --setting-sources=* | --system-prompt=* | --system-prompt-file=* | --append-system-prompt=* | --append-system-prompt-file=* | --append-subagent-system-prompt=* | --append-subagent-system-prompt-file=* | --agents=*)
         workcell_die "Workcell blocked unsafe Claude override: ${arg%%=*}"
         ;;
     esac

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -2909,6 +2909,18 @@ if run_entrypoint claude claude --append-subagent-system-prompt evil --version >
 fi
 grep -q "Workcell blocked unsafe Claude override" /tmp/workcell-entrypoint-claude-subagent-prompt.out
 
+if run_entrypoint claude claude --append-subagent-system-prompt-file /workspace/prompt.txt --version >/tmp/workcell-entrypoint-claude-subagent-prompt-file.out 2>&1; then
+  echo "expected Workcell entrypoint to reject Claude subagent prompt files outside breakglass" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Claude override" /tmp/workcell-entrypoint-claude-subagent-prompt-file.out
+
+if run_entrypoint claude claude --append-subagent-system-prompt-file=/workspace/prompt.txt --version >/tmp/workcell-entrypoint-claude-subagent-prompt-file-equals.out 2>&1; then
+  echo "expected Workcell entrypoint to reject Claude subagent prompt file equals syntax outside breakglass" >&2
+  exit 1
+fi
+grep -q "Workcell blocked unsafe Claude override" /tmp/workcell-entrypoint-claude-subagent-prompt-file-equals.out
+
 if run_entrypoint claude claude --system-prompt-file /workspace/evil.md --version >/tmp/workcell-entrypoint-claude-system-prompt-file.out 2>&1; then
   echo "expected Workcell entrypoint to reject Claude file-based system prompt overrides outside breakglass" >&2
   exit 1
@@ -3278,6 +3290,8 @@ test -f "$CODEX_HOME/config.toml"
     grep -Eq "^unified_exec[[:space:]]+stable[[:space:]]+true$" /tmp/codex-features.out
     grep -Eq "^code_mode_host[[:space:]]+stable[[:space:]]+true$" /tmp/codex-features.out
     test -x /usr/local/libexec/workcell/real/codex-code-mode-host
+    test "$(stat -c '%u:%g:%a' /usr/local/libexec/workcell/real/codex)" = 0:0:755
+    test "$(stat -c '%u:%g:%a' /usr/local/libexec/workcell/real/codex-code-mode-host)" = 0:0:755
     if command -v python3 >/tmp/python-which.out 2>&1; then
       echo "expected runtime image to omit python3 from the operator PATH" >&2
       exit 1


### PR DESCRIPTION
## Summary

- Reject `--append-subagent-system-prompt-file` in the Claude provider policy, in both the bare and the `=` forms. The policy already rejected `--append-subagent-system-prompt`, but the file variant passed through and let a workspace file reach the subagent system prompt.
- Install the Codex and Codex code-mode host runtime artifacts with `install -o 0 -g 0 -m 0755` instead of `mv` plus a later `chmod`. The artifacts now get root ownership and mode in one step, and the extracted staging copies are removed with the archives.
- Require the root-owned install form in the pinned-input Dockerfile validator. The previous requirement matched the target path alone, so it accepted an unowned `mv`.
- Update the control-plane manifest digest for `provider-policy.sh`.

## Security invariants

- The entrypoint blocks the subagent prompt-file override outside breakglass, for `--flag value` and `--flag=value`.
- The runtime image ships `/usr/local/libexec/workcell/real/codex` and `codex-code-mode-host` as `0:0:755`.
- The validator rejects `mv`, a mode-only `install`, a wrong owner, a wrong group, a wrong mode, and a commented or `echo`-prefixed install line.

## Validation

- `go test ./internal/metadatautil/ -count=1`: ok (20.7s), including the new accept and reject cases for both Codex artifacts.
- `go test ./internal/workcellhardening/ -count=1`: ok (2.7s).
- `go build ./...`, `go vet ./internal/metadatautil/`, `gofmt -l`: clean.
- `bash -n` and `shellcheck -x` on `runtime/container/provider-policy.sh` and `scripts/container-smoke.sh`: clean.
- `shasum -a 256 runtime/container/provider-policy.sh` matches the manifest entry.
- Container smoke adds the two entrypoint rejection checks and the `stat -c '%u:%g:%a'` assertions for both Codex artifacts; these run in the container smoke lane.
