### PR TITLE
^B De-flake the validator-bind probe log wait (30-run stress and mutation control pass; test-only stability fix)

### DIFF
--- a/internal/host/validatorbind/validatorbind_test.go
+++ b/internal/host/validatorbind/validatorbind_test.go
@@ -19,6 +19,8 @@ import (
 
 var errInvalidCleanupContext = errors.New("cleanup context is canceled or unbounded")
 
+const completedProbeLogMarker = "workcell-validator-bind-probe-log-complete"
+
 func TestRequireProvesExactWorkspaceAndCleansChallenge(t *testing.T) {
 	t.Parallel()
 	workspace := createWorkspace(t, "workspace,with-comma")
@@ -179,12 +181,9 @@ func TestRequireLocalDeadlineFailsClosedAndCleansChallengeAndContainer(t *testin
 	t.Parallel()
 	workspace := createWorkspace(t, "workspace")
 	docker := executableFixture(t, "docker")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
 	var cleanupArgs []string
 	var probeName string
-	err := requireWithProbeTimeout(ctx, Options{
+	err := requireWithProbeTimeout(context.Background(), Options{
 		DockerBinary: docker,
 		Image:        "validator:fixture",
 		Workspace:    workspace,
@@ -440,8 +439,9 @@ fi
 if [ "$1" = "rm" ]; then
 	exit 0
 fi
+printf '%%s\n' %q >> %q
 exec /bin/sleep 60
-`, commandLog)
+`, commandLog, completedProbeLogMarker, commandLog)
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func waitForLoggedProbeStart(t *testing.T, commandLog string, timeout time.Durat
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if data, err := os.ReadFile(commandLog); err == nil && slices.Contains(strings.Split(string(data), "\n"), "run") {
+		if data, err := os.ReadFile(commandLog); err == nil && completedProbeLog(data) {
 			return
 		}
 		select {
@@ -566,6 +566,21 @@ func waitForLoggedProbeStart(t *testing.T, commandLog string, timeout time.Durat
 			t.Fatal("blocking Docker executable did not record the probe command")
 		case <-ticker.C:
 		}
+	}
+}
+
+func completedProbeLog(data []byte) bool {
+	return slices.Contains(strings.Split(string(data), "\n"), completedProbeLogMarker)
+}
+
+func TestCompletedProbeLogRequiresCompletionMarker(t *testing.T) {
+	partial := []byte("--context\nfixture-context\nrun\n")
+	if completedProbeLog(partial) {
+		t.Fatal("partial probe log reported completion")
+	}
+	complete := append(partial, []byte(completedProbeLogMarker+"\n")...)
+	if !completedProbeLog(complete) {
+		t.Fatal("completed probe log did not report completion")
 	}
 }
 

--- a/internal/host/validatorbind/validatorbind_test.go
+++ b/internal/host/validatorbind/validatorbind_test.go
@@ -183,7 +183,12 @@ func TestRequireLocalDeadlineFailsClosedAndCleansChallengeAndContainer(t *testin
 	docker := executableFixture(t, "docker")
 	var cleanupArgs []string
 	var probeName string
-	err := requireWithProbeTimeout(context.Background(), Options{
+	// Watchdog only: the zero probe timeout expires immediately, so this
+	// deadline cannot compete with it, but it bounds the probe-context wait
+	// below if probe-context cancellation ever regresses.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := requireWithProbeTimeout(ctx, Options{
 		DockerBinary: docker,
 		Image:        "validator:fixture",
 		Workspace:    workspace,


### PR DESCRIPTION
De-flake the probe-log wait in the validator-bind cancellation test.

## Summary

- `waitForLoggedProbeStart` returned as soon as `run` appeared in the fixture
  command log. The blocking Docker fixture writes its arguments first and
  reaches `exec /bin/sleep 60` afterwards, so the wait could release before
  the fixture blocked. Cancellation then raced the fixture start.
- The fixture now writes an explicit completion marker on the line before the
  `exec`. The wait requires that marker, which proves the fixture logged all
  arguments and is at the blocking call. The `rm` path exits before the marker
  write, so the cleanup-argument assertion is unchanged.
- `TestRequireLocalDeadlineFailsClosedAndCleansChallengeAndContainer` no longer
  wraps a one-second parent timeout around a probe timeout of `0`. The parent
  timeout was a second clock that could expire first on a loaded machine and
  return `context.DeadlineExceeded` in place of `errValidatorBindProbeTimeout`.
- `completedProbeLog` holds the marker predicate, and a focused test pins it.
  A mutation back to the previous `run` check keeps the cancellation test green
  because the race is rare; the focused test is the control that fails.

Test-only change. No runtime, policy, or adapter code is touched.

## Testing

- `go vet ./internal/host/validatorbind/` — pass.
- `go test ./internal/host/validatorbind/ -count=1` — ok, 2.383s.
- `go test ./internal/host/validatorbind/ -run 'TestRequireCancellationStopsBlockingExecutable|TestRequireLocalDeadlineFailsClosedAndCleansChallengeAndContainer' -count=30` — ok, 27.162s, no flake in 30 runs.
- Mutation negative control: reverting `completedProbeLog` to the previous
  `run` check fails `TestCompletedProbeLogRequiresCompletionMarker`
  ("partial probe log reported completion") while
  `TestRequireCancellationStopsBlockingExecutable` still passes.
- `gofmt -l internal/host/validatorbind/` — no output.
