### PR TITLE
Serialize empty direct mount specs as JSON arrays

### DIFF
--- a/internal/injection/extract_direct_mounts.go
+++ b/internal/injection/extract_direct_mounts.go
@@ -100,9 +100,9 @@ func runExtractDirectMounts(manifestPath, mountSpecPath string, beforeManifestWr
 }
 
 func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
-	var directMounts []DirectMount
+	directMounts := make([]DirectMount, 0)
 
-	if rawCredentials, ok := manifest["credentials"]; ok && rawCredentials != nil {
+	if rawCredentials := manifest["credentials"]; rawCredentials != nil {
 		credentials, err := asObjectMap(rawCredentials, "credentials")
 		if err != nil {
 			return nil, err
@@ -120,7 +120,7 @@ func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
 		}
 	}
 
-	if rawCopies, ok := manifest["copies"]; ok && rawCopies != nil {
+	if rawCopies := manifest["copies"]; rawCopies != nil {
 		copies, err := asArray(rawCopies, "copies")
 		if err != nil {
 			return nil, err
@@ -140,8 +140,8 @@ func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
 		}
 	}
 
-	rawSSH, ok := manifest["ssh"]
-	if !ok || rawSSH == nil {
+	rawSSH := manifest["ssh"]
+	if rawSSH == nil {
 		return sortDirectMounts(directMounts), nil
 	}
 
@@ -151,7 +151,7 @@ func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
 	}
 
 	for _, key := range []string{"config", "known_hosts"} {
-		if rawEntry, ok := ssh[key]; ok && rawEntry != nil {
+		if rawEntry := ssh[key]; rawEntry != nil {
 			entry, err := asObjectMap(rawEntry, "ssh."+key)
 			if err != nil {
 				return nil, err
@@ -164,7 +164,7 @@ func collectDirectMounts(manifest map[string]any) ([]DirectMount, error) {
 		}
 	}
 
-	if rawIdentities, ok := ssh["identities"]; ok && rawIdentities != nil {
+	if rawIdentities := ssh["identities"]; rawIdentities != nil {
 		identities, err := asArray(rawIdentities, "ssh.identities")
 		if err != nil {
 			return nil, err

--- a/internal/injection/extract_direct_mounts_test.go
+++ b/internal/injection/extract_direct_mounts_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omkhar/workcell/internal/runtimeutil"
 	"golang.org/x/sys/unix"
 )
 
@@ -379,7 +378,7 @@ func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
 	}
 }
 
-func TestRunExtractDirectMountsWritesReadableEmptyArrayWithoutDirectMounts(t *testing.T) {
+func TestRunExtractDirectMountsWritesEmptyArrayWithoutDirectMounts(t *testing.T) {
 	tests := map[string]map[string]any{
 		"empty": {},
 		"null optional sections": {
@@ -389,9 +388,6 @@ func TestRunExtractDirectMountsWritesReadableEmptyArrayWithoutDirectMounts(t *te
 		},
 		"null optional ssh fields": {
 			"ssh": map[string]any{"config": nil, "known_hosts": nil, "identities": nil},
-		},
-		"network only": {
-			"network": map[string]any{"allow_endpoints": []any{"registry.internal.example"}},
 		},
 		"plain copy only": {
 			"copies": []any{map[string]any{
@@ -406,13 +402,6 @@ func TestRunExtractDirectMountsWritesReadableEmptyArrayWithoutDirectMounts(t *te
 			_, mountSpec := runGoExtractDirectMounts(t, manifest)
 			if string(mountSpec) != "[]\n" {
 				t.Fatalf("mount specification = %q, want empty JSON array", mountSpec)
-			}
-
-			mountSpecPath := filepath.Join(t.TempDir(), "mounts.json")
-			writeFile(t, mountSpecPath, mountSpec)
-			mounts, err := runtimeutil.ListDirectMounts(mountSpecPath)
-			if err != nil || len(mounts) != 0 {
-				t.Fatalf("ListDirectMounts = %#v, %v", mounts, err)
 			}
 		})
 	}

--- a/internal/injection/extract_direct_mounts_test.go
+++ b/internal/injection/extract_direct_mounts_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omkhar/workcell/internal/runtimeutil"
 	"golang.org/x/sys/unix"
 )
 
@@ -251,8 +252,8 @@ func TestRunExtractDirectMountsAtomicallyReplacesMountSpecSymlink(t *testing.T) 
 	if info, err := os.Lstat(mountSpecPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
 		t.Fatalf("mount-spec leaf was not atomically replaced: %v, %v", info, err)
 	}
-	if got := readFile(t, mountSpecPath); !bytes.Equal(bytes.TrimSpace(got), []byte("null")) {
-		t.Fatalf("mount specification = %q, want preserved JSON null", got)
+	if got := readFile(t, mountSpecPath); !bytes.Equal(bytes.TrimSpace(got), []byte("[]")) {
+		t.Fatalf("mount specification = %q, want empty JSON array", got)
 	}
 	assertFileMode(t, mountSpecPath, 0o600)
 }
@@ -378,6 +379,45 @@ func TestRunExtractDirectMountsLeavesPlainCopySourcesInline(t *testing.T) {
 	}
 }
 
+func TestRunExtractDirectMountsWritesReadableEmptyArrayWithoutDirectMounts(t *testing.T) {
+	tests := map[string]map[string]any{
+		"empty": {},
+		"null optional sections": {
+			"credentials": nil,
+			"copies":      nil,
+			"ssh":         nil,
+		},
+		"null optional ssh fields": {
+			"ssh": map[string]any{"config": nil, "known_hosts": nil, "identities": nil},
+		},
+		"network only": {
+			"network": map[string]any{"allow_endpoints": []any{"registry.internal.example"}},
+		},
+		"plain copy only": {
+			"copies": []any{map[string]any{
+				"source": "copies/0",
+				"target": "/state/injected/public.txt",
+			}},
+		},
+	}
+
+	for name, manifest := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, mountSpec := runGoExtractDirectMounts(t, manifest)
+			if string(mountSpec) != "[]\n" {
+				t.Fatalf("mount specification = %q, want empty JSON array", mountSpec)
+			}
+
+			mountSpecPath := filepath.Join(t.TempDir(), "mounts.json")
+			writeFile(t, mountSpecPath, mountSpec)
+			mounts, err := runtimeutil.ListDirectMounts(mountSpecPath)
+			if err != nil || len(mounts) != 0 {
+				t.Fatalf("ListDirectMounts = %#v, %v", mounts, err)
+			}
+		})
+	}
+}
+
 func TestRunExtractDirectMountsRejectsUnsafeManifestPaths(t *testing.T) {
 	root := t.TempDir()
 	original := []byte(`{"copies":[]}` + "\n")
@@ -425,8 +465,8 @@ func TestRunExtractDirectMountsManifestByteLimit(t *testing.T) {
 	if err := RunExtractDirectMounts(manifestPath, mountSpecPath); err != nil {
 		t.Fatalf("RunExtractDirectMounts exact limit: %v", err)
 	}
-	if got := readFile(t, mountSpecPath); string(got) != "null\n" {
-		t.Fatalf("exact-limit mount specification = %q, want null", got)
+	if got := readFile(t, mountSpecPath); string(got) != "[]\n" {
+		t.Fatalf("exact-limit mount specification = %q, want empty JSON array", got)
 	}
 
 	overLimit := append(exact, ' ')


### PR DESCRIPTION
Manifests with no direct mounts serialized their mount specification as a bare `null`, which reads as an absent value rather than an empty mount set. Consumers had to treat "no mounts" and "no specification" as the same shape.

## Summary

- `collectDirectMounts` starts from `make([]DirectMount, 0)` instead of a nil slice, so an empty result marshals as `[]` rather than `null`.
- The optional-section guards drop their redundant key-presence half (`ok && raw != nil` becomes `raw != nil`): a missing key and an explicit JSON `null` both yield a nil value from a Go map, so the nil check alone already covers both.
- Two existing assertions that pinned the old `null` output move to `[]`.
- New table test covers the manifest shapes that produce no direct mounts: empty, explicitly null optional sections, explicitly null optional `ssh` fields, and a plain (non-mount) copy entry.

## Testing

- `go build ./...` — clean.
- `go test ./... -count=1` — 47 packages ok. One unrelated flake in `internal/host/launcher` under full-suite load (`TestRunHostColimaWithTimeoutReturnsExitCodeWhenFastEnough`, a 2.04s-vs-2s timing budget); passes 3/3 when run alone, untouched by this change.
- `go test ./internal/injection ./internal/runtimeutil -count=1` — ok.
- `gofmt -l internal/injection/` and `go vet ./internal/injection/...` — clean.
- Mutation checks against the new test, each reverted after: nil slice instead of `make` (caught), `ssh` field nil guard dropped (caught), copies `source` type-assert branch forced (caught), nil check swapped for key presence (caught). Every retained table case is the sole detector of at least one of these; cases with no unique detection were dropped rather than kept as filler.
