### PR TITLE
Validate the provider bump plan JSON in the pinned upstream refresh

### DIFF
--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -105,10 +105,12 @@ type updaterFixtureCurlCall struct {
 type updaterFixtureOptions struct {
 	Token             string
 	RelativeTokenFile bool
+	ProviderPlan      string
+	ProviderPlanCode  int
 }
 
 func defaultUpdaterFixtureOptions() updaterFixtureOptions {
-	return updaterFixtureOptions{}
+	return updaterFixtureOptions{ProviderPlan: `{"has_changes":false}`}
 }
 
 func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
@@ -138,7 +140,7 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 		"check-pinned-inputs":        0,
 		"upstream-get":               7,
 	})
-	if want := []string{"summary", "check"}; !reflect.DeepEqual(checkRun.ProviderLog, want) {
+	if want := []string{"summary", "json"}; !reflect.DeepEqual(checkRun.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", checkRun.ProviderLog, want)
 	}
 	assertUpdaterScratchHasOnlyLogs(t, checkScratch)
@@ -166,7 +168,7 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 		"check-pinned-inputs":        1,
 		"upstream-get":               7,
 	})
-	if want := []string{"summary", "check", "apply"}; !reflect.DeepEqual(applyRun.ProviderLog, want) {
+	if want := []string{"summary", "json", "apply"}; !reflect.DeepEqual(applyRun.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", applyRun.ProviderLog, want)
 	}
 	assertUpdaterScratchHasOnlyLogs(t, applyScratch)
@@ -208,6 +210,48 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 	afterCleanCheck := snapshotUpdaterFixtureTree(t, fixtureRoot)
 	if !reflect.DeepEqual(afterCleanCheck, beforeCleanCheck) {
 		t.Fatalf("clean update-upstream-pins.sh --check was not byte-stable\nbefore: %#v\nafter:  %#v", beforeCleanCheck, afterCleanCheck)
+	}
+}
+
+func TestUpdateUpstreamPinsUsesValidatedProviderPlanStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		plan       string
+		planCode   int
+		wantCode   int
+		wantOutput string
+	}{
+		{name: "unchanged", plan: `{"has_changes":false}`, wantCode: 0, wantOutput: "Pinned upstream refresh summary:\n"},
+		{name: "changed", plan: `{"has_changes":true}`, wantCode: 1, wantOutput: "Pinned upstream refresh summary:\n"},
+		{name: "operational status one", plan: `{"has_changes":false}`, planCode: 1, wantCode: 1, wantOutput: "fixture provider plan failure\nUnable to compute provider bump plan.\n"},
+		{name: "malformed", plan: `{`, wantCode: 1, wantOutput: "Unable to read provider changes from the provider bump plan.\n"},
+		{name: "empty stream", plan: ``, wantCode: 1, wantOutput: "Unable to read provider changes from the provider bump plan.\n"},
+		{name: "multiple documents", plan: "{\"has_changes\":false}\n{\"has_changes\":true}", wantCode: 1, wantOutput: "Unable to read provider changes from the provider bump plan.\n"},
+		{name: "missing status", plan: `{}`, wantCode: 1, wantOutput: "Unable to read provider changes from the provider bump plan.\n"},
+		{name: "nonboolean status", plan: `{"has_changes":"false"}`, wantCode: 1, wantOutput: "Unable to read provider changes from the provider bump plan.\n"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			pins := readUpdaterFixturePins(t)
+			plan := updaterTargetDebianPlan()
+			fixtureRoot := writeUpdaterFixture(t, updaterManifestFromPlan(plan), 0o640)
+			toolsRoot := t.TempDir()
+			options := defaultUpdaterFixtureOptions()
+			options.ProviderPlan = testCase.plan
+			options.ProviderPlanCode = testCase.planCode
+			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), buildUpdaterFixtureCITools(t, toolsRoot), writeUpdaterFixtureGoWrapper(t, toolsRoot), pins, plan, "--check", options)
+			if run.Code != testCase.wantCode {
+				t.Fatalf("update-upstream-pins exit code = %d, want %d\n%s", run.Code, testCase.wantCode, run.Output)
+			}
+			if !strings.Contains(run.Output, testCase.wantOutput) {
+				t.Fatalf("update-upstream-pins output = %q, want suffix %q", run.Output, testCase.wantOutput)
+			}
+			if want := []string{"summary", "json"}; !reflect.DeepEqual(run.ProviderLog, want) {
+				t.Fatalf("provider updater command log = %q, want %q", run.ProviderLog, want)
+			}
+		})
 	}
 }
 
@@ -289,7 +333,7 @@ func TestUpdateUpstreamPinsApplyFailureLeavesFixtureUnchanged(t *testing.T) {
 		"check-pinned-inputs":        0,
 		"upstream-get":               7,
 	})
-	if want := []string{"summary", "check"}; !reflect.DeepEqual(run.ProviderLog, want) {
+	if want := []string{"summary", "json"}; !reflect.DeepEqual(run.ProviderLog, want) {
 		t.Fatalf("provider updater command log = %q, want %q", run.ProviderLog, want)
 	}
 	assertUpdaterScratchHasOnlyLogs(t, scratchRoot)
@@ -511,8 +555,13 @@ case "${1:-}" in
     printf '%s\n' summary >>"${WORKCELL_FIXTURE_PROVIDER_LOG}"
     printf '%s\n' 'Provider pin refresh summary: fixture (up to date)'
     ;;
-  --check)
-    printf '%s\n' check >>"${WORKCELL_FIXTURE_PROVIDER_LOG}"
+  --json)
+    printf '%s\n' json >>"${WORKCELL_FIXTURE_PROVIDER_LOG}"
+    if [[ "${WORKCELL_FIXTURE_PROVIDER_PLAN_CODE}" -ne 0 ]]; then
+      printf '%s\n' 'fixture provider plan failure' >&2
+      exit "${WORKCELL_FIXTURE_PROVIDER_PLAN_CODE}"
+    fi
+    printf '%s\n' "${WORKCELL_FIXTURE_PROVIDER_PLAN}"
     ;;
   --apply)
     printf '%s\n' apply >>"${WORKCELL_FIXTURE_PROVIDER_LOG}"
