### PR TITLE
Split release image build from registry handoff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ env:
   WORKCELL_BUILDKIT_IMAGE: moby/buildkit:buildx-stable-1@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
   WORKCELL_BUILDX_VERSION: v0.37.0
   WORKCELL_COSIGN_VERSION: v3.1.3
+  WORKCELL_ORAS_VERSION: 1.3.3
+  WORKCELL_ORAS_LINUX_AMD64_SHA256: 9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59
   WORKCELL_QEMU_IMAGE: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
   WORKCELL_SYFT_VERSION: v1.51.1
 
@@ -292,6 +294,9 @@ jobs:
       actions: read # Read workflow metadata needed by artifact and code-scanning actions.
       contents: read
       security-events: write # Upload SARIF results produced during release preflight scans.
+    outputs:
+      binding_artifact_id: ${{ steps.upload_bindings.outputs.artifact-id }}
+      install_artifact_id: ${{ steps.upload_install.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -635,7 +640,8 @@ jobs:
               }
             }' > dist/workcell-runtime-preflight.json
 
-      - name: Upload preflight binding manifests
+      - id: upload_bindings
+        name: Upload preflight binding manifests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workcell-release-preflight
@@ -646,7 +652,8 @@ jobs:
             dist/workcell-runtime-preflight.json
           retention-days: 90
 
-      - name: Upload preflight release install artifacts
+      - id: upload_install
+        name: Upload preflight release install artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workcell-release-install-candidate
@@ -756,31 +763,24 @@ jobs:
           brew cleanup workcell >/dev/null 2>&1 || true
           brew untap "${tap_name}" >/dev/null 2>&1 || true
 
-  build-arm64-image:
-    name: Build native arm64 release image
-    # Build and push the linux/arm64 runtime image by digest on a native arm64
-    # runner (no QEMU).  The amd64 image is still built inside the publish
-    # `release` job (native on ubuntu-latest); publish consumes this job's
-    # pushed-by-digest output to assemble the multi-arch manifest.  Gated on the
-    # `release` environment so no image is pushed to GHCR before the same human
-    # approval that gates publication, matching the existing release gate.
-    runs-on: ubuntu-24.04-arm
+  build-amd64-image:
+    name: Build native amd64 release image artifact
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs:
       - tag-policy
       - codeql-preflight
       - preflight
+      - preflight-amd64-repro
       - preflight-arm64-copilot-runtime
       - preflight-container-smoke
       - install-verification
-    environment:
-      name: release
-      url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
       contents: read
-      packages: write # Push the arm64 image (by digest) to GitHub Container Registry.
     outputs:
-      digest: ${{ steps.build_arm64.outputs.digest }}
+      digest: ${{ steps.build_amd64.outputs.digest }}
+      artifact_id: ${{ steps.upload_amd64.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload_amd64.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -797,11 +797,78 @@ jobs:
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      - id: build_amd64
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
+          build-args: |
+            BUILDKIT_MULTI_PLATFORM=1
+            SOURCE_DATE_EPOCH=${{ steps.source_date.outputs.epoch }}
+          context: .
+          file: runtime/container/Dockerfile
+          outputs: type=oci,dest=${{ runner.temp }}/workcell-amd64.oci.tar,oci-mediatypes=true,rewrite-timestamp=true
+          platforms: linux/amd64
+          provenance: mode=max
+          sbom: true
+          tags: ${{ env.IMAGE_NAME }}
+
+      - name: Bind amd64 image artifact
+        env:
+          IMAGE_DIGEST: ${{ steps.build_amd64.outputs.digest }}
+          PREFLIGHT_DIGEST: ${{ needs.preflight-amd64-repro.outputs.image_manifest_digest }}
+          PREFLIGHT_CONFIG_DIGEST: ${{ needs.preflight-amd64-repro.outputs.config_digest }}
+        run: |
+          go run ./cmd/workcell-citools create-release-image-handoff \
+            "${RUNNER_TEMP}/workcell-amd64.oci.tar" \
+            "${RUNNER_TEMP}/workcell-amd64-handoff.json" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            linux/amd64 "${IMAGE_DIGEST}" "${PREFLIGHT_DIGEST}" "${PREFLIGHT_CONFIG_DIGEST}"
+
+      - id: upload_amd64
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: workcell-release-image-amd64
+          path: |
+            ${{ runner.temp }}/workcell-amd64.oci.tar
+            ${{ runner.temp }}/workcell-amd64-handoff.json
+          retention-days: 7
+
+  build-arm64-image:
+    name: Build native arm64 release image artifact
+    # Build the linux/arm64 runtime image on a native runner without registry,
+    # signing, attestation, or release-publication authority.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    needs:
+      - tag-policy
+      - codeql-preflight
+      - preflight
+      - preflight-arm64-repro
+      - preflight-arm64-copilot-runtime
+      - preflight-container-smoke
+      - install-verification
+    permissions:
+      contents: read
+    outputs:
+      digest: ${{ steps.build_arm64.outputs.digest }}
+      artifact_id: ${{ steps.upload_arm64.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload_arm64.outputs.artifact-digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: source_date
+        name: Compute source date epoch
+        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          cache-binary: false
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
       - id: build_arm64
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -816,34 +883,186 @@ jobs:
           # arm64 digest matches the preflight manifest exactly.
           context: .
           file: runtime/container/Dockerfile
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true,rewrite-timestamp=true
+          outputs: type=oci,dest=${{ runner.temp }}/workcell-arm64.oci.tar,oci-mediatypes=true,rewrite-timestamp=true
           platforms: linux/arm64
           provenance: mode=max
           sbom: true
           tags: ${{ env.IMAGE_NAME }}
 
+      - name: Bind arm64 image artifact
+        env:
+          IMAGE_DIGEST: ${{ steps.build_arm64.outputs.digest }}
+          PREFLIGHT_DIGEST: ${{ needs.preflight-arm64-repro.outputs.image_manifest_digest }}
+          PREFLIGHT_CONFIG_DIGEST: ${{ needs.preflight-arm64-repro.outputs.config_digest }}
+        run: |
+          go run ./cmd/workcell-citools create-release-image-handoff \
+            "${RUNNER_TEMP}/workcell-arm64.oci.tar" \
+            "${RUNNER_TEMP}/workcell-arm64-handoff.json" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            linux/arm64 "${IMAGE_DIGEST}" "${PREFLIGHT_DIGEST}" "${PREFLIGHT_CONFIG_DIGEST}"
+
+      - id: upload_arm64
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: workcell-release-image-arm64
+          path: |
+            ${{ runner.temp }}/workcell-arm64.oci.tar
+            ${{ runner.temp }}/workcell-arm64-handoff.json
+          retention-days: 7
+
+  bind-release-subjects:
+    name: Bind independent release subjects
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs:
+      - preflight
+      - install-verification
+      - build-amd64-image
+      - build-arm64-image
+    permissions:
+      contents: read
+    outputs:
+      artifact_id: ${{ steps.upload_subjects.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload_subjects.outputs.artifact-digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download preflight manifests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.preflight.outputs.binding_artifact_id }}
+          path: dist/preflight
+
+      - name: Download preflight install subjects
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.preflight.outputs.install_artifact_id }}
+          path: dist/preflight-install
+
+      - name: Download amd64 image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-amd64-image.outputs.artifact_id }}
+          path: dist/image-amd64
+
+      - name: Download arm64 image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-arm64-image.outputs.artifact_id }}
+          path: dist/image-arm64
+
+      - id: source_date
+        name: Compute source date epoch
+        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          cache-binary: false
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
+
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: ${{ env.WORKCELL_SYFT_VERSION }}
+
+      - name: Expose SBOM tool in trusted system path
+        run: sudo install -m 0755 "$(command -v syft)" /usr/local/bin/syft
+
+      - name: Install pinned ORAS
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bin"
+          archive="${RUNNER_TEMP}/oras.tar.gz"
+          curl -fsSL --retry 3 --max-time 60 -o "${archive}" \
+            "https://github.com/oras-project/oras/releases/download/v${WORKCELL_ORAS_VERSION}/oras_${WORKCELL_ORAS_VERSION}_linux_amd64.tar.gz"
+          echo "${WORKCELL_ORAS_LINUX_AMD64_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" oras
+          install -m 0755 "${RUNNER_TEMP}/oras" "${RUNNER_TEMP}/bin/oras"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Create independent release subjects
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
+          AMD64_IMAGE_DIGEST: ${{ needs.build-amd64-image.outputs.digest }}
+          ARM64_IMAGE_DIGEST: ${{ needs.build-arm64-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          bound="dist/preflight-subjects"
+          bundle="workcell-${GITHUB_REF_NAME}.tar.gz"
+          amd64_digest="$(jq -r '.platforms["linux/amd64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)"
+          amd64_config="$(jq -r '.platforms["linux/amd64"].config_digest' dist/preflight/workcell-runtime-preflight.json)"
+          arm64_digest="$(jq -r '.platforms["linux/arm64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)"
+          arm64_config="$(jq -r '.platforms["linux/arm64"].config_digest' dist/preflight/workcell-runtime-preflight.json)"
+          amd64_layout="${RUNNER_TEMP}/bind-layout-amd64"
+          arm64_layout="${RUNNER_TEMP}/bind-layout-arm64"
+          release_layout="${RUNNER_TEMP}/bind-release-image"
+          source_root="${RUNNER_TEMP}/bind-source"
+          mkdir -p "${amd64_layout}" "${arm64_layout}" "${source_root}"
+          go run ./cmd/workcell-citools create-release-image-handoff \
+            dist/image-amd64/workcell-amd64.oci.tar "${RUNNER_TEMP}/validated-amd64.json" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            linux/amd64 "${AMD64_IMAGE_DIGEST}" "${amd64_digest}" "${amd64_config}"
+          go run ./cmd/workcell-citools create-release-image-handoff \
+            dist/image-arm64/workcell-arm64.oci.tar "${RUNNER_TEMP}/validated-arm64.json" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            linux/arm64 "${ARM64_IMAGE_DIGEST}" "${arm64_digest}" "${arm64_config}"
+          tar -xf dist/image-amd64/workcell-amd64.oci.tar -C "${amd64_layout}"
+          tar -xf dist/image-arm64/workcell-arm64.oci.tar -C "${arm64_layout}"
+          oras cp --recursive --from-oci-layout "${amd64_layout}@${amd64_digest}" --to-oci-layout "${release_layout}:amd64"
+          oras cp --recursive --from-oci-layout "${arm64_layout}@${arm64_digest}" --to-oci-layout "${release_layout}:arm64"
+          oras manifest index create --oci-layout "${release_layout}:${GITHUB_REF_NAME}" amd64 arm64 >/dev/null
+          mkdir -p "${bound}"
+          cp "dist/preflight-install/${bundle}" "${bound}/${bundle}"
+          cp dist/preflight-install/workcell.rb "${bound}/workcell.rb"
+          cp dist/preflight/workcell-build-inputs-preflight.json "${bound}/workcell-build-inputs.json"
+          cp dist/preflight/workcell-control-plane-preflight.json "${bound}/workcell-control-plane.json"
+          printf '%s@%s\n' "${IMAGE_NAME}" "$(oras resolve --oci-layout "${release_layout}:${GITHUB_REF_NAME}")" > "${bound}/workcell-image.digest"
+          tar -xzf "${bound}/${bundle}" -C "${source_root}"
+          syft scan "dir:${source_root}/workcell-${GITHUB_REF_NAME}" -o "spdx-json=${bound}/workcell-source.spdx.json"
+          syft scan "oci-dir:${release_layout}" -o "spdx-json=${bound}/workcell-image.spdx.json"
+          ./scripts/generate-builder-environment-manifest.sh "${bound}/workcell-builder-environment.json"
+          ./scripts/generate-release-checksums.sh "${bound}/SHA256SUMS" \
+            "${bound}/${bundle}" "${bound}/workcell.rb" "${bound}/workcell-image.digest" \
+            "${bound}/workcell-build-inputs.json" "${bound}/workcell-control-plane.json" \
+            "${bound}/workcell-builder-environment.json" "${bound}/workcell-source.spdx.json" \
+            "${bound}/workcell-image.spdx.json"
+
+      - id: upload_subjects
+        name: Upload independently bound release subjects
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: workcell-release-preflight-subjects
+          path: dist/preflight-subjects
+          retention-days: 90
+
   release:
-    name: Publish release artifacts
+    name: Assemble release artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs:
       - tag-policy
       - codeql-preflight
       - preflight
+      - preflight-amd64-repro
+      - preflight-arm64-repro
       - preflight-arm64-copilot-runtime
       - preflight-container-smoke
       - install-verification
+      - build-amd64-image
       - build-arm64-image
-    environment:
-      name: release
-      url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+      - bind-release-subjects
     permissions:
-      actions: read # Read preflight artifacts from the Actions API.
-      artifact-metadata: write # Publish artifact metadata alongside release assets.
-      attestations: write # Generate GitHub attestations for released artifacts.
       contents: read
-      id-token: write # Mint OIDC tokens for signing and attestation workflows.
-      packages: write # Push the container image to GitHub Container Registry.
+    outputs:
+      artifact_id: ${{ steps.upload_unsigned.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload_unsigned.outputs.artifact-digest }}
+      image_digest: ${{ steps.publish_manifest.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -855,6 +1074,24 @@ jobs:
         with:
           name: workcell-release-preflight
           path: dist/preflight
+
+      - name: Download independently bound release subjects
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.bind-release-subjects.outputs.artifact_id }}
+          path: dist/trusted-subjects
+
+      - name: Download bound amd64 image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-amd64-image.outputs.artifact_id }}
+          path: dist/image-amd64
+
+      - name: Download bound arm64 image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-arm64-image.outputs.artifact_id }}
+          path: dist/image-arm64
 
       - id: source_date
         name: Compute source date epoch
