### PR TITLE
^D Describe the upstream refresh PR metadata accurately (full testkit suite and mutation control pass; timestamp-only candidates)

### DIFF
--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -1630,24 +1630,21 @@ func TestPublishUpstreamRefreshPRMetadataSupportsTimestampOnlyCandidate(t *testi
 		t.Fatalf("%s does not contain refresh metadata", scriptPath)
 	}
 	metadata := string(content[metadataStart:])
-	checks := []struct {
-		text    string
-		present bool
-	}{
-		{"apply the exact upstream refresh candidate from the reviewed workflow", true},
-		{"apply the exact reviewed upstream refresh candidate", true},
-		{"preserve the candidate patch, tree, and changed-file bindings", true},
-		{"provider pins", false},
-		{"toolchain inputs", false},
-		{"helper versions", false},
-		{"image digests", false},
-		{"install tools", false},
-		{"provider maintenance", false},
+	for _, want := range []string{
+		"apply the exact upstream refresh candidate from the reviewed workflow",
+		"apply the exact reviewed upstream refresh candidate",
+		"preserve the candidate patch, tree, and changed-file bindings",
+	} {
+		if !strings.Contains(metadata, want) {
+			t.Fatalf("%s refresh metadata does not contain %q", scriptPath, want)
+		}
 	}
-	for _, check := range checks {
-		actual := strings.Contains(metadata, check.text)
-		if actual != check.present {
-			t.Fatalf("%s refresh metadata presence for %q = %t, want %t", scriptPath, check.text, actual, check.present)
+	for _, unwanted := range []string{
+		"provider pins", "toolchain inputs", "helper versions",
+		"image digests", "install tools", "provider maintenance",
+	} {
+		if strings.Contains(metadata, unwanted) {
+			t.Fatalf("%s refresh metadata still claims %q, which a timestamp-only candidate does not change", scriptPath, unwanted)
 		}
 	}
 }

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -1611,9 +1611,44 @@ func TestPublishUpstreamRefreshPRRequiresCleanWorktree(t *testing.T) {
 	}
 
 	const commitTemplateStart = `cat >"${commit_file}" <<'EOF'
-^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)`
+^F Refresh pinned upstreams (pr-parity passed; upstream maintenance)`
 	if !strings.Contains(script, commitTemplateStart) {
 		t.Fatalf("%s must generate the reviewed Risk-Aware upstream-refresh commit subject", scriptPath)
+	}
+}
+
+func TestPublishUpstreamRefreshPRMetadataSupportsTimestampOnlyCandidate(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "publish-upstream-refresh-pr.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadataStart := strings.Index(string(content), `title="Refresh pinned upstreams"`)
+	if metadataStart < 0 {
+		t.Fatalf("%s does not contain refresh metadata", scriptPath)
+	}
+	metadata := string(content[metadataStart:])
+	checks := []struct {
+		text    string
+		present bool
+	}{
+		{"apply the exact upstream refresh candidate from the reviewed workflow", true},
+		{"apply the exact reviewed upstream refresh candidate", true},
+		{"preserve the candidate patch, tree, and changed-file bindings", true},
+		{"provider pins", false},
+		{"toolchain inputs", false},
+		{"helper versions", false},
+		{"image digests", false},
+		{"install tools", false},
+		{"provider maintenance", false},
+	}
+	for _, check := range checks {
+		actual := strings.Contains(metadata, check.text)
+		if actual != check.present {
+			t.Fatalf("%s refresh metadata presence for %q = %t, want %t", scriptPath, check.text, actual, check.present)
+		}
 	}
 }
 

--- a/scripts/publish-upstream-refresh-pr.sh
+++ b/scripts/publish-upstream-refresh-pr.sh
@@ -297,8 +297,8 @@ printf '%s\n' "${title}" >"${title_file}"
 cat >"${body_file}" <<EOF
 ## Summary
 
-- refresh provider pins and Linux base/toolchain inputs from reviewed upstream metadata
-- refresh release-build helper versions, image digests, and workflow-managed install tools
+- apply the exact upstream refresh candidate from the reviewed workflow
+- preserve the candidate patch, tree, and changed-file bindings
 
 ## Candidate
 
@@ -322,10 +322,10 @@ $(cat "${diffstat_path}")
 EOF
 
 cat >"${commit_file}" <<'EOF'
-^F Refresh pinned upstreams (pr-parity passed; runtime/provider maintenance)
+^F Refresh pinned upstreams (pr-parity passed; upstream maintenance)
 
-- refresh provider pins and Linux base/toolchain inputs
-- refresh release-build helper versions and image digests
+- apply the exact reviewed upstream refresh candidate
+- preserve the candidate patch, tree, and changed-file bindings
 EOF
 
 "${ROOT_DIR}/scripts/repo-publish-pr.sh" \


### PR DESCRIPTION
The upstream-refresh publisher hardcoded a claim about what every candidate contains. The generated PR body and commit template asserted the refresh touched provider pins, Linux base/toolchain inputs, release-build helper versions, image digests, and workflow-managed install tools. A candidate can carry timestamp-only changes, in which case the published PR and commit both described work that did not happen.

## Summary

- Replace the generated PR body and commit-template bullets with what the script actually guarantees: apply the exact reviewed candidate, and preserve its patch digest, tree OID, and changed-file bindings.
- Retag the commit subject scope from `runtime/provider maintenance` to `upstream maintenance`, so the subject does not narrow the change either.
- Pin the new wording in `internal/testkit` with a presence check on the three accurate phrases and an absence check on the six inaccurate claims, scoped to the metadata block so an unrelated mention elsewhere in the script cannot false-pass or false-fail it.

No behavior change: only the text the publisher writes into the PR body, title metadata block, and commit message.

## Testing

- `go test ./internal/testkit/ -count=1` — ok, 118.506s (full package).
- `go test ./internal/testkit/ -count=1 -run 'TestPublishUpstreamRefreshPR' -v` — PASS, both the existing clean-worktree test and the new metadata test.
- `go vet ./internal/testkit/` — clean; `gofmt -l internal/testkit/validation_entrypoints_test.go` — no output.
- `shfmt -ln=bash -i 2 -ci -d scripts/publish-upstream-refresh-pr.sh` — clean; `shellcheck -x scripts/publish-upstream-refresh-pr.sh` — clean.
- Mutation negative control: reverted the `preserve the candidate patch, tree, and changed-file bindings` body bullet to old provider-pin wording; `TestPublishUpstreamRefreshPRMetadataSupportsTimestampOnlyCandidate` failed with the missing phrase named, and passed again once restored.