@@ -647,6 +696,8 @@ func runUpdaterFixtureWithOptions(t *testing.T, fixtureRoot, scratchRoot, citool
 		"WORKCELL_FIXTURE_HADOLINT_CHECKSUMS=" + pins.HadolintChecksums,
 		"WORKCELL_FIXTURE_HADOLINT_VERSION=" + pins.HadolintVersion,
 		"WORKCELL_FIXTURE_PROVIDER_LOG=" + providerLogPath,
+		"WORKCELL_FIXTURE_PROVIDER_PLAN=" + options.ProviderPlan,
+		fmt.Sprintf("WORKCELL_FIXTURE_PROVIDER_PLAN_CODE=%d", options.ProviderPlanCode),
 		"WORKCELL_FIXTURE_ROOT=" + fixtureRoot,
 		"WORKCELL_FIXTURE_QEMU_DIGEST=" + qemuDigest,
 		"WORKCELL_FIXTURE_QEMU_TAG=" + qemuTag,

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -216,6 +216,13 @@ func TestUpdateUpstreamPinsHermeticApplyAndCheck(t *testing.T) {
 func TestUpdateUpstreamPinsUsesValidatedProviderPlanStatus(t *testing.T) {
 	t.Parallel()
 
+	pins := readUpdaterFixturePins(t)
+	plan := updaterTargetDebianPlan()
+	toolsRoot := t.TempDir()
+	citoolsPath := buildUpdaterFixtureCITools(t, toolsRoot)
+	goWrapperPath := writeUpdaterFixtureGoWrapper(t, toolsRoot)
+	fixtureRoot := writeUpdaterFixture(t, updaterManifestFromPlan(plan), 0o640)
+
 	testCases := []struct {
 		name       string
 		plan       string
@@ -234,14 +241,10 @@ func TestUpdateUpstreamPinsUsesValidatedProviderPlanStatus(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			pins := readUpdaterFixturePins(t)
-			plan := updaterTargetDebianPlan()
-			fixtureRoot := writeUpdaterFixture(t, updaterManifestFromPlan(plan), 0o640)
-			toolsRoot := t.TempDir()
 			options := defaultUpdaterFixtureOptions()
 			options.ProviderPlan = testCase.plan
 			options.ProviderPlanCode = testCase.planCode
-			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), buildUpdaterFixtureCITools(t, toolsRoot), writeUpdaterFixtureGoWrapper(t, toolsRoot), pins, plan, "--check", options)
+			run := runUpdaterFixtureWithOptions(t, fixtureRoot, t.TempDir(), citoolsPath, goWrapperPath, pins, plan, "--check", options)
 			if run.Code != testCase.wantCode {
 				t.Fatalf("update-upstream-pins exit code = %d, want %d\n%s", run.Code, testCase.wantCode, run.Output)
 			}

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -581,15 +581,21 @@ target_qemu_tag="$(latest_qemu_tag)"
 target_qemu_image="tonistiigi/binfmt:${target_qemu_tag}@$(docker_image_digest "tonistiigi/binfmt:${target_qemu_tag}")"
 
 provider_summary="$("${ROOT_DIR}/scripts/update-provider-pins.sh")"
-provider_check_status=0
-"${ROOT_DIR}/scripts/update-provider-pins.sh" --check >/dev/null 2>&1 || provider_check_status=$?
-if [[ "${provider_check_status}" -ne 0 && "${provider_check_status}" -ne 1 ]]; then
-  echo "Unable to compute provider bump status." >&2
-  exit "${provider_check_status}"
+provider_plan_status=0
+provider_plan_json="$("${ROOT_DIR}/scripts/update-provider-pins.sh" --json)" || provider_plan_status=$?
+if [[ "${provider_plan_status}" -ne 0 ]]; then
+  echo "Unable to compute provider bump plan." >&2
+  exit "${provider_plan_status}"
 fi
-provider_has_changes=0
-if [[ "${provider_check_status}" -eq 1 ]]; then
-  provider_has_changes=1
+if ! provider_has_changes="$(jq -ser '
+  if length == 1 and (.[0] | type) == "object" and (.[0].has_changes | type) == "boolean" then
+    if .[0].has_changes then 1 else 0 end
+  else
+    error("provider bump plan must set has_changes to a boolean")
+  end
+' <<<"${provider_plan_json}")"; then
+  echo "Unable to read provider changes from the provider bump plan." >&2
+  exit 1
 fi
 
 debian_has_changes=0


### PR DESCRIPTION
The pinned upstream refresh read provider bump state from an exit code that cannot carry the distinction it was being asked to carry.

## Summary

- `scripts/update-upstream-pins.sh` derived `provider_has_changes` from `update-provider-pins.sh --check`, where exit 1 means "an eligible provider update is available". Any operational failure that also exits 1 was therefore recorded as "the provider has changes", and the call ran under `>/dev/null 2>&1`, so the diagnostic that would have explained it was discarded.
- The refresh now calls `--json` and reads `has_changes` out of the resolved plan document. Exit status is back to meaning only success or failure: any nonzero status aborts the refresh, propagates the child's status, and leaves the child's stderr on the terminal.
- The plan is validated before it is trusted: exactly one JSON document, an object, and a boolean `has_changes`. A malformed, empty, multi-document, key-missing, or wrongly-typed plan exits 1 with `Unable to read provider changes from the provider bump plan.` instead of silently defaulting to a bump decision.
- The fixture provider script in the updater testkit gains a `--json` mode with an injectable plan body and exit code, so the new failure modes are exercised hermetically. The three existing provider command-log assertions move from `check` to `json`.
- `scripts/update-provider-pins.sh` is unchanged; `--json` was already implemented there. Its `--check` mode now has no in-repo caller but remains a documented manual mode, so it is left in place.

## Testing

- `go test ./internal/testkit/ -run 'TestUpdateUpstreamPinsUsesValidatedProviderPlanStatus' -count=1` — ok, 7.6s (all 8 table cases pass)
- `go test ./internal/testkit/ -run 'TestUpdateUpstreamPins' -count=1` — ok, 7.5s
- `go test ./internal/testkit/ ./internal/workcellhardening/ -count=1` — ok 89.4s / ok 2.5s
- `gofmt -l ./internal/testkit/` — no output
- `go vet ./internal/testkit/` — clean
- `shellcheck -x scripts/update-upstream-pins.sh` — clean
- `./scripts/check-public-repo-hygiene.sh` — Public repo hygiene check passed

The new table test builds `workcell-citools` and the fixture tree once for the whole table rather than once per case, which took the test from 14.4s to 7.6s.