@@ -880,29 +1117,6 @@ jobs:
             echo "::error::Either publish the repository, set vars.WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=true for the private flow, or explicitly opt out with vars.WORKCELL_RELEASE_NO_ATTEST=true (each release will then ship without attestations)." >&2
             exit 1
           fi
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
-
-      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          syft-version: ${{ env.WORKCELL_SYFT_VERSION }}
-
-      - name: Expose signing and SBOM tools in trusted system path
-        run: |
-          sudo install -m 0755 "$(command -v cosign)" /usr/local/bin/cosign
-          sudo install -m 0755 "$(command -v syft)" /usr/local/bin/syft
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          # Use repository_owner instead of github.actor: any maintainer
-          # can tag a release; the ghcr push always targets the
-          # ghcr.io/<owner> namespace, so the login user should be
-          # owner-scoped rather than actor-scoped.
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
 
       - name: Build validation tool image
         run: |
@@ -962,7 +1176,6 @@ jobs:
           ln -sfn "source-tree/workcell-${GITHUB_REF_NAME}" dist/release-source
           echo "RELEASE_SOURCE_ROOT=dist/release-source" >> "${GITHUB_ENV}"
           ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs.json
-          ./scripts/generate-builder-environment-manifest.sh dist/workcell-builder-environment.json
 
       - name: Re-verify pinned upstreams from archived source tree
         env:
@@ -1026,31 +1239,62 @@ jobs:
             dist/workcell-control-plane.json \
             dist/preflight/workcell-control-plane-preflight.json
 
-      - id: build_amd64
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        env:
-          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
-        with:
-          build-args: |
-            BUILDKIT_MULTI_PLATFORM=1
-            SOURCE_DATE_EPOCH=${{ steps.source_date.outputs.epoch }}
-          context: dist/release-source
-          file: dist/release-source/runtime/container/Dockerfile
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true,rewrite-timestamp=true
-          platforms: linux/amd64
-          provenance: mode=max
-          sbom: true
-          tags: ${{ env.IMAGE_NAME }}
+      - name: Install pinned ORAS for offline OCI assembly
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bin"
+          archive="${RUNNER_TEMP}/oras.tar.gz"
+          curl -fsSL --retry 3 --max-time 60 \
+            -o "${archive}" \
+            "https://github.com/oras-project/oras/releases/download/v${WORKCELL_ORAS_VERSION}/oras_${WORKCELL_ORAS_VERSION}_linux_amd64.tar.gz"
+          echo "${WORKCELL_ORAS_LINUX_AMD64_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" oras
+          install -m 0755 "${RUNNER_TEMP}/oras" "${RUNNER_TEMP}/bin/oras"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
-      - name: Verify published platform digests match preflight
+      - name: Verify bound platform digests match preflight
         env:
-          AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
-          ARM64_DIGEST: ${{ needs.build-arm64-image.outputs.digest }}
+          AMD64_DIGEST: ${{ needs.preflight-amd64-repro.outputs.image_manifest_digest }}
+          ARM64_DIGEST: ${{ needs.preflight-arm64-repro.outputs.image_manifest_digest }}
+          AMD64_ARTIFACT_DIGEST: ${{ needs.build-amd64-image.outputs.artifact_digest }}
+          ARM64_ARTIFACT_DIGEST: ${{ needs.build-arm64-image.outputs.artifact_digest }}
         run: |
           set -euo pipefail
 
+          [[ "${AMD64_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+          [[ "${ARM64_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+
+          for arch in amd64 arm64; do
+            artifact="dist/image-${arch}/workcell-${arch}.oci.tar"
+            handoff="dist/image-${arch}/workcell-${arch}-handoff.json"
+            test -f "${artifact}"
+            test -f "${handoff}"
+            test "$(find "dist/image-${arch}" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" = 2
+            test "$(jq -c 'keys | sort' "${handoff}")" = '["archive_sha256","commit","config_digest","image_digest","manifest_digest","platform","repository","run_id","tag"]'
+            jq -e \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg run_id "${GITHUB_RUN_ID}" \
+              --arg tag "${GITHUB_REF_NAME}" \
+              --arg commit "${GITHUB_SHA}" \
+              --arg platform "linux/${arch}" \
+              '.repository == $repository and .run_id == $run_id and .tag == $tag and .commit == $commit and .platform == $platform' \
+              "${handoff}" >/dev/null
+            test "$(sha256sum "${artifact}" | awk '{print $1}')" = "$(jq -r '.archive_sha256' "${handoff}")"
+            mkdir -p "dist/image-${arch}/layout"
+            tar -xf "${artifact}" -C "dist/image-${arch}/layout"
+          done
+
           inspect_raw() {
-            docker buildx imagetools inspect --raw "$1"
+            local digest="${1##*@}"
+            local blob=""
+            for root in dist/image-amd64/layout dist/image-arm64/layout; do
+              blob="${root}/blobs/sha256/${digest#sha256:}"
+              if [[ -f "${blob}" ]]; then
+                cat "${blob}"
+                return
+              fi
+            done
+            echo "Missing OCI blob ${digest}" >&2
+            return 1
           }
 
           resolve_published_platform() {
@@ -1092,7 +1336,7 @@ jobs:
                   echo "Malformed published image manifest digest for ${platform} in ${ref}: ${image_manifest_digest}" >&2
                   exit 1
                 fi
-                image_manifest="$(inspect_raw "${IMAGE_NAME}@${image_manifest_digest}")"
+                image_manifest="$(inspect_raw "${image_manifest_digest}")"
                 ;;
               *)
                 echo "Unsupported published descriptor media type for ${ref}: ${media_type}" >&2
@@ -1114,6 +1358,11 @@ jobs:
           expected_manifest_arm64="$(jq -r '.platforms["linux/arm64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)"
           expected_config_arm64="$(jq -r '.platforms["linux/arm64"].config_digest' dist/preflight/workcell-runtime-preflight.json)"
 
+          test "$(jq -r '.manifest_digest' dist/image-amd64/workcell-amd64-handoff.json)" = "${expected_manifest_amd64}"
+          test "$(jq -r '.config_digest' dist/image-amd64/workcell-amd64-handoff.json)" = "${expected_config_amd64}"
+          test "$(jq -r '.manifest_digest' dist/image-arm64/workcell-arm64-handoff.json)" = "${expected_manifest_arm64}"
+          test "$(jq -r '.config_digest' dist/image-arm64/workcell-arm64-handoff.json)" = "${expected_config_arm64}"
+
           read -r actual_manifest_amd64 actual_config_amd64 < <(resolve_published_platform "${AMD64_DIGEST}" "linux/amd64")
           read -r actual_manifest_arm64 actual_config_arm64 < <(resolve_published_platform "${ARM64_DIGEST}" "linux/arm64")
 
@@ -1121,79 +1370,220 @@ jobs:
              [[ "${actual_config_amd64}" != "${expected_config_amd64}" ]] || \
              [[ "${actual_manifest_arm64}" != "${expected_manifest_arm64}" ]] || \
              [[ "${actual_config_arm64}" != "${expected_config_arm64}" ]]; then
-            echo "Published platform image/config digests differ from preflight" >&2
+            echo "Bound platform image/config digests differ from preflight" >&2
             echo "amd64: ${actual_manifest_amd64} ${actual_config_amd64} expected ${expected_manifest_amd64} ${expected_config_amd64}" >&2
             echo "arm64: ${actual_manifest_arm64} ${actual_config_arm64} expected ${expected_manifest_arm64} ${expected_config_arm64}" >&2
             exit 1
           fi
 
       - id: publish_manifest
-        name: Publish deterministic multi-arch manifest
+        name: Assemble deterministic multi-arch OCI layout
         env:
-          AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
-          ARM64_DIGEST: ${{ needs.build-arm64-image.outputs.digest }}
+          AMD64_DIGEST: ${{ needs.preflight-amd64-repro.outputs.image_manifest_digest }}
+          ARM64_DIGEST: ${{ needs.preflight-arm64-repro.outputs.image_manifest_digest }}
         run: |
-          refs=(
-            "${IMAGE_NAME}@${AMD64_DIGEST}"
-            "${IMAGE_NAME}@${ARM64_DIGEST}"
-          )
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${GITHUB_REF_NAME}" \
-            -t "${IMAGE_NAME}:sha-${GITHUB_SHA}" \
-            "${refs[@]}"
-          manifest_json="$(docker buildx imagetools inspect "${IMAGE_NAME}:${GITHUB_REF_NAME}" --format '{{json .Manifest}}')"
-          image_manifests_json="$(jq -c '[.manifests[]? | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")]' <<<"${manifest_json}")"
+          oras cp --recursive --from-oci-layout \
+            "dist/image-amd64/layout@${AMD64_DIGEST}" \
+            --to-oci-layout dist/release-image:amd64
+          oras cp --recursive --from-oci-layout \
+            "dist/image-arm64/layout@${ARM64_DIGEST}" \
+            --to-oci-layout dist/release-image:arm64
+          oras manifest index create --oci-layout \
+            "dist/release-image:${GITHUB_REF_NAME}" \
+            amd64 arm64 >/dev/null
+          manifest_json="$(oras manifest fetch --oci-layout "dist/release-image:${GITHUB_REF_NAME}")"
+          image_manifests_json="$(jq -c '.manifests' <<<"${manifest_json}")"
           platform_arches="$(jq -r '[.[].platform.architecture] | @json' <<<"${image_manifests_json}")"
           if [[ "${platform_arches}" != '["amd64","arm64"]' ]]; then
             echo "Deterministic multi-arch image manifest must contain exactly amd64 then arm64, found ${platform_arches}" >&2
             exit 1
           fi
 
-          digest="$(jq -r '.digest // empty' <<<"${manifest_json}")"
-          if [[ "${digest}" != sha256:* ]]; then
-            echo "Unable to determine published manifest digest from imagetools inspect: ${digest}" >&2
-            exit 1
-          fi
+          digest="$(oras resolve --oci-layout "dist/release-image:${GITHUB_REF_NAME}")"
+          test "${digest}" = "sha256:$(printf '%s' "${manifest_json}" | sha256sum | awk '{print $1}')"
 
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           printf '%s@%s\n' "${IMAGE_NAME}" "${digest}" > dist/workcell-image.digest
+          tar -cf dist/workcell-release-image.oci.tar -C dist/release-image .
 
-      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          artifact-name: workcell-source.spdx.json
-          format: spdx-json
-          output-file: dist/workcell-source.spdx.json
-          path: dist/release-source
-          syft-version: ${{ env.WORKCELL_SYFT_VERSION }}
-          upload-artifact: false
-          upload-release-assets: false
-
-      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          artifact-name: workcell-image.spdx.json
-          format: spdx-json
-          image: ${{ env.IMAGE_NAME }}@${{ steps.publish_manifest.outputs.digest }}
-          output-file: dist/workcell-image.spdx.json
-          syft-version: ${{ env.WORKCELL_SYFT_VERSION }}
-          upload-artifact: false
-          upload-release-assets: false
-
-      - name: Generate release checksums
+      - name: Select independently bound release subjects
+        env:
+          ASSEMBLED_IMAGE_DIGEST: ${{ steps.publish_manifest.outputs.digest }}
         run: |
-          ./scripts/generate-release-checksums.sh dist/SHA256SUMS \
-            "dist/${BUNDLE_NAME}" \
-            dist/workcell.rb \
-            dist/workcell-image.digest \
-            dist/workcell-build-inputs.json \
-            dist/workcell-control-plane.json \
-            dist/workcell-builder-environment.json \
-            dist/workcell-source.spdx.json \
+          set -euo pipefail
+          test "$(find dist/trusted-subjects -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" = 9
+          test -z "$(find dist/trusted-subjects -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+          test "$(cut -d@ -f2 dist/trusted-subjects/workcell-image.digest)" = "${ASSEMBLED_IMAGE_DIGEST}"
+          cp dist/trusted-subjects/* dist/
+
+      - name: Bind unsigned release artifact
+        env:
+          IMAGE_DIGEST: ${{ steps.publish_manifest.outputs.digest }}
+        run: |
+          jq -n \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            --arg tag "${GITHUB_REF_NAME}" \
+            --arg commit "${GITHUB_SHA}" \
+            --arg image_digest "${IMAGE_DIGEST}" \
+            --arg amd64_manifest "$(jq -r '.platforms["linux/amd64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)" \
+            --arg amd64_config "$(jq -r '.platforms["linux/amd64"].config_digest' dist/preflight/workcell-runtime-preflight.json)" \
+            --arg arm64_manifest "$(jq -r '.platforms["linux/arm64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)" \
+            --arg arm64_config "$(jq -r '.platforms["linux/arm64"].config_digest' dist/preflight/workcell-runtime-preflight.json)" \
+            --arg image_archive_sha256 "$(sha256sum dist/workcell-release-image.oci.tar | awk '{print $1}')" \
+            '{repository:$repository,run_id:$run_id,tag:$tag,commit:$commit,image_digest:$image_digest,image_archive_sha256:$image_archive_sha256,platforms:{"linux/amd64":{manifest_digest:$amd64_manifest,config_digest:$amd64_config},"linux/arm64":{manifest_digest:$arm64_manifest,config_digest:$arm64_config}}}' \
+            > dist/workcell-release-handoff.json
+
+      - id: upload_unsigned
+        name: Upload bound unsigned release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: workcell-release-unsigned
+          path: |
+            dist/${{ env.BUNDLE_NAME }}
+            dist/workcell.rb
+            dist/workcell-image.digest
+            dist/workcell-build-inputs.json
+            dist/workcell-control-plane.json
+            dist/workcell-builder-environment.json
+            dist/SHA256SUMS
+            dist/workcell-source.spdx.json
             dist/workcell-image.spdx.json
+            dist/workcell-release-image.oci.tar
+            dist/workcell-release-handoff.json
+          retention-days: 7
+
+  sign-release:
+    name: Publish and sign bound release artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - tag-policy
+      - preflight
+      - bind-release-subjects
+      - preflight-amd64-repro
+      - preflight-arm64-repro
+      - release
+    environment:
+      name: release
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+    permissions:
+      artifact-metadata: write # Publish GitHub artifact attestations.
+      attestations: write # Create GitHub attestations for reviewed subjects.
+      contents: read
+      id-token: write # Request the keyless signing identity.
+      packages: write # Upload the validated OCI layout and its signatures.
+    env:
+      BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz
+    outputs:
+      artifact_id: ${{ steps.upload_signed.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload_signed.outputs.artifact-digest }}
+    steps:
+      - name: Download bound unsigned release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.release.outputs.artifact_id }}
+          path: dist
+
+      - name: Download independently bound release subjects
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.bind-release-subjects.outputs.artifact_id }}
+          path: trusted-subjects
+
+      - name: Validate privileged handoff
+        env:
+          EXPECTED_ARTIFACT_DIGEST: ${{ needs.release.outputs.artifact_digest }}
+          EXPECTED_SUBJECT_ARTIFACT_DIGEST: ${{ needs.bind-release-subjects.outputs.artifact_digest }}
+          EXPECTED_IMAGE_DIGEST: ${{ needs.release.outputs.image_digest }}
+          EXPECTED_AMD64_MANIFEST: ${{ needs.preflight-amd64-repro.outputs.image_manifest_digest }}
+          EXPECTED_AMD64_CONFIG: ${{ needs.preflight-amd64-repro.outputs.config_digest }}
+          EXPECTED_ARM64_MANIFEST: ${{ needs.preflight-arm64-repro.outputs.image_manifest_digest }}
+          EXPECTED_ARM64_CONFIG: ${{ needs.preflight-arm64-repro.outputs.config_digest }}
+        run: |
+          [[ "${EXPECTED_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+          [[ "${EXPECTED_SUBJECT_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+          test "$(find dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" = 11
+          test -z "$(find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+          test "$(jq -c 'keys | sort' dist/workcell-release-handoff.json)" = '["commit","image_archive_sha256","image_digest","platforms","repository","run_id","tag"]'
+          jq -e \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            --arg tag "${GITHUB_REF_NAME}" \
+            --arg commit "${GITHUB_SHA}" \
+            --arg image_digest "${EXPECTED_IMAGE_DIGEST}" \
+            '.repository == $repository and .run_id == $run_id and .tag == $tag and .commit == $commit and .image_digest == $image_digest' \
+            dist/workcell-release-handoff.json >/dev/null
+          test "$(jq -r '.platforms["linux/amd64"].manifest_digest' dist/workcell-release-handoff.json)" = "${EXPECTED_AMD64_MANIFEST}"
+          test "$(jq -r '.platforms["linux/amd64"].config_digest' dist/workcell-release-handoff.json)" = "${EXPECTED_AMD64_CONFIG}"
+          test "$(jq -r '.platforms["linux/arm64"].manifest_digest' dist/workcell-release-handoff.json)" = "${EXPECTED_ARM64_MANIFEST}"
+          test "$(jq -r '.platforms["linux/arm64"].config_digest' dist/workcell-release-handoff.json)" = "${EXPECTED_ARM64_CONFIG}"
+          test "$(sha256sum dist/workcell-release-image.oci.tar | awk '{print $1}')" = \
+            "$(jq -r '.image_archive_sha256' dist/workcell-release-handoff.json)"
+          test "$(find trusted-subjects -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" = 9
+          test -z "$(find trusted-subjects -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+          for subject in "${BUNDLE_NAME}" workcell.rb workcell-image.digest workcell-build-inputs.json \
+            workcell-control-plane.json workcell-builder-environment.json SHA256SUMS \
+            workcell-source.spdx.json workcell-image.spdx.json; do
+            cmp -s "dist/${subject}" "trusted-subjects/${subject}"
+          done
+          sha256sum -c dist/SHA256SUMS
+          tar -tvf dist/workcell-release-image.oci.tar | awk '$1 !~ /^[-d]/ {exit 1}'
+          test -z "$(tar -tf dist/workcell-release-image.oci.tar | sed 's#^\./##' | LC_ALL=C sort | uniq -d)"
+          if tar -tf dist/workcell-release-image.oci.tar | grep -Ev '^(\./)?$|^(\./)?(oci-layout|index.json)$|^(\./)?blobs/?$|^(\./)?blobs/sha256/?$|^(\./)?blobs/sha256/[0-9a-f]{64}$'; then
+            echo "OCI handoff contains a non-canonical path" >&2
+            exit 1
+          fi
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: ${{ env.WORKCELL_COSIGN_VERSION }}
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Install fixed OCI publisher
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bin"
+          archive="${RUNNER_TEMP}/oras.tar.gz"
+          curl -fsSL --retry 3 --max-time 60 \
+            -o "${archive}" \
+            "https://github.com/oras-project/oras/releases/download/v${WORKCELL_ORAS_VERSION}/oras_${WORKCELL_ORAS_VERSION}_linux_amd64.tar.gz"
+          echo "${WORKCELL_ORAS_LINUX_AMD64_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" oras
+          install -m 0755 "${RUNNER_TEMP}/oras" "${RUNNER_TEMP}/bin/oras"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Publish bound OCI layout
+        env:
+          IMAGE_DIGEST: ${{ needs.release.outputs.image_digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release-image"
+          tar -xf dist/workcell-release-image.oci.tar -C "${RUNNER_TEMP}/release-image"
+          while IFS= read -r blob; do
+            test "$(sha256sum "${blob}" | awk '{print $1}')" = "$(basename "${blob}")"
+          done < <(find "${RUNNER_TEMP}/release-image/blobs/sha256" -type f -print)
+          test "$(oras resolve --oci-layout "${RUNNER_TEMP}/release-image:${GITHUB_REF_NAME}")" = "${IMAGE_DIGEST}"
+          manifest_json="$(oras manifest fetch --oci-layout "${RUNNER_TEMP}/release-image:${GITHUB_REF_NAME}")"
+          test "$(jq -c '[.manifests[] | {digest,platform}]' <<<"${manifest_json}")" = \
+            "$(jq -c '[{digest:.platforms["linux/amd64"].manifest_digest,platform:{architecture:"amd64",os:"linux"}},{digest:.platforms["linux/arm64"].manifest_digest,platform:{architecture:"arm64",os:"linux"}}]' dist/workcell-release-handoff.json)"
+          for arch in amd64 arm64; do
+            manifest_digest="$(jq -r --arg platform "linux/${arch}" '.platforms[$platform].manifest_digest' dist/workcell-release-handoff.json)"
+            config_digest="$(jq -r --arg platform "linux/${arch}" '.platforms[$platform].config_digest' dist/workcell-release-handoff.json)"
+            test "$(jq -r '.config.digest' "${RUNNER_TEMP}/release-image/blobs/sha256/${manifest_digest#sha256:}")" = "${config_digest}"
+          done
+          oras cp --recursive --from-oci-layout \
+            "${RUNNER_TEMP}/release-image:${GITHUB_REF_NAME}" \
+            "${IMAGE_NAME}:${GITHUB_REF_NAME},sha-${GITHUB_SHA}"
+          test "$(oras resolve "${IMAGE_NAME}:${GITHUB_REF_NAME}")" = "${IMAGE_DIGEST}"
 
       - name: Sign release image
         env:
           COSIGN_YES: "true"
-          IMAGE_DIGEST: ${{ steps.publish_manifest.outputs.digest }}
+          IMAGE_DIGEST: ${{ needs.release.outputs.image_digest }}
         run: |
           cosign sign "${IMAGE_NAME}@${IMAGE_DIGEST}"
 
@@ -1273,7 +1663,7 @@ jobs:
         if: env.RELEASE_NO_ATTEST != 'true' && env.ENABLE_GITHUB_ATTESTATIONS_SUPPORTED == 'true'
         with:
           subject-name: ${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.publish_manifest.outputs.digest }}
+          subject-digest: ${{ needs.release.outputs.image_digest }}
           push-to-registry: true
 
       - uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -1281,7 +1671,7 @@ jobs:
         with:
           sbom-path: dist/workcell-image.spdx.json
           subject-name: ${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.publish_manifest.outputs.digest }}
+          subject-digest: ${{ needs.release.outputs.image_digest }}
           push-to-registry: true
 
       - uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -1325,7 +1715,8 @@ jobs:
         with:
           subject-path: dist/SHA256SUMS
 
-      - name: Upload workflow artifacts
+      - id: upload_signed
+        name: Upload workflow artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workcell-release-artifacts
@@ -1356,7 +1747,7 @@ jobs:
     timeout-minutes: 30
     needs:
       - tag-policy
-      - release
+      - sign-release
     environment:
       name: hosted-controls-audit
     permissions:
@@ -1371,7 +1762,7 @@ jobs:
       - name: Download sealed release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: workcell-release-artifacts
+          artifact-ids: ${{ needs.sign-release.outputs.artifact_id }}
           path: dist
 
       - name: Verify release tag signature

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -915,6 +915,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs:
+      - tag-policy
       - preflight
       - install-verification
       - build-amd64-image
@@ -1260,8 +1261,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          [[ "${AMD64_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
-          [[ "${ARM64_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+          grep -Eq '^[0-9a-f]{64}$' <<<"${AMD64_ARTIFACT_DIGEST}"
+          grep -Eq '^[0-9a-f]{64}$' <<<"${ARM64_ARTIFACT_DIGEST}"
 
           for arch in amd64 arm64; do
             artifact="dist/image-${arch}/workcell-${arch}.oci.tar"
@@ -1501,8 +1502,8 @@ jobs:
           EXPECTED_ARM64_MANIFEST: ${{ needs.preflight-arm64-repro.outputs.image_manifest_digest }}
           EXPECTED_ARM64_CONFIG: ${{ needs.preflight-arm64-repro.outputs.config_digest }}
         run: |
-          [[ "${EXPECTED_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
-          [[ "${EXPECTED_SUBJECT_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+          grep -Eq '^[0-9a-f]{64}$' <<<"${EXPECTED_ARTIFACT_DIGEST}"
+          grep -Eq '^[0-9a-f]{64}$' <<<"${EXPECTED_SUBJECT_ARTIFACT_DIGEST}"
           test "$(find dist -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" = 11
           test -z "$(find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
           test "$(jq -c 'keys | sort' dist/workcell-release-handoff.json)" = '["commit","image_archive_sha256","image_digest","platforms","repository","run_id","tag"]'
@@ -1715,8 +1716,8 @@ jobs:
         with:
           subject-path: dist/SHA256SUMS
 
-      - id: upload_signed
-        name: Upload workflow artifacts
+      - name: Upload workflow artifacts
+        id: upload_signed
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workcell-release-artifacts

--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -103,6 +103,7 @@ func subcommands() []subcommand {
 		{"apply-debian-bootstrap", "PLAN_PATH REPO_ROOT", 2, 2, cmdApplyDebianBootstrap},
 		{"generate-build-input-manifest", "DOCKERFILE PACKAGE_JSON PACKAGE_LOCK OUTPUT BUILD_REF SOURCE_DATE_EPOCH REQUIRE_TRACKED", 7, 7, cmdGenerateBuildInputManifest},
 		{"generate-builder-environment-manifest", "OUTPUT BUILDKIT_IMAGE BUILDX_VERSION_TARGET COSIGN_VERSION_TARGET QEMU_IMAGE SYFT_VERSION_TARGET BUILDX_VERSION BUILDX_INSPECT DOCKER_VERSION_JSON QEMU_VERSION COSIGN_VERSION CURL_VERSION GIT_VERSION GZIP_VERSION SYFT_VERSION TAR_VERSION", 16, 16, cmdGenerateBuilderEnvironmentManifest},
+		{"create-release-image-handoff", "ARCHIVE OUTPUT REPOSITORY RUN_ID TAG COMMIT PLATFORM IMAGE_DIGEST MANIFEST_DIGEST CONFIG_DIGEST", 10, 10, cmdCreateReleaseImageHandoff},
 		{"check-pinned-inputs", "REPO_ROOT MAX_DEBIAN_SNAPSHOT_AGE_DAYS", 2, 2, cmdCheckPinnedInputs},
 		{"verify-reproducible-build", "OCI_EXPORT_A OCI_EXPORT_B REPRO_PLATFORMS REPRO_MANIFEST_PATH SOURCE_DATE_EPOCH", 5, 5, cmdVerifyReproducibleBuild},
 		{"generate-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS OUTPUT_PATH SOURCE_DATE_EPOCH", 4, 4, cmdGenerateReproducibleBuildManifest},
@@ -172,6 +173,10 @@ func subcommands() []subcommand {
 		{"workcell-precommit-upstream-pin-gate", "ROOT_DIR", 1, 1, hardeningCheck(workcellhardening.CheckPrecommitUpstreamPinGate)},
 		{"workcell-trusted-docker-client-rg", "ROOT_DIR", 1, 1, hardeningCheck(workcellhardening.CheckTrustedDockerClientRg)},
 	}
+}
+
+func cmdCreateReleaseImageHandoff(args []string) error {
+	return metadatautil.CreateReleaseImageHandoff(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9])
 }
 
 // scenario-manifest is intentionally dispatched in main() rather than

--- a/docs/ci-threat-model.md
+++ b/docs/ci-threat-model.md
@@ -76,12 +76,14 @@ Each action uses a full commit SHA.
 The action owner and repository must be in `policy/allowed-actions.toml`.
 
 The release workflow has the main publication authority.
-Its release job can write packages, artifact metadata, and attestations.
-It can also request an OIDC token.
+Its architecture build and assembly jobs have only `contents: read` permission.
+They cannot write packages, metadata, or attestations, and they cannot request an OIDC token.
+A release-approved job validates the artifact handoff before publication and signing.
+That job does not check out or execute repository code.
+A separate read-only job binds every non-image signing subject before approval.
 Its final publisher has `contents: write` for the repository.
 The current publisher script uses this scope to create a release and upload assets.
 
-The native arm64 release job can push an image by digest to GHCR.
 Release scan jobs can upload SARIF data.
 
 Other workflows also have write authority:
@@ -96,7 +98,7 @@ It can also reopen or edit that issue.
 It can also upload a review-only candidate artifact.
 The job has no content-write or release-publication scope.
 
-The release environment protects artifact construction and image publication.
+The release environment protects registry publication, signing, and attestation.
 The environment requires maintainer approval and does not permit administrator bypass.
 
 The final publisher uses the `hosted-controls-audit` environment.
@@ -252,8 +254,8 @@ It does not claim Build L2 for the two SBOM files or nine Sigstore bundles.
 It does not claim Build L3.
 
 GitHub-hosted jobs create authentic platform provenance.
-Build and attestation steps still share one job and its OIDC authority.
-A compromised build step can give a false digest to the attestation step.
+Build and assembly jobs do not share package-write or OIDC authority with the signing job.
+The signing job validates repository, run, tag, commit, platform, configuration, and artifact digests.
 
 The build is reproducible, pinned, and network-dependent.
 It is not hermetic.
@@ -269,7 +271,7 @@ Residual risk describes the risk after the current controls.
 | 3 | Fork code steals a secret. | GitHub makes fork tokens read-only. Fork code cannot use environment secrets. | Low. |
 | 4 | A runner steals authority or changes output. | GitHub-hosted ephemeral jobs, narrow tokens, and disabled checkout credentials reduce exposure. | Medium. Jobs do not restrict network egress. |
 | 5 | An attacker compromises a signing identity. | Cosign is keyless. The maintainer key stays outside CI. Releases are immutable. | Medium. Keyless signing removes stored Cosign keys, but it does not stop workflow-identity or maintainer-key misuse. |
-| 6 | A false artifact gets authentic provenance. | GitHub OIDC binds provenance to the release workflow. Consumers pin that identity. | Medium. Build and provenance authority share a job. |
+| 6 | A false artifact gets authentic provenance. | The privileged job validates immutable artifact handoffs before signing. Builders have no publication authority. | Medium. The workflow still trusts pinned actions and GitHub artifact transport. |
 | 7 | Fork code poisons a trusted cache. | PR runs write only to PR-specific cache scopes. They can read `validator-main`. | Low. Non-PR runs can write `validator-main`. |
 | 8 | A consumer installs an unverified artifact. | The documented release installer verifies Cosign data and the bundle digest before extraction. | Medium. Other installation paths remain available. |
 | 9 | A malicious change reaches a release. | Signed commits, signed tags, required checks, environment approval, and immutable releases protect publication. | Medium. One maintainer signs and approves releases. |

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -104,9 +104,14 @@ It creates source-dependent manifests and the amd64 image from the extracted tre
 It creates the formula from the verified archive digest.
 The native arm64 image job builds from the checked-out release tag.
 
-The workflow also creates the builder-environment manifest, image-digest file, software bills of materials, signatures, and checksums.
-The release job seals the assets in one workflow artifact.
-The final job publishes that sealed artifact.
+The assembly job creates manifests, software bills of materials, checksums, and one OCI layout.
+The architecture build jobs and assembly job have only `contents: read` permission.
+They transfer bound artifacts with GitHub Actions artifact runtime credentials.
+A separate read-only job creates the nine non-image signing subjects.
+The signer downloads those subjects by immutable artifact ID and requires exact byte matches.
+A release-approved signing job validates the handoff and publishes the OCI layout.
+The signing job uses fixed tools and does not check out repository code.
+The final job publishes the 18 signed GitHub release assets.
 
 Release preflight does these checks:
 
@@ -124,8 +129,8 @@ It uses native `ubuntu-24.04-arm` for arm64.
 The workflow compares both platform digests with preflight data.
 Then it creates one multi-platform manifest.
 
-The `release` environment gates image pushes and sealed-asset construction.
-No image reaches GHCR before that gate.
+The `release` environment gates registry publication, signatures, and attestations.
+No architecture build or assembly step can push packages or request an OIDC token.
 The `hosted-controls-audit` environment gates release preflight and final GitHub release publication.
 
 The release uses Cosign to create keyless Sigstore signatures.
@@ -135,6 +140,7 @@ GitHub attestations do not replace Sigstore signatures.
 The final publisher has `actions: read` and `contents: write` permissions.
 It checks hosted controls immediately before publication.
 It removes the administration token before it uses the default publication token.
+This authority split does not make a SLSA Build L3 claim.
 
 ## Upstream refresh
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -399,6 +399,11 @@ If the release workflow later waits on the release environment, I will record
 that self-review publicly with the workflow run URL and timestamp.
 ```
 
+The approval starts the registry and signing job.
+The architecture build jobs and assembly job have no write or OIDC authority.
+The signing job validates the bound handoff before it publishes the image.
+The final publisher uploads the 18 GitHub release assets separately.
+
 ## 6. Follow release PR checks and comments until green
 
 Stay on the release PR until all required checks succeed and all actionable

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -20,6 +20,10 @@ The local `pr-parity` gate and the `Security` workflow run this check.
 | `fuzz.yml` | `rust-fuzz-reproducers` | 14 |
 | `fuzz.yml` | `rust-fuzz-lockfile` | 14 |
 | `release.yml` | `workcell-release-preflight` | 90 |
+| `release.yml` | `workcell-release-preflight-subjects` | 90 |
+| `release.yml` | `workcell-release-image-amd64` | 7 |
+| `release.yml` | `workcell-release-image-arm64` | 7 |
+| `release.yml` | `workcell-release-unsigned` | 7 |
 | `release.yml` | `workcell-release-install-candidate` | 90 |
 | `release.yml` | `workcell-release-artifacts` | 7 |
 | `security.yml` | `zizmor-sarif` | 5 |
@@ -31,6 +35,9 @@ The local `pr-parity` gate and the `Security` workflow run this check.
 ### Release artifacts
 
 `workcell-release-preflight` contains four preflight manifests.
+`workcell-release-preflight-subjects` contains nine independently bound signing subjects.
+The architecture artifacts contain bound OCI layouts for unprivileged assembly.
+`workcell-release-unsigned` contains the bound input for the release-approved signing job.
 The manifests bind build inputs, the control plane, the source bundle, and runtime images.
 
 `workcell-release-install-candidate` contains the source bundle and Homebrew formula used by the macOS install jobs.

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -301,8 +301,8 @@ func (check *pinnedInputsCheck) validateSecurityWorkflowDispatch() error {
 }
 
 func (check *pinnedInputsCheck) validateReleaseManifestAndRuntimeSources() error {
-	if !strings.Contains(check.releaseWorkflow, "docker buildx imagetools create") {
-		return errors.New(".github/workflows/release.yml must assemble the published multi-arch manifest with docker buildx imagetools create")
+	if !strings.Contains(check.releaseWorkflow, "oras manifest index create --oci-layout") {
+		return errors.New(".github/workflows/release.yml must assemble the published multi-arch manifest in an OCI layout")
 	}
 	if regexp.MustCompile(`docker/build-push-action@.*?platforms:\s*linux/amd64,linux/arm64`).MatchString(check.releaseWorkflow) {
 		return errors.New(".github/workflows/release.yml must not publish the final multi-arch image through one opaque multi-platform build-push step")
@@ -356,15 +356,15 @@ func (check *pinnedInputsCheck) validateReleaseRequiredSteps() error {
 		"macos-26",
 		"macos-15",
 		"actions/download-artifact@",
-		"context: dist/release-source",
+		"outputs: type=oci,dest=${{ runner.temp }}/workcell-amd64.oci.tar",
 		"name: Re-verify pinned upstreams from archived source tree",
 		"name: Verify GitHub macOS release test runners",
 		"working-directory: dist/release-source",
 		"WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source",
 		"WORKCELL_CONTROL_PLANE_ROOT: ${{ github.workspace }}/dist/release-source",
-		"Verify published platform digests match preflight",
-		"docker buildx imagetools inspect --raw",
-		"{{json .Manifest}}",
+		"Verify bound platform digests match preflight",
+		"oras manifest index create --oci-layout",
+		"oras cp --recursive --from-oci-layout",
 		"vnd.docker.reference.type",
 		"RELEASE_NO_ATTEST: ${{ vars.WORKCELL_RELEASE_NO_ATTEST || 'false' }}",
 		"actions/attest@",
@@ -402,6 +402,7 @@ func (check *pinnedInputsCheck) validateReleaseArtifactFlows() error {
 		},
 		func() error { return ValidateReleaseWorkflowGitHubAttestationFlow(check.releaseWorkflow) },
 		func() error { return ValidateReleaseWorkflowPublicationGate(check.releaseWorkflow) },
+		func() error { return ValidateReleaseWorkflowAuthoritySplit(check.releaseWorkflow) },
 	)
 }
 

--- a/internal/metadatautil/release_image_handoff.go
+++ b/internal/metadatautil/release_image_handoff.go
@@ -75,45 +75,31 @@ func CreateReleaseImageHandoff(archivePath, outputPath, repository, runID, tag, 
 }
 
 func inspectReleaseImageArchive(path, manifestDigest, configDigest string) (releaseImageIndex, releaseImageManifest, string, error) {
+	var index releaseImageIndex
+	var manifest releaseImageManifest
 	file, err := os.Open(path)
 	if err != nil {
-		return releaseImageIndex{}, releaseImageManifest{}, "", err
+		return index, manifest, "", err
 	}
 	defer file.Close()
 	archiveDigest, err := hashAndRewindReleaseImage(file)
 	if err != nil {
-		return releaseImageIndex{}, releaseImageManifest{}, "", err
+		return index, manifest, "", err
 	}
-	reader := tar.NewReader(file)
-	layoutBytes, indexBytes, manifestBytes, configBytes, err := readReleaseImageMembers(reader, manifestDigest, configDigest)
-	if err != nil {
-		return releaseImageIndex{}, releaseImageManifest{}, "", err
+	members := releaseImageMembers{
+		manifestName: releaseImageBlobName(manifestDigest),
+		configName:   releaseImageBlobName(configDigest),
+		seen:         map[string]struct{}{},
 	}
-	index, manifest, err := decodeAndValidateReleaseImage(layoutBytes, indexBytes, manifestBytes, configBytes, manifestDigest, configDigest)
+	if err := members.collect(tar.NewReader(file)); err != nil {
+		return index, manifest, "", err
+	}
+	index, manifest, err = members.decode()
 	return index, manifest, archiveDigest, err
 }
 
-func decodeAndValidateReleaseImage(layoutBytes, indexBytes, manifestBytes, configBytes []byte, manifestDigest, configDigest string) (releaseImageIndex, releaseImageManifest, error) {
-	index, manifest, err := decodeReleaseImageDocuments(indexBytes, manifestBytes)
-	if err != nil {
-		return index, manifest, err
-	}
-	if err := validateReleaseImageLayout(layoutBytes); err != nil {
-		return index, manifest, err
-	}
-	err = validateReleaseImageBlobs(manifestBytes, manifestDigest, configBytes, configDigest)
-	return index, manifest, err
-}
-
-func validateReleaseImageLayout(content []byte) error {
-	var layout releaseImageLayout
-	if err := json.Unmarshal(content, &layout); err != nil {
-		return fmt.Errorf("parse OCI layout: %w", err)
-	}
-	if layout.Version != "1.0.0" {
-		return fmt.Errorf("unsupported OCI image layout version %q", layout.Version)
-	}
-	return nil
+func releaseImageBlobName(digest string) string {
+	return "blobs/sha256/" + strings.TrimPrefix(digest, "sha256:")
 }
 
 func hashAndRewindReleaseImage(file *os.File) (string, error) {
@@ -123,48 +109,6 @@ func hashAndRewindReleaseImage(file *os.File) (string, error) {
 	}
 	_, err := file.Seek(0, io.SeekStart)
 	return hex.EncodeToString(hash.Sum(nil)), err
-}
-
-func validateReleaseImageBlobs(manifest []byte, manifestDigest string, config []byte, configDigest string) error {
-	if err := validateReleaseImageBlob(manifest, manifestDigest); err != nil {
-		return err
-	}
-	return validateReleaseImageBlob(config, configDigest)
-}
-
-func validateReleaseImageBlob(content []byte, digest string) error {
-	actual := sha256.Sum256(content)
-	if hex.EncodeToString(actual[:]) != strings.TrimPrefix(digest, "sha256:") {
-		return fmt.Errorf("OCI blob content does not match %s", digest)
-	}
-	return nil
-}
-
-func decodeReleaseImageDocuments(indexBytes, manifestBytes []byte) (releaseImageIndex, releaseImageManifest, error) {
-	var index releaseImageIndex
-	var manifest releaseImageManifest
-	if err := json.Unmarshal(indexBytes, &index); err != nil {
-		return index, manifest, fmt.Errorf("parse OCI index: %w", err)
-	}
-	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return index, manifest, fmt.Errorf("parse OCI manifest: %w", err)
-	}
-	return index, manifest, nil
-}
-
-func readReleaseImageMembers(reader *tar.Reader, manifestDigest, configDigest string) ([]byte, []byte, []byte, []byte, error) {
-	members := releaseImageMembers{
-		manifestName: "blobs/sha256/" + strings.TrimPrefix(manifestDigest, "sha256:"),
-		configName:   "blobs/sha256/" + strings.TrimPrefix(configDigest, "sha256:"),
-		seen:         map[string]struct{}{},
-	}
-	if err := collectReleaseImageMembers(reader, &members); err != nil {
-		return nil, nil, nil, nil, err
-	}
-	if err := requireReleaseImageMembers(members.layout, members.index, members.manifest, members.config); err != nil {
-		return nil, nil, nil, nil, err
-	}
-	return members.layout, members.index, members.manifest, members.config, nil
 }
 
 type releaseImageMembers struct {
@@ -177,31 +121,82 @@ type releaseImageMembers struct {
 	config       []byte
 }
 
-func collectReleaseImageMembers(reader *tar.Reader, members *releaseImageMembers) error {
+func (members *releaseImageMembers) collect(reader *tar.Reader) error {
 	for {
-		done, err := readReleaseImageMember(reader, members)
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
-		if done {
-			return nil
+		name, err := validateReleaseImageMember(header)
+		if err != nil {
+			return err
+		}
+		if err := members.read(reader, name); err != nil {
+			return err
 		}
 	}
 }
 
-func readReleaseImageMember(reader *tar.Reader, members *releaseImageMembers) (bool, error) {
-	header, err := reader.Next()
-	if errors.Is(err, io.EOF) {
-		return true, nil
+func (members *releaseImageMembers) read(reader io.Reader, name string) error {
+	if _, ok := members.seen[name]; ok {
+		return fmt.Errorf("release image archive contains duplicate member %q", name)
 	}
+	members.seen[name] = struct{}{}
+	var err error
+	switch {
+	case name == "oci-layout":
+		members.layout, err = readReleaseImageDocument(reader, name)
+	case name == "index.json":
+		members.index, err = readReleaseImageDocument(reader, name)
+	case validReleaseImageBlobName(name):
+		err = members.readBlob(reader, name)
+	}
+	return err
+}
+
+func (members *releaseImageMembers) readBlob(reader io.Reader, name string) error {
+	if name != members.manifestName && name != members.configName {
+		return validateReleaseImageBlobStream(reader, name)
+	}
+	content, err := readReleaseImageDocument(reader, name)
 	if err != nil {
-		return false, err
+		return err
 	}
-	name, err := validateReleaseImageMember(header)
-	if err != nil {
-		return false, err
+	if err := validateReleaseImageBlob(content, path.Base(name)); err != nil {
+		return err
 	}
-	return false, members.read(reader, name)
+	if name == members.manifestName {
+		members.manifest = content
+	}
+	if name == members.configName {
+		members.config = content
+	}
+	return nil
+}
+
+func (members *releaseImageMembers) decode() (releaseImageIndex, releaseImageManifest, error) {
+	var index releaseImageIndex
+	var manifest releaseImageManifest
+	if len(members.layout) == 0 || len(members.index) == 0 || len(members.manifest) == 0 || len(members.config) == 0 {
+		return index, manifest, errors.New("release image archive lacks the OCI layout, index, bound manifest, or config")
+	}
+	if err := json.Unmarshal(members.index, &index); err != nil {
+		return index, manifest, fmt.Errorf("parse OCI index: %w", err)
+	}
+	if err := json.Unmarshal(members.manifest, &manifest); err != nil {
+		return index, manifest, fmt.Errorf("parse OCI manifest: %w", err)
+	}
+	var layout releaseImageLayout
+	if err := json.Unmarshal(members.layout, &layout); err != nil {
+		return index, manifest, fmt.Errorf("parse OCI layout: %w", err)
+	}
+	if layout.Version != "1.0.0" {
+		return index, manifest, fmt.Errorf("unsupported OCI image layout version %q", layout.Version)
+	}
+	return index, manifest, nil
 }
 
 func validateReleaseImageMember(header *tar.Header) (string, error) {
@@ -212,17 +207,13 @@ func validateReleaseImageMember(header *tar.Header) (string, error) {
 	if path.Clean(name) != name {
 		return "", fmt.Errorf("release image archive contains non-canonical member %q", header.Name)
 	}
-	if !validReleaseImageMemberType(header.Typeflag) {
+	if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeDir {
 		return "", fmt.Errorf("release image archive contains special member %q", header.Name)
 	}
 	if !validReleaseImageMemberName(name, header.Typeflag == tar.TypeDir) {
 		return "", fmt.Errorf("release image archive contains unexpected member %q", header.Name)
 	}
 	return name, nil
-}
-
-func validReleaseImageMemberType(typeflag byte) bool {
-	return typeflag == tar.TypeReg || typeflag == tar.TypeRegA || typeflag == tar.TypeDir
 }
 
 func validReleaseImageMemberName(name string, directory bool) bool {
@@ -233,73 +224,12 @@ func validReleaseImageMemberName(name string, directory bool) bool {
 }
 
 func validReleaseImageBlobName(name string) bool {
-	const prefix = "blobs/sha256/"
-	encoded := strings.TrimPrefix(name, prefix)
+	encoded := strings.TrimPrefix(name, "blobs/sha256/")
 	if encoded == name || len(encoded) != 64 {
 		return false
 	}
 	_, err := hex.DecodeString(encoded)
 	return err == nil
-}
-
-func recordReleaseImageMember(seen map[string]struct{}, name string) error {
-	if _, ok := seen[name]; ok {
-		return fmt.Errorf("release image archive contains duplicate member %q", name)
-	}
-	seen[name] = struct{}{}
-	return nil
-}
-
-func requireReleaseImageMembers(layoutBytes, indexBytes, manifestBytes, configBytes []byte) error {
-	if len(layoutBytes) == 0 || len(indexBytes) == 0 || len(manifestBytes) == 0 || len(configBytes) == 0 {
-		return errors.New("release image archive lacks the OCI layout, index, bound manifest, or config")
-	}
-	return nil
-}
-
-func (members *releaseImageMembers) read(reader io.Reader, name string) error {
-	if err := recordReleaseImageMember(members.seen, name); err != nil {
-		return err
-	}
-	if validReleaseImageBlobName(name) {
-		return members.readBlob(reader, name)
-	}
-	var err error
-	if name == "index.json" {
-		members.index, err = readReleaseImageDocument(reader, name)
-	}
-	if name == "oci-layout" {
-		members.layout, err = readReleaseImageDocument(reader, name)
-	}
-	return err
-}
-
-func (members *releaseImageMembers) readBlob(reader io.Reader, name string) error {
-	if !members.isBoundBlob(name) {
-		return validateReleaseImageBlobStream(reader, name)
-	}
-	content, err := readReleaseImageDocument(reader, name)
-	if err != nil {
-		return err
-	}
-	if err := validateReleaseImageBlob(content, "sha256:"+path.Base(name)); err != nil {
-		return err
-	}
-	members.storeBoundBlob(name, content)
-	return nil
-}
-
-func (members *releaseImageMembers) isBoundBlob(name string) bool {
-	return name == members.manifestName || name == members.configName
-}
-
-func (members *releaseImageMembers) storeBoundBlob(name string, content []byte) {
-	if name == members.manifestName {
-		members.manifest = content
-	}
-	if name == members.configName {
-		members.config = content
-	}
 }
 
 func readReleaseImageDocument(reader io.Reader, name string) ([]byte, error) {
@@ -311,6 +241,14 @@ func readReleaseImageDocument(reader io.Reader, name string) ([]byte, error) {
 		return nil, fmt.Errorf("release image document %q exceeds %d bytes", name, maxReleaseImageDocumentSize)
 	}
 	return content, nil
+}
+
+func validateReleaseImageBlob(content []byte, encoded string) error {
+	actual := sha256.Sum256(content)
+	if hex.EncodeToString(actual[:]) != encoded {
+		return fmt.Errorf("OCI blob content does not match sha256:%s", encoded)
+	}
+	return nil
 }
 
 func validateReleaseImageBlobStream(reader io.Reader, name string) error {
@@ -325,35 +263,18 @@ func validateReleaseImageBlobStream(reader io.Reader, name string) error {
 }
 
 func validateReleaseImageDescriptor(index releaseImageIndex, platform, digest string) error {
-	osName, architecture, err := splitReleaseImagePlatform(platform)
-	if err != nil {
-		return err
+	osName, architecture, ok := strings.Cut(platform, "/")
+	if !ok || osName == "" || architecture == "" {
+		return fmt.Errorf("invalid release image platform %q", platform)
 	}
-	matches := countReleaseImageDescriptors(index, digest, osName, architecture)
+	matches := 0
+	for _, descriptor := range index.Manifests {
+		if descriptor.Digest == digest && descriptor.Platform.OS == osName && descriptor.Platform.Architecture == architecture {
+			matches++
+		}
+	}
 	if matches != 1 {
 		return fmt.Errorf("release image must contain one %s descriptor for %s, found %d", platform, digest, matches)
 	}
 	return nil
-}
-
-func splitReleaseImagePlatform(platform string) (string, string, error) {
-	osName, architecture, ok := strings.Cut(platform, "/")
-	if !ok || osName == "" || architecture == "" {
-		return "", "", fmt.Errorf("invalid release image platform %q", platform)
-	}
-	return osName, architecture, nil
-}
-
-func countReleaseImageDescriptors(index releaseImageIndex, digest, osName, architecture string) int {
-	matches := 0
-	for _, descriptor := range index.Manifests {
-		if releaseImageDescriptorMatches(descriptor.Digest, descriptor.Platform.OS, descriptor.Platform.Architecture, digest, osName, architecture) {
-			matches++
-		}
-	}
-	return matches
-}
-
-func releaseImageDescriptorMatches(actualDigest, actualOS, actualArchitecture, digest, osName, architecture string) bool {
-	return actualDigest == digest && actualOS == osName && actualArchitecture == architecture
 }

--- a/internal/metadatautil/release_image_handoff.go
+++ b/internal/metadatautil/release_image_handoff.go
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"archive/tar"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+)
+
+type releaseImageIndex struct {
+	Manifests []struct {
+		Digest   string `json:"digest"`
+		Platform struct {
+			OS           string `json:"os"`
+			Architecture string `json:"architecture"`
+		} `json:"platform"`
+	} `json:"manifests"`
+}
+
+type releaseImageManifest struct {
+	Config struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+}
+
+type releaseImageLayout struct {
+	Version string `json:"imageLayoutVersion"`
+}
+
+const maxReleaseImageDocumentSize = 1 << 20
+
+type releaseImageHandoff struct {
+	Repository     string `json:"repository"`
+	RunID          string `json:"run_id"`
+	Tag            string `json:"tag"`
+	Commit         string `json:"commit"`
+	Platform       string `json:"platform"`
+	ImageDigest    string `json:"image_digest"`
+	ManifestDigest string `json:"manifest_digest"`
+	ConfigDigest   string `json:"config_digest"`
+	ArchiveSHA256  string `json:"archive_sha256"`
+}
+
+func CreateReleaseImageHandoff(archivePath, outputPath, repository, runID, tag, commit, platform, imageDigest, manifestDigest, configDigest string) error {
+	index, manifest, archiveDigest, err := inspectReleaseImageArchive(archivePath, manifestDigest, configDigest)
+	if err != nil {
+		return err
+	}
+	if err := validateReleaseImageDescriptor(index, platform, manifestDigest); err != nil {
+		return err
+	}
+	if manifest.Config.Digest != configDigest {
+		return fmt.Errorf("release image config digest %q does not match %q", manifest.Config.Digest, configDigest)
+	}
+	handoff := releaseImageHandoff{
+		Repository: repository, RunID: runID, Tag: tag, Commit: commit,
+		Platform: platform, ImageDigest: imageDigest, ManifestDigest: manifestDigest,
+		ConfigDigest: configDigest, ArchiveSHA256: archiveDigest,
+	}
+	content, err := json.Marshal(handoff)
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	return os.WriteFile(outputPath, content, 0o600)
+}
+
+func inspectReleaseImageArchive(path, manifestDigest, configDigest string) (releaseImageIndex, releaseImageManifest, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return releaseImageIndex{}, releaseImageManifest{}, "", err
+	}
+	defer file.Close()
+	archiveDigest, err := hashAndRewindReleaseImage(file)
+	if err != nil {
+		return releaseImageIndex{}, releaseImageManifest{}, "", err
+	}
+	reader := tar.NewReader(file)
+	layoutBytes, indexBytes, manifestBytes, configBytes, err := readReleaseImageMembers(reader, manifestDigest, configDigest)
+	if err != nil {
+		return releaseImageIndex{}, releaseImageManifest{}, "", err
+	}
+	index, manifest, err := decodeAndValidateReleaseImage(layoutBytes, indexBytes, manifestBytes, configBytes, manifestDigest, configDigest)
+	return index, manifest, archiveDigest, err
+}
+
+func decodeAndValidateReleaseImage(layoutBytes, indexBytes, manifestBytes, configBytes []byte, manifestDigest, configDigest string) (releaseImageIndex, releaseImageManifest, error) {
+	index, manifest, err := decodeReleaseImageDocuments(indexBytes, manifestBytes)
+	if err != nil {
+		return index, manifest, err
+	}
+	if err := validateReleaseImageLayout(layoutBytes); err != nil {
+		return index, manifest, err
+	}
+	err = validateReleaseImageBlobs(manifestBytes, manifestDigest, configBytes, configDigest)
+	return index, manifest, err
+}
+
+func validateReleaseImageLayout(content []byte) error {
+	var layout releaseImageLayout
+	if err := json.Unmarshal(content, &layout); err != nil {
+		return fmt.Errorf("parse OCI layout: %w", err)
+	}
+	if layout.Version != "1.0.0" {
+		return fmt.Errorf("unsupported OCI image layout version %q", layout.Version)
+	}
+	return nil
+}
+
+func hashAndRewindReleaseImage(file *os.File) (string, error) {
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	_, err := file.Seek(0, io.SeekStart)
+	return hex.EncodeToString(hash.Sum(nil)), err
+}
+
+func validateReleaseImageBlobs(manifest []byte, manifestDigest string, config []byte, configDigest string) error {
+	if err := validateReleaseImageBlob(manifest, manifestDigest); err != nil {
+		return err
+	}
+	return validateReleaseImageBlob(config, configDigest)
+}
+
+func validateReleaseImageBlob(content []byte, digest string) error {
+	actual := sha256.Sum256(content)
+	if hex.EncodeToString(actual[:]) != strings.TrimPrefix(digest, "sha256:") {
+		return fmt.Errorf("OCI blob content does not match %s", digest)
+	}
+	return nil
+}
+
+func decodeReleaseImageDocuments(indexBytes, manifestBytes []byte) (releaseImageIndex, releaseImageManifest, error) {
+	var index releaseImageIndex
+	var manifest releaseImageManifest
+	if err := json.Unmarshal(indexBytes, &index); err != nil {
+		return index, manifest, fmt.Errorf("parse OCI index: %w", err)
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return index, manifest, fmt.Errorf("parse OCI manifest: %w", err)
+	}
+	return index, manifest, nil
+}
+
+func readReleaseImageMembers(reader *tar.Reader, manifestDigest, configDigest string) ([]byte, []byte, []byte, []byte, error) {
+	members := releaseImageMembers{
+		manifestName: "blobs/sha256/" + strings.TrimPrefix(manifestDigest, "sha256:"),
+		configName:   "blobs/sha256/" + strings.TrimPrefix(configDigest, "sha256:"),
+		seen:         map[string]struct{}{},
+	}
+	if err := collectReleaseImageMembers(reader, &members); err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if err := requireReleaseImageMembers(members.layout, members.index, members.manifest, members.config); err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return members.layout, members.index, members.manifest, members.config, nil
+}
+
+type releaseImageMembers struct {
+	manifestName string
+	configName   string
+	seen         map[string]struct{}
+	layout       []byte
+	index        []byte
+	manifest     []byte
+	config       []byte
+}
+
+func collectReleaseImageMembers(reader *tar.Reader, members *releaseImageMembers) error {
+	for {
+		done, err := readReleaseImageMember(reader, members)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+	}
+}
+
+func readReleaseImageMember(reader *tar.Reader, members *releaseImageMembers) (bool, error) {
+	header, err := reader.Next()
+	if errors.Is(err, io.EOF) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	name, err := validateReleaseImageMember(header)
+	if err != nil {
+		return false, err
+	}
+	return false, members.read(reader, name)
+}
+
+func validateReleaseImageMember(header *tar.Header) (string, error) {
+	name := strings.TrimPrefix(header.Name, "./")
+	if header.Typeflag == tar.TypeDir {
+		name = strings.TrimSuffix(name, "/")
+	}
+	if path.Clean(name) != name {
+		return "", fmt.Errorf("release image archive contains non-canonical member %q", header.Name)
+	}
+	if !validReleaseImageMemberType(header.Typeflag) {
+		return "", fmt.Errorf("release image archive contains special member %q", header.Name)
+	}
+	if !validReleaseImageMemberName(name, header.Typeflag == tar.TypeDir) {
+		return "", fmt.Errorf("release image archive contains unexpected member %q", header.Name)
+	}
+	return name, nil
+}
+
+func validReleaseImageMemberType(typeflag byte) bool {
+	return typeflag == tar.TypeReg || typeflag == tar.TypeRegA || typeflag == tar.TypeDir
+}
+
+func validReleaseImageMemberName(name string, directory bool) bool {
+	if directory {
+		return name == "blobs" || name == "blobs/sha256"
+	}
+	return name == "oci-layout" || name == "index.json" || validReleaseImageBlobName(name)
+}
+
+func validReleaseImageBlobName(name string) bool {
+	const prefix = "blobs/sha256/"
+	encoded := strings.TrimPrefix(name, prefix)
+	if encoded == name || len(encoded) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(encoded)
+	return err == nil
+}
+
+func recordReleaseImageMember(seen map[string]struct{}, name string) error {
+	if _, ok := seen[name]; ok {
+		return fmt.Errorf("release image archive contains duplicate member %q", name)
+	}
+	seen[name] = struct{}{}
+	return nil
+}
+
+func requireReleaseImageMembers(layoutBytes, indexBytes, manifestBytes, configBytes []byte) error {
+	if len(layoutBytes) == 0 || len(indexBytes) == 0 || len(manifestBytes) == 0 || len(configBytes) == 0 {
+		return errors.New("release image archive lacks the OCI layout, index, bound manifest, or config")
+	}
+	return nil
+}
+
+func (members *releaseImageMembers) read(reader io.Reader, name string) error {
+	if err := recordReleaseImageMember(members.seen, name); err != nil {
+		return err
+	}
+	if validReleaseImageBlobName(name) {
+		return members.readBlob(reader, name)
+	}
+	var err error
+	if name == "index.json" {
+		members.index, err = readReleaseImageDocument(reader, name)
+	}
+	if name == "oci-layout" {
+		members.layout, err = readReleaseImageDocument(reader, name)
+	}
+	return err
+}
+
+func (members *releaseImageMembers) readBlob(reader io.Reader, name string) error {
+	if !members.isBoundBlob(name) {
+		return validateReleaseImageBlobStream(reader, name)
+	}
+	content, err := readReleaseImageDocument(reader, name)
+	if err != nil {
+		return err
+	}
+	if err := validateReleaseImageBlob(content, "sha256:"+path.Base(name)); err != nil {
+		return err
+	}
+	members.storeBoundBlob(name, content)
+	return nil
+}
+
+func (members *releaseImageMembers) isBoundBlob(name string) bool {
+	return name == members.manifestName || name == members.configName
+}
+
+func (members *releaseImageMembers) storeBoundBlob(name string, content []byte) {
+	if name == members.manifestName {
+		members.manifest = content
+	}
+	if name == members.configName {
+		members.config = content
+	}
+}
+
+func readReleaseImageDocument(reader io.Reader, name string) ([]byte, error) {
+	content, err := io.ReadAll(io.LimitReader(reader, maxReleaseImageDocumentSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(content) > maxReleaseImageDocumentSize {
+		return nil, fmt.Errorf("release image document %q exceeds %d bytes", name, maxReleaseImageDocumentSize)
+	}
+	return content, nil
+}
+
+func validateReleaseImageBlobStream(reader io.Reader, name string) error {
+	hash := sha256.New()
+	if _, err := io.Copy(hash, reader); err != nil {
+		return err
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != path.Base(name) {
+		return fmt.Errorf("OCI blob content does not match sha256:%s", path.Base(name))
+	}
+	return nil
+}
+
+func validateReleaseImageDescriptor(index releaseImageIndex, platform, digest string) error {
+	osName, architecture, err := splitReleaseImagePlatform(platform)
+	if err != nil {
+		return err
+	}
+	matches := countReleaseImageDescriptors(index, digest, osName, architecture)
+	if matches != 1 {
+		return fmt.Errorf("release image must contain one %s descriptor for %s, found %d", platform, digest, matches)
+	}
+	return nil
+}
+
+func splitReleaseImagePlatform(platform string) (string, string, error) {
+	osName, architecture, ok := strings.Cut(platform, "/")
+	if !ok || osName == "" || architecture == "" {
+		return "", "", fmt.Errorf("invalid release image platform %q", platform)
+	}
+	return osName, architecture, nil
+}
+
+func countReleaseImageDescriptors(index releaseImageIndex, digest, osName, architecture string) int {
+	matches := 0
+	for _, descriptor := range index.Manifests {
+		if releaseImageDescriptorMatches(descriptor.Digest, descriptor.Platform.OS, descriptor.Platform.Architecture, digest, osName, architecture) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func releaseImageDescriptorMatches(actualDigest, actualOS, actualArchitecture, digest, osName, architecture string) bool {
+	return actualDigest == digest && actualOS == osName && actualArchitecture == architecture
+}

--- a/internal/metadatautil/release_image_handoff_stream_test.go
+++ b/internal/metadatautil/release_image_handoff_stream_test.go
@@ -25,8 +25,8 @@ func TestReleaseImageNonTargetBlobUsesBoundedStreaming(t *testing.T) {
 }
 
 func TestReleaseImageDocumentLimit(t *testing.T) {
-	reader := io.LimitReader(strings.NewReader(strings.Repeat("x", maxReleaseImageDocumentSize+1)), maxReleaseImageDocumentSize+1)
-	_, err := readReleaseImageDocument(reader, "index.json")
+	oversized := strings.NewReader(strings.Repeat("x", maxReleaseImageDocumentSize+1))
+	_, err := readReleaseImageDocument(oversized, "index.json")
 	if err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("readReleaseImageDocument() error = %v", err)
 	}

--- a/internal/metadatautil/release_image_handoff_stream_test.go
+++ b/internal/metadatautil/release_image_handoff_stream_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReleaseImageNonTargetBlobUsesBoundedStreaming(t *testing.T) {
+	const size = 32 << 20
+	digest := repeatedReleaseImageByteDigest('x', size)
+	reader := &boundedReleaseImageReader{remaining: size, value: 'x'}
+	members := releaseImageMembers{manifestName: "manifest", configName: "config"}
+	if err := members.readBlob(reader, "blobs/sha256/"+digest); err != nil {
+		t.Fatalf("readBlob() error = %v", err)
+	}
+	if reader.maxRequest > 64<<10 {
+		t.Fatalf("largest read buffer = %d, want at most 65536", reader.maxRequest)
+	}
+}
+
+func TestReleaseImageDocumentLimit(t *testing.T) {
+	reader := io.LimitReader(strings.NewReader(strings.Repeat("x", maxReleaseImageDocumentSize+1)), maxReleaseImageDocumentSize+1)
+	_, err := readReleaseImageDocument(reader, "index.json")
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("readReleaseImageDocument() error = %v", err)
+	}
+}
+
+type boundedReleaseImageReader struct {
+	remaining  int
+	maxRequest int
+	value      byte
+}
+
+func (reader *boundedReleaseImageReader) Read(buffer []byte) (int, error) {
+	if len(buffer) > reader.maxRequest {
+		reader.maxRequest = len(buffer)
+	}
+	if reader.remaining == 0 {
+		return 0, io.EOF
+	}
+	count := min(len(buffer), reader.remaining)
+	for index := range buffer[:count] {
+		buffer[index] = reader.value
+	}
+	reader.remaining -= count
+	return count, nil
+}
+
+func repeatedReleaseImageByteDigest(value byte, size int) string {
+	hash := sha256.New()
+	reader := &boundedReleaseImageReader{remaining: size, value: value}
+	_, _ = io.Copy(hash, reader)
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/internal/metadatautil/release_image_handoff_test.go
+++ b/internal/metadatautil/release_image_handoff_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"archive/tar"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCreateReleaseImageHandoffBindsArchiveIdentity(t *testing.T) {
+	archive, manifestDigest, configDigest := writeReleaseImageArchive(t, 1, "", false)
+	output := filepath.Join(t.TempDir(), "handoff.json")
+	err := metadatautil.CreateReleaseImageHandoff(archive, output, "owner/repo", "12", "v1", "commit", "linux/amd64", "sha256:index", manifestDigest, configDigest)
+	if err != nil {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+	assertReleaseImageHandoff(t, output)
+}
+
+func TestCreateReleaseImageHandoffRejectsMismatchedArchive(t *testing.T) {
+	archive, _, configDigest := writeReleaseImageArchive(t, 1, "", false)
+	err := metadatautil.CreateReleaseImageHandoff(archive, filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", "sha256:"+strings.Repeat("0", 64), configDigest)
+	if err == nil || !strings.Contains(err.Error(), "lacks the OCI layout") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func TestCreateReleaseImageHandoffRejectsWrongConfiguration(t *testing.T) {
+	wrongDigest := "sha256:" + strings.Repeat("1", 64)
+	archive, manifestDigest, configDigest := writeReleaseImageArchive(t, 1, wrongDigest, false)
+	err := metadatautil.CreateReleaseImageHandoff(archive, filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", manifestDigest, configDigest)
+	if err == nil || !strings.Contains(err.Error(), "config digest") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func TestCreateReleaseImageHandoffRejectsDuplicateDescriptors(t *testing.T) {
+	archive, manifestDigest, configDigest := writeReleaseImageArchive(t, 2, "", false)
+	err := metadatautil.CreateReleaseImageHandoff(archive, filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", manifestDigest, configDigest)
+	if err == nil || !strings.Contains(err.Error(), "found 2") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func TestCreateReleaseImageHandoffRejectsDuplicateMembers(t *testing.T) {
+	archive, manifestDigest, configDigest := writeReleaseImageArchive(t, 1, "", true)
+	err := metadatautil.CreateReleaseImageHandoff(archive, filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", manifestDigest, configDigest)
+	if err == nil || !strings.Contains(err.Error(), "duplicate member") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func TestCreateReleaseImageHandoffRejectsMislabeledBlob(t *testing.T) {
+	configDigest := "sha256:" + strings.Repeat("2", 64)
+	manifest := []byte(fmt.Sprintf(`{"config":{"digest":%q}}`, configDigest))
+	manifestDigest := contentDigest(manifest)
+	index := []byte(fmt.Sprintf(`{"manifests":[{"digest":%q,"platform":{"os":"linux","architecture":"amd64"}}]}`, manifestDigest))
+	members := []releaseArchiveMember{
+		{name: "oci-layout", content: []byte(`{"imageLayoutVersion":"1.0.0"}`)},
+		{name: "index.json", content: index},
+		{name: "blobs/sha256/" + strings.TrimPrefix(manifestDigest, "sha256:"), content: manifest},
+		{name: "blobs/sha256/" + strings.TrimPrefix(configDigest, "sha256:"), content: []byte("wrong")},
+	}
+	archive := writeReleaseArchiveMembers(t, members)
+	err := metadatautil.CreateReleaseImageHandoff(archive, filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", manifestDigest, configDigest)
+	if err == nil || !strings.Contains(err.Error(), "blob content") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func TestCreateReleaseImageHandoffRejectsTraversal(t *testing.T) {
+	archive, manifestDigest, configDigest := writeReleaseImageArchive(t, 1, "", false)
+	members := readReleaseArchiveMembers(t, archive)
+	members = append(members, releaseArchiveMember{name: "../preflight-subjects/workcell.rb", content: []byte("replacement")})
+	err := metadatautil.CreateReleaseImageHandoff(writeReleaseArchiveMembers(t, members), filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", manifestDigest, configDigest)
+	if err == nil || !strings.Contains(err.Error(), "unexpected member") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func TestCreateReleaseImageHandoffRejectsLinks(t *testing.T) {
+	archive, manifestDigest, configDigest := writeReleaseImageArchive(t, 1, "", false)
+	members := readReleaseArchiveMembers(t, archive)
+	members = append(members, releaseArchiveMember{name: "blobs/sha256/" + strings.Repeat("3", 64), typeflag: tar.TypeSymlink, linkname: "../index.json"})
+	err := metadatautil.CreateReleaseImageHandoff(writeReleaseArchiveMembers(t, members), filepath.Join(t.TempDir(), "out"), "r", "1", "v1", "c", "linux/amd64", "sha256:i", manifestDigest, configDigest)
+	if err == nil || !strings.Contains(err.Error(), "special member") {
+		t.Fatalf("CreateReleaseImageHandoff() error = %v", err)
+	}
+}
+
+func assertReleaseImageHandoff(t *testing.T, output string) {
+	t.Helper()
+	content, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var handoff map[string]any
+	if err := json.Unmarshal(content, &handoff); err != nil {
+		t.Fatal(err)
+	}
+	if !validReleaseImageHandoff(handoff) {
+		t.Fatalf("handoff = %#v", handoff)
+	}
+}
+
+func validReleaseImageHandoff(handoff map[string]any) bool {
+	return handoff["repository"] == "owner/repo" && handoff["platform"] == "linux/amd64" && len(handoff["archive_sha256"].(string)) == 64
+}
+
+func writeReleaseImageArchive(t *testing.T, descriptorCount int, manifestConfigDigest string, duplicateManifest bool) (string, string, string) {
+	t.Helper()
+	config := []byte(`{"architecture":"amd64","os":"linux"}`)
+	configDigest := contentDigest(config)
+	if manifestConfigDigest == "" {
+		manifestConfigDigest = configDigest
+	}
+	manifest := []byte(fmt.Sprintf(`{"config":{"digest":%q}}`, manifestConfigDigest))
+	manifestDigest := contentDigest(manifest)
+	descriptor := fmt.Sprintf(`{"digest":%q,"platform":{"os":"linux","architecture":"amd64"}}`, manifestDigest)
+	index := []byte(`{"manifests":[` + strings.TrimSuffix(strings.Repeat(descriptor+",", descriptorCount), ",") + `]}`)
+	members := []releaseArchiveMember{
+		{name: "oci-layout", content: []byte(`{"imageLayoutVersion":"1.0.0"}`)},
+		{name: "index.json", content: index},
+		{name: "blobs/sha256/" + strings.TrimPrefix(manifestDigest, "sha256:"), content: manifest},
+		{name: "blobs/sha256/" + strings.TrimPrefix(configDigest, "sha256:"), content: config},
+	}
+	if duplicateManifest {
+		members = append(members, members[1])
+	}
+	return writeReleaseArchiveMembers(t, members), manifestDigest, configDigest
+}
+
+type releaseArchiveMember struct {
+	name     string
+	content  []byte
+	typeflag byte
+	linkname string
+}
+
+func readReleaseArchiveMembers(t *testing.T, archive string) []releaseArchiveMember {
+	t.Helper()
+	file, err := os.Open(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	reader := tar.NewReader(file)
+	var members []releaseArchiveMember
+	for {
+		member, done, err := readReleaseArchiveMember(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if done {
+			return members
+		}
+		members = append(members, member)
+	}
+}
+
+func readReleaseArchiveMember(reader *tar.Reader) (releaseArchiveMember, bool, error) {
+	header, err := reader.Next()
+	if err == io.EOF {
+		return releaseArchiveMember{}, true, nil
+	}
+	if err != nil {
+		return releaseArchiveMember{}, false, err
+	}
+	content, err := io.ReadAll(reader)
+	member := releaseArchiveMember{name: header.Name, content: content, typeflag: header.Typeflag, linkname: header.Linkname}
+	return member, false, err
+}
+
+func writeReleaseArchiveMembers(t *testing.T, members []releaseArchiveMember) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "image.tar")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := tar.NewWriter(file)
+	for _, member := range members {
+		writeReleaseArchiveMember(t, writer, member)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeReleaseArchiveMember(t *testing.T, writer *tar.Writer, member releaseArchiveMember) {
+	t.Helper()
+	typeflag := member.typeflag
+	if typeflag == 0 {
+		typeflag = tar.TypeReg
+	}
+	if err := writer.WriteHeader(&tar.Header{Name: member.name, Mode: 0o600, Size: int64(len(member.content)), Typeflag: typeflag, Linkname: member.linkname}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write(member.content); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func contentDigest(content []byte) string {
+	digest := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -39,10 +39,13 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
   release:
     permissions:
       contents: read
+  sign-release:
+    environment:
+      name: release
   publish-github-release:
     needs:
       - tag-policy
-      - release
+      - sign-release
     environment:
       name: hosted-controls-audit
     permissions:
@@ -68,7 +71,7 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 		name, old, replacement, want string
 	}{
 		{name: "artifact job stays read-only", old: "contents: read", replacement: "contents: write", want: "read-only"},
-		{name: "depends on sealed artifacts", old: "      - release", replacement: "      - preflight", want: "depend directly"},
+		{name: "depends on sealed artifacts", old: "      - sign-release", replacement: "      - preflight", want: "depend directly"},
 		{name: "uses audit environment", old: "name: hosted-controls-audit", replacement: "name: release", want: "hosted-controls-audit"},
 		{name: "minimal permissions", old: "contents: write\n    steps:", replacement: "contents: write\n      packages: write\n    steps:", want: "grant only"},
 		{name: "unsets audit token", old: "unset WORKCELL_HOSTED_CONTROLS_TOKEN", replacement: "true", want: "unset its credential"},
@@ -81,6 +84,47 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 				t.Fatalf("ValidateReleaseWorkflowPublicationGate() error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestValidateReleaseWorkflowAuthoritySplit(t *testing.T) {
+	content := readReleaseWorkflow(t)
+	if err := metadatautil.ValidateReleaseWorkflowAuthoritySplit(string(content)); err != nil {
+		t.Fatalf("ValidateReleaseWorkflowAuthoritySplit() error = %v", err)
+	}
+	mutated := strings.Replace(string(content), "    permissions:\n      contents: read\n    outputs:\n      digest: ${{ steps.build_amd64.outputs.digest }}", "    permissions:\n      contents: read\n      packages: write\n    outputs:\n      digest: ${{ steps.build_amd64.outputs.digest }}", 1)
+	requireReleaseAuthorityError(t, mutated, "build-amd64-image")
+	mutated = strings.Replace(string(content), "    steps:\n      - name: Download bound unsigned release artifact", "    steps:\n      - uses: actions/checkout@bad\n      - name: Download bound unsigned release artifact", 1)
+	requireReleaseAuthorityError(t, mutated, "exact privileged step contract")
+}
+
+func TestValidateReleaseWorkflowAuthoritySplitRejectsSignerDrift(t *testing.T) {
+	content := readReleaseWorkflow(t)
+	workflow := string(content)
+	mutations := []string{
+		strings.Replace(workflow, "sha256sum -c dist/SHA256SUMS", "source dist/SHA256SUMS", 1),
+		strings.Replace(workflow, "    env:\n      BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz", "    env:\n      BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz\n      EXTRA: forbidden", 1),
+		strings.Replace(workflow, "      - name: Sign release image", "      - name: Unexpected command\n        run: eval dist/payload\n\n      - name: Sign release image", 1),
+	}
+	for _, mutated := range mutations {
+		requireReleaseAuthorityError(t, mutated, "exact privileged step contract")
+	}
+}
+
+func readReleaseWorkflow(t *testing.T) []byte {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
+func requireReleaseAuthorityError(t *testing.T, workflow, want string) {
+	t.Helper()
+	err := metadatautil.ValidateReleaseWorkflowAuthoritySplit(workflow)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("ValidateReleaseWorkflowAuthoritySplit() error = %v, want %q", err, want)
 	}
 }
 

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -4,6 +4,8 @@
 package metadatautil
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -21,21 +23,37 @@ type workflowDocument struct {
 	Jobs map[string]workflowJob `yaml:"jobs"`
 }
 
+type workflowNodeDocument struct {
+	Jobs map[string]yaml.Node `yaml:"jobs"`
+}
+
 type workflowJob struct {
-	Name        string    `yaml:"name"`
-	Needs       yaml.Node `yaml:"needs"`
-	Environment struct {
+	Name           string    `yaml:"name"`
+	RunsOn         yaml.Node `yaml:"runs-on"`
+	TimeoutMinutes int       `yaml:"timeout-minutes"`
+	Needs          yaml.Node `yaml:"needs"`
+	Environment    struct {
 		Name string `yaml:"name"`
 	} `yaml:"environment"`
 	Permissions map[string]string `yaml:"permissions"`
+	Env         map[string]string `yaml:"env"`
+	Outputs     map[string]string `yaml:"outputs"`
 	Steps       []workflowStep    `yaml:"steps"`
 }
 
 type workflowStep struct {
+	ID   string            `yaml:"id"`
 	Name string            `yaml:"name"`
 	Env  map[string]string `yaml:"env"`
 	Run  string            `yaml:"run"`
+	Uses string            `yaml:"uses"`
+	If   string            `yaml:"if"`
+	With yaml.Node         `yaml:"with"`
 }
+
+// This digest covers the complete parsed sign-release job. It rejects unknown
+// fields, reordered steps, changed commands, and changed action inputs.
+const releaseSignerContractSHA256 = "67e319138562ca059e2b39f89b306fa32d8cf7400d1eba119e106bef5b5bc0c9"
 
 func CollectWorkflowJobNames(content []byte) ([]string, error) {
 	var document workflowDocument
@@ -74,8 +92,8 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		return errors.New("release workflow must define the final publish-github-release job")
 	}
 	if publishJob.Needs.Kind != yaml.SequenceNode || len(publishJob.Needs.Content) != 2 ||
-		publishJob.Needs.Content[0].Value != "tag-policy" || publishJob.Needs.Content[1].Value != "release" {
-		return errors.New("final GitHub release publication job must depend directly on tag-policy and the release artifact job")
+		publishJob.Needs.Content[0].Value != "tag-policy" || publishJob.Needs.Content[1].Value != "sign-release" {
+		return errors.New("final GitHub release publication job must depend directly on tag-policy and the signing job")
 	}
 	if publishJob.Environment.Name != "hosted-controls-audit" {
 		return errors.New("final GitHub release publication job must run in hosted-controls-audit")
@@ -102,6 +120,116 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		return nil
 	}
 	return errors.New("release workflow must combine the fresh hosted-controls check and GitHub release publication in one reviewed step")
+}
+
+func ValidateReleaseWorkflowAuthoritySplit(workflowText string) error {
+	var document workflowDocument
+	if err := yaml.Unmarshal([]byte(workflowText), &document); err != nil {
+		return fmt.Errorf("parse release authority split: %w", err)
+	}
+	if err := validateUnprivilegedReleaseJobs(document); err != nil {
+		return err
+	}
+	if err := validateReleaseSigner(document); err != nil {
+		return err
+	}
+	if err := validateReleaseSignerContract(workflowText); err != nil {
+		return err
+	}
+	return requireReleaseAuthorityText(workflowText)
+}
+
+func requireReleaseAuthorityText(workflowText string) error {
+	for _, required := range []string{"artifact-ids: ${{ needs.release.outputs.artifact_id }}", "artifact-ids: ${{ needs.bind-release-subjects.outputs.artifact_id }}", "Validate privileged handoff", "oras cp --recursive --from-oci-layout"} {
+		if !strings.Contains(workflowText, required) {
+			return fmt.Errorf("release authority split must contain %q", required)
+		}
+	}
+	return nil
+}
+
+func validateUnprivilegedReleaseJobs(document workflowDocument) error {
+	for _, name := range []string{"build-amd64-image", "build-arm64-image", "bind-release-subjects", "release"} {
+		job, ok := document.Jobs[name]
+		if !ok || len(job.Permissions) != 1 || job.Permissions["contents"] != "read" {
+			return fmt.Errorf("release job %s must grant only contents: read", name)
+		}
+	}
+	return nil
+}
+
+func validateReleaseSigner(document workflowDocument) error {
+	signer, ok := document.Jobs["sign-release"]
+	if !ok {
+		return errors.New("release workflow must define sign-release")
+	}
+	if err := validateReleaseSignerIdentity(signer); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateReleaseSignerContract(workflowText string) error {
+	var document workflowNodeDocument
+	if err := yaml.Unmarshal([]byte(workflowText), &document); err != nil {
+		return err
+	}
+	signer, ok := document.Jobs["sign-release"]
+	if !ok {
+		return errors.New("release workflow must define sign-release")
+	}
+	digest, err := releaseSignerDigest(signer)
+	if err != nil {
+		return err
+	}
+	if digest != releaseSignerContractSHA256 {
+		return fmt.Errorf("sign-release must match the exact privileged step contract: got %s", digest)
+	}
+	return nil
+}
+
+func validateReleaseSignerIdentity(signer workflowJob) error {
+	expected := map[string]string{"artifact-metadata": "write", "attestations": "write", "contents": "read", "id-token": "write", "packages": "write"}
+	if signer.Environment.Name != "release" || !samePermissions(signer.Permissions, expected) {
+		return errors.New("sign-release must use the release environment and exact publication permissions")
+	}
+	if !needsExactly(signer.Needs, []string{"tag-policy", "preflight", "bind-release-subjects", "preflight-amd64-repro", "preflight-arm64-repro", "release"}) {
+		return errors.New("sign-release must depend directly on policy, both platform preflights, and assembly")
+	}
+	return nil
+}
+
+func releaseSignerDigest(signer yaml.Node) (string, error) {
+	content, err := yaml.Marshal(signer)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(content)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func needsExactly(node yaml.Node, expected []string) bool {
+	if node.Kind != yaml.SequenceNode || len(node.Content) != len(expected) {
+		return false
+	}
+	for index, name := range expected {
+		if node.Content[index].Value != name {
+			return false
+		}
+	}
+	return true
+}
+
+func samePermissions(actual, expected map[string]string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for name, value := range expected {
+		if actual[name] != value {
+			return false
+		}
+	}
+	return true
 }
 
 func CheckWorkflows(rootDir, policyPath string) error {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,32 +29,24 @@ type workflowNodeDocument struct {
 }
 
 type workflowJob struct {
-	Name           string    `yaml:"name"`
-	RunsOn         yaml.Node `yaml:"runs-on"`
-	TimeoutMinutes int       `yaml:"timeout-minutes"`
-	Needs          yaml.Node `yaml:"needs"`
-	Environment    struct {
+	Name        string    `yaml:"name"`
+	Needs       yaml.Node `yaml:"needs"`
+	Environment struct {
 		Name string `yaml:"name"`
 	} `yaml:"environment"`
 	Permissions map[string]string `yaml:"permissions"`
-	Env         map[string]string `yaml:"env"`
-	Outputs     map[string]string `yaml:"outputs"`
 	Steps       []workflowStep    `yaml:"steps"`
 }
 
 type workflowStep struct {
-	ID   string            `yaml:"id"`
 	Name string            `yaml:"name"`
 	Env  map[string]string `yaml:"env"`
 	Run  string            `yaml:"run"`
-	Uses string            `yaml:"uses"`
-	If   string            `yaml:"if"`
-	With yaml.Node         `yaml:"with"`
 }
 
 // This digest covers the complete parsed sign-release job. It rejects unknown
 // fields, reordered steps, changed commands, and changed action inputs.
-const releaseSignerContractSHA256 = "67e319138562ca059e2b39f89b306fa32d8cf7400d1eba119e106bef5b5bc0c9"
+const releaseSignerContractSHA256 = "de015b893267df308bf6e8904bf00b97e826e6e7183300323110189da8ec0cff"
 
 func CollectWorkflowJobNames(content []byte) ([]string, error) {
 	var document workflowDocument
@@ -163,8 +156,12 @@ func validateReleaseSigner(document workflowDocument) error {
 	if !ok {
 		return errors.New("release workflow must define sign-release")
 	}
-	if err := validateReleaseSignerIdentity(signer); err != nil {
-		return err
+	expected := map[string]string{"artifact-metadata": "write", "attestations": "write", "contents": "read", "id-token": "write", "packages": "write"}
+	if signer.Environment.Name != "release" || !maps.Equal(signer.Permissions, expected) {
+		return errors.New("sign-release must use the release environment and exact publication permissions")
+	}
+	if !needsExactly(signer.Needs, []string{"tag-policy", "preflight", "bind-release-subjects", "preflight-amd64-repro", "preflight-arm64-repro", "release"}) {
+		return errors.New("sign-release must depend directly on policy, both platform preflights, and assembly")
 	}
 	return nil
 }
@@ -178,58 +175,21 @@ func validateReleaseSignerContract(workflowText string) error {
 	if !ok {
 		return errors.New("release workflow must define sign-release")
 	}
-	digest, err := releaseSignerDigest(signer)
+	content, err := yaml.Marshal(signer)
 	if err != nil {
 		return err
 	}
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
 	if digest != releaseSignerContractSHA256 {
 		return fmt.Errorf("sign-release must match the exact privileged step contract: got %s", digest)
 	}
 	return nil
 }
 
-func validateReleaseSignerIdentity(signer workflowJob) error {
-	expected := map[string]string{"artifact-metadata": "write", "attestations": "write", "contents": "read", "id-token": "write", "packages": "write"}
-	if signer.Environment.Name != "release" || !samePermissions(signer.Permissions, expected) {
-		return errors.New("sign-release must use the release environment and exact publication permissions")
-	}
-	if !needsExactly(signer.Needs, []string{"tag-policy", "preflight", "bind-release-subjects", "preflight-amd64-repro", "preflight-arm64-repro", "release"}) {
-		return errors.New("sign-release must depend directly on policy, both platform preflights, and assembly")
-	}
-	return nil
-}
-
-func releaseSignerDigest(signer yaml.Node) (string, error) {
-	content, err := yaml.Marshal(signer)
-	if err != nil {
-		return "", err
-	}
-	digest := sha256.Sum256(content)
-	return hex.EncodeToString(digest[:]), nil
-}
-
 func needsExactly(node yaml.Node, expected []string) bool {
-	if node.Kind != yaml.SequenceNode || len(node.Content) != len(expected) {
-		return false
-	}
-	for index, name := range expected {
-		if node.Content[index].Value != name {
-			return false
-		}
-	}
-	return true
-}
-
-func samePermissions(actual, expected map[string]string) bool {
-	if len(actual) != len(expected) {
-		return false
-	}
-	for name, value := range expected {
-		if actual[name] != value {
-			return false
-		}
-	}
-	return true
+	return node.Kind == yaml.SequenceNode &&
+		slices.EqualFunc(node.Content, expected, func(actual *yaml.Node, name string) bool { return actual.Value == name })
 }
 
 func CheckWorkflows(rootDir, policyPath string) error {

--- a/policy/retention-policy.json
+++ b/policy/retention-policy.json
@@ -14,6 +14,10 @@
     },
     "release.yml": {
       "workcell-release-preflight": 90,
+      "workcell-release-preflight-subjects": 90,
+      "workcell-release-image-amd64": 7,
+      "workcell-release-image-arm64": 7,
+      "workcell-release-unsigned": 7,
       "workcell-release-install-candidate": 90,
       "workcell-release-artifacts": 7
     },

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -135,11 +135,23 @@
       "local_mode": "none",
       "github_only_reason": "pull_request_target metadata policy remains GitHub-only"
     },
+    "release.yml/build-amd64-image": {
+      "profiles": ["release-preflight"],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "native amd64 release image artifact build requires the GitHub-hosted release workflow"
+    },
     "release.yml/build-arm64-image": {
       "profiles": ["release-preflight"],
       "authority": "release-only",
       "local_mode": "none",
-      "github_only_reason": "native arm64 release image build and GHCR push remain GitHub-only and gated on the release environment"
+      "github_only_reason": "native arm64 release image artifact build requires the GitHub-hosted arm64 runner"
+    },
+    "release.yml/bind-release-subjects": {
+      "profiles": ["release-preflight"],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "independent release-subject binding consumes GitHub-hosted architecture and preflight artifacts"
     },
     "release.yml/codeql-preflight[build-mode=autobuild,language=go]": {
       "profiles": ["release-preflight"],
@@ -205,7 +217,13 @@
       "profiles": ["release-preflight"],
       "authority": "release-only",
       "local_mode": "none",
-      "github_only_reason": "release artifact signing, attestation, and registry publication remain GitHub-only"
+      "github_only_reason": "bound release artifact assembly depends on GitHub-hosted architecture artifacts"
+    },
+    "release.yml/sign-release": {
+      "profiles": ["release-preflight"],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "release-approved registry publication, signing, and attestation require GitHub credentials and hosted release state"
     },
     "release.yml/publish-github-release": {
       "profiles": ["release-preflight"],

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -508,11 +508,11 @@
       "github_only_reason": "pull_request_target metadata policy remains GitHub-only"
     },
     {
-      "id": "release.yml/build-arm64-image",
+      "id": "release.yml/bind-release-subjects",
       "workflow_path": ".github/workflows/release.yml",
       "workflow_name": "Release",
-      "job_id": "build-arm64-image",
-      "job_name": "Build native arm64 release image",
+      "job_id": "bind-release-subjects",
+      "job_name": "Bind independent release subjects",
       "workflow_events": [
         "push"
       ],
@@ -521,7 +521,39 @@
       ],
       "authority": "release-only",
       "local_mode": "none",
-      "github_only_reason": "native arm64 release image build and GHCR push remain GitHub-only and gated on the release environment"
+      "github_only_reason": "independent release-subject binding consumes GitHub-hosted architecture and preflight artifacts"
+    },
+    {
+      "id": "release.yml/build-amd64-image",
+      "workflow_path": ".github/workflows/release.yml",
+      "workflow_name": "Release",
+      "job_id": "build-amd64-image",
+      "job_name": "Build native amd64 release image artifact",
+      "workflow_events": [
+        "push"
+      ],
+      "profiles": [
+        "release-preflight"
+      ],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "native amd64 release image artifact build requires the GitHub-hosted release workflow"
+    },
+    {
+      "id": "release.yml/build-arm64-image",
+      "workflow_path": ".github/workflows/release.yml",
+      "workflow_name": "Release",
+      "job_id": "build-arm64-image",
+      "job_name": "Build native arm64 release image artifact",
+      "workflow_events": [
+        "push"
+      ],
+      "profiles": [
+        "release-preflight"
+      ],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "native arm64 release image artifact build requires the GitHub-hosted arm64 runner"
     },
     {
       "id": "release.yml/codeql-preflight[build-mode=autobuild,language=go]",
@@ -724,7 +756,7 @@
       "workflow_path": ".github/workflows/release.yml",
       "workflow_name": "Release",
       "job_id": "release",
-      "job_name": "Publish release artifacts",
+      "job_name": "Assemble release artifacts",
       "workflow_events": [
         "push"
       ],
@@ -733,7 +765,23 @@
       ],
       "authority": "release-only",
       "local_mode": "none",
-      "github_only_reason": "release artifact signing, attestation, and registry publication remain GitHub-only"
+      "github_only_reason": "bound release artifact assembly depends on GitHub-hosted architecture artifacts"
+    },
+    {
+      "id": "release.yml/sign-release",
+      "workflow_path": ".github/workflows/release.yml",
+      "workflow_name": "Release",
+      "job_id": "sign-release",
+      "job_name": "Publish and sign bound release artifacts",
+      "workflow_events": [
+        "push"
+      ],
+      "profiles": [
+        "release-preflight"
+      ],
+      "authority": "release-only",
+      "local_mode": "none",
+      "github_only_reason": "release-approved registry publication, signing, and attestation require GitHub credentials and hosted release state"
     },
     {
       "id": "release.yml/tag-policy",


### PR DESCRIPTION
Remove registry, signing, and attestation authority from every job that builds or assembles release content.

## Summary

- `build-amd64-image` is a new job: the amd64 runtime image is built to an OCI archive instead of pushed by digest from the publishing job. `build-arm64-image` loses its GHCR login, its `packages: write` scope, and its `release` environment gate, and now emits the same kind of archive.
- Each builder emits a signed handoff manifest (`create-release-image-handoff`) binding repository, run, tag, commit, platform, image digest, preflight manifest and config digests, and the archive SHA-256. The Go validator walks the OCI archive, rejects non-canonical, special, unexpected, and duplicate members, verifies every blob against its own name, and requires exactly one platform descriptor for the bound manifest digest.
- `bind-release-subjects` is a new read-only job that independently constructs the nine non-image signing subjects before the approval gate.
- `release` drops to `contents: read` and only assembles: it verifies both bound archives against preflight, builds the multi-arch OCI layout offline with pinned ORAS, and uploads an unsigned bundle. `docker buildx imagetools` no longer assembles the published manifest.
- `sign-release` is the only privileged job. It runs in the `release` environment, does not check out or execute repository code, validates the handoff and every byte of the bound subjects before publishing the layout, then signs and attests.
- `ValidateReleaseWorkflowAuthoritySplit` enforces the split: the four unprivileged jobs must grant only `contents: read`, the signer must hold the exact environment, permissions, and dependencies, and the whole parsed `sign-release` job must match a pinned SHA-256 contract so an added step, changed command, or changed action input fails the check.
- Threat model, workflow, releasing, and retention docs plus the lane and retention policies are updated for the new jobs and artifacts.

## Testing

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./internal/metadatautil/ -count=1` — ok, covering the new handoff and authority-split suites.
- `go test ./internal/host/release/ -count=1` — ok (asset inventory, tag-policy gate, and inventory-parser mutation suites).
- `go test ./... -count=1` — all packages ok; `internal/host/c3certify` and `internal/host/launcher` each flake once under full-suite load and pass in isolation on this branch and on `main`.
- `actionlint .github/workflows/release.yml` — no findings.
- `zizmor .github/workflows/release.yml` — no findings.