### PR TITLE
Add the apt broker socket server and SO_PEERCRED admission

### DIFF
--- a/internal/aptbroker/peer_linux.go
+++ b/internal/aptbroker/peer_linux.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package aptbroker
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func validateServerSupport() error { return nil }
+
+func peerUID(connection *net.UnixConn) (uint32, error) {
+	uid, err := socketPeerUID(connection)
+	if err != nil {
+		return 0, err
+	}
+	if uid == 0 {
+		return 0, fmt.Errorf("root peer is not allowed")
+	}
+	return uid, nil
+}
+
+func socketPeerUID(connection *net.UnixConn) (uint32, error) {
+	raw, err := connection.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var uid uint32
+	var controlErr error
+	err = raw.Control(func(fd uintptr) {
+		credential, err := unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+		if err != nil {
+			controlErr = err
+			return
+		}
+		uid = credential.Uid
+	})
+	if err != nil {
+		return 0, err
+	}
+	if controlErr != nil {
+		return 0, controlErr
+	}
+	return uid, nil
+}
+
+func fileUID(info os.FileInfo) uint32 {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return stat.Uid
+	}
+	return ^uint32(0)
+}

--- a/internal/aptbroker/peer_other.go
+++ b/internal/aptbroker/peer_other.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build !linux
+
+package aptbroker
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func validateServerSupport() error {
+	return fmt.Errorf("apt broker server is unsupported on this platform")
+}
+
+func peerUID(*net.UnixConn) (uint32, error) {
+	return 0, fmt.Errorf("apt broker server is unsupported on this platform")
+}
+func fileUID(os.FileInfo) uint32 {
+	return ^uint32(0)
+}

--- a/internal/aptbroker/server.go
+++ b/internal/aptbroker/server.go
@@ -295,13 +295,40 @@ func validateSocketParent(path string, requireRoot bool) error {
 	if !isTrustedSocketDirectory(parent) {
 		return fmt.Errorf("apt broker socket parent is not trusted")
 	}
-	if requireRoot && fileUID(parent) != 0 {
+	if !requireRoot {
+		return nil
+	}
+	if fileUID(parent) != 0 {
 		return fmt.Errorf("apt broker socket parent is not root-owned")
 	}
-	if requireRoot && parent.Mode().Perm() != 0o755 {
+	if parent.Mode().Perm() != 0o755 {
 		return fmt.Errorf("apt broker socket parent mode is not 0755")
 	}
-	return nil
+	return validateSocketAncestry(path)
+}
+
+// Checking the immediate parent alone trusts a pathname the bind resolves for
+// itself a moment later. Any ancestor that an unprivileged uid can replace,
+// including a symlink the parent Stat above would have followed, could be
+// repointed in between so the socket lands somewhere else. Requiring every
+// ancestor to be a real directory that only root can write removes the uid that
+// would perform the swap, rather than trying to win the race against it.
+func validateSocketAncestry(path string) error {
+	for current := path; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("apt broker socket ancestor %s is not a directory", current)
+		}
+		if fileUID(info) != 0 || info.Mode().Perm()&0o022 != 0 {
+			return fmt.Errorf("apt broker socket ancestor %s is writable outside root", current)
+		}
+		if filepath.Dir(current) == current {
+			return nil
+		}
+	}
 }
 
 func isTrustedSocketDirectory(info os.FileInfo) bool {

--- a/internal/aptbroker/server.go
+++ b/internal/aptbroker/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -252,13 +253,37 @@ func listenSocket(path string, requireRoot bool) (*net.UnixListener, error) {
 	if err := prepareSocketPath(path); err != nil {
 		return nil, err
 	}
-	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	listener, err := bindSocket(path)
 	if err != nil {
 		return nil, err
 	}
-	if err := secureSocket(path, listener, requireRoot); err != nil {
+	if err := validateSocket(path, requireRoot); err != nil {
+		_ = listener.Close()
 		return nil, err
 	}
+	return listener, nil
+}
+
+// The socket carries its final mode out of the bind itself. Applying the mode
+// to the pathname afterwards lets anyone who can write the parent directory
+// swap in a symlink between the two steps and redirect a privileged chmod onto
+// a file of their choosing. The bind also already owns the socket as the server
+// uid, so an explicit chown would reopen that same window for an ownership the
+// kernel has given us anyway; validateSocket confirms it instead. Close must
+// not unlink either, or it would delete whatever holds the pathname at shutdown
+// before removeSocket can check that it is still our socket.
+//
+// ponytail: umask is process-global, which is safe here only because Serve
+// binds once during startup. Bind through a parent directory descriptor if this
+// ever has to run beside other file creation.
+func bindSocket(path string) (*net.UnixListener, error) {
+	previous := syscall.Umask(0o111)
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	syscall.Umask(previous)
+	if err != nil {
+		return nil, err
+	}
+	listener.SetUnlinkOnClose(false)
 	return listener, nil
 }
 
@@ -292,30 +317,6 @@ func prepareSocketPath(path string) error {
 		return err
 	}
 	return fmt.Errorf("apt broker socket already exists")
-}
-
-func secureSocket(path string, listener *net.UnixListener, requireRoot bool) error {
-	fail := func(err error) error {
-		_ = listener.Close()
-		return err
-	}
-	if err := setSocketAccess(path, requireRoot); err != nil {
-		return fail(err)
-	}
-	if err := validateSocket(path, requireRoot); err != nil {
-		return fail(err)
-	}
-	return nil
-}
-
-func setSocketAccess(path string, requireRoot bool) error {
-	if err := os.Chmod(path, 0o666); err != nil {
-		return err
-	}
-	if requireRoot {
-		return os.Chown(path, 0, 0)
-	}
-	return nil
 }
 
 func validateSocket(path string, requireRoot bool) error {

--- a/internal/aptbroker/server.go
+++ b/internal/aptbroker/server.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -257,34 +256,44 @@ func listenSocket(path string, requireRoot bool) (*net.UnixListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := validateSocket(path, requireRoot); err != nil {
-		_ = listener.Close()
+	if err := secureSocket(path, listener, requireRoot); err != nil {
 		return nil, err
 	}
 	return listener, nil
 }
 
-// The socket carries its final mode out of the bind itself. Applying the mode
-// to the pathname afterwards lets anyone who can write the parent directory
-// swap in a symlink between the two steps and redirect a privileged chmod onto
-// a file of their choosing. The bind also already owns the socket as the server
-// uid, so an explicit chown would reopen that same window for an ownership the
-// kernel has given us anyway; validateSocket confirms it instead. Close must
-// not unlink either, or it would delete whatever holds the pathname at shutdown
-// before removeSocket can check that it is still our socket.
-//
-// ponytail: umask is process-global, which is safe here only because Serve
-// binds once during startup. Bind through a parent directory descriptor if this
-// ever has to run beside other file creation.
+// Close must not unlink, or it would delete whatever holds the pathname at
+// shutdown before removeSocket can check that it is still our socket.
 func bindSocket(path string) (*net.UnixListener, error) {
-	previous := syscall.Umask(0o111)
 	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
-	syscall.Umask(previous)
 	if err != nil {
 		return nil, err
 	}
 	listener.SetUnlinkOnClose(false)
 	return listener, nil
+}
+
+// No chown is made: the bind already created the socket owned by the server
+// uid, so the kernel has given us the ownership validateSocket goes on to
+// confirm, and asking for it again by pathname would only add a way to be
+// pointed somewhere else. The mode does have to be set after the bind. That is
+// safe because a privileged deployment sets RequireRootSocket, and
+// validateSocketParent then proves no unprivileged uid can write any ancestor,
+// so none can substitute a symlink for the socket in between; without the flag
+// the server holds no privilege the mode change could abuse. validateSocket
+// re-checks the result with Lstat and fails closed if it is not our socket.
+func secureSocket(path string, listener *net.UnixListener, requireRoot bool) error {
+	fail := func(err error) error {
+		removeSocket(path, listener)
+		return err
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		return fail(err)
+	}
+	if err := validateSocket(path, requireRoot); err != nil {
+		return fail(err)
+	}
+	return nil
 }
 
 func validateSocketParent(path string, requireRoot bool) error {

--- a/internal/aptbroker/server.go
+++ b/internal/aptbroker/server.go
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package aptbroker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultHelperPath    = "/usr/local/libexec/workcell/apt-helper.sh"
+	DefaultTimeout       = 300 * time.Second
+	MaxTimeout           = 900 * time.Second
+	maxConcurrent        = 4
+	requestReadTimeout   = 10 * time.Second
+	responseWriteTimeout = 10 * time.Second
+	serverShutdownLimit  = 5 * time.Second
+)
+
+type ServerConfig struct {
+	SocketPath        string
+	HelperPath        string
+	Timeout           time.Duration
+	MaxConcurrent     int
+	ExpectedPeerUID   uint32
+	RequireRootSocket bool
+	ErrorWriter       io.Writer
+	Ready             func() error
+}
+
+func (c *ServerConfig) normalize() error {
+	c.applyDefaults()
+	if !validHelperTimeout(c.Timeout) {
+		return fmt.Errorf("invalid helper timeout")
+	}
+	if !validConcurrency(c.MaxConcurrent) {
+		return fmt.Errorf("invalid concurrent request limit")
+	}
+	if c.ExpectedPeerUID == 0 {
+		return fmt.Errorf("peer uid is required")
+	}
+	return nil
+}
+
+func validHelperTimeout(timeout time.Duration) bool {
+	return timeout > 0 && timeout <= MaxTimeout
+}
+
+func validConcurrency(concurrency int) bool {
+	return concurrency >= 1 && concurrency <= maxConcurrent
+}
+
+func (c *ServerConfig) applyDefaults() {
+	if c.SocketPath == "" {
+		c.SocketPath = DefaultSocketPath
+	}
+	if c.HelperPath == "" {
+		c.HelperPath = DefaultHelperPath
+	}
+	if c.Timeout == 0 {
+		c.Timeout = DefaultTimeout
+	}
+	if c.MaxConcurrent == 0 {
+		c.MaxConcurrent = maxConcurrent
+	}
+}
+
+func (c ServerConfig) report(err error) {
+	if err == nil {
+		return
+	}
+	writer := c.ErrorWriter
+	if writer == nil {
+		writer = os.Stderr
+	}
+	_, _ = fmt.Fprintf(writer, "Workcell apt broker: %v\n", err)
+}
+
+func Serve(ctx context.Context, config ServerConfig) error {
+	if err := validateServerSupport(); err != nil {
+		return err
+	}
+	if err := config.normalize(); err != nil {
+		return err
+	}
+	listener, err := listenSocket(config.SocketPath, config.RequireRootSocket)
+	if err != nil {
+		return err
+	}
+	defer removeSocket(config.SocketPath, listener)
+	if config.Ready != nil {
+		if err := config.Ready(); err != nil {
+			return fmt.Errorf("complete startup handshake: %w", err)
+		}
+	}
+	serverContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go closeListenerOnCancel(serverContext, listener)
+	return acceptConnections(serverContext, cancel, listener, config)
+}
+
+func closeListenerOnCancel(ctx context.Context, listener *net.UnixListener) {
+	<-ctx.Done()
+	_ = listener.Close()
+}
+
+func acceptConnections(ctx context.Context, cancel context.CancelFunc, listener *net.UnixListener, config ServerConfig) error {
+	admitted := make(chan struct{}, config.MaxConcurrent)
+	var handlers sync.WaitGroup
+	for {
+		connection, err := listener.AcceptUnix()
+		if err != nil {
+			acceptErr := acceptError(ctx, err)
+			cancel()
+			return errors.Join(acceptErr, waitForHandlers(&handlers, serverShutdownLimit))
+		}
+		if err := admitConnection(connection, config.ExpectedPeerUID, admitted); err != nil {
+			config.report(err)
+			continue
+		}
+		handlers.Add(1)
+		go serveConnection(ctx, connection, config, admitted, &handlers)
+	}
+}
+
+func waitForHandlers(handlers *sync.WaitGroup, limit time.Duration) error {
+	done := make(chan struct{})
+	go func() { handlers.Wait(); close(done) }()
+	timer := time.NewTimer(limit)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("apt broker handler shutdown exceeded limit")
+	}
+}
+
+func acceptError(ctx context.Context, err error) error {
+	if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+func admitConnection(connection *net.UnixConn, expectedUID uint32, admitted chan<- struct{}) error {
+	uid, err := peerUID(connection)
+	if err := validatePeerUID(uid, err, expectedUID); err != nil {
+		_ = connection.Close()
+		return err
+	}
+	if !reserveAdmission(admitted) {
+		_ = connection.Close()
+		return fmt.Errorf("concurrent request limit reached")
+	}
+	return nil
+}
+
+func validatePeerUID(uid uint32, peerErr error, expectedUID uint32) error {
+	if peerErr != nil {
+		return fmt.Errorf("inspect peer credentials: %w", peerErr)
+	}
+	if uid == 0 || uid != expectedUID {
+		return fmt.Errorf("reject peer uid %d", uid)
+	}
+	return nil
+}
+
+func reserveAdmission(admitted chan<- struct{}) bool {
+	select {
+	case admitted <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func serveConnection(ctx context.Context, connection *net.UnixConn, config ServerConfig, admitted <-chan struct{}, handlers *sync.WaitGroup) {
+	defer handlers.Done()
+	defer func() { <-admitted }()
+	defer connection.Close()
+	finished := make(chan struct{})
+	defer close(finished)
+	go closeConnectionOnCancel(ctx, connection, finished)
+	config.report(handleConnection(ctx, connection, config))
+}
+
+func handleConnection(ctx context.Context, connection *net.UnixConn, config ServerConfig) error {
+	request, err := readRequest(connection)
+	if err != nil {
+		return err
+	}
+	response, err := runOwnedHelper(ctx, connection, request, config.helperConfig())
+	if err != nil {
+		return fmt.Errorf("run helper: %w", err)
+	}
+	return writeResponse(connection, response)
+}
+
+func readRequest(connection *net.UnixConn) (Request, error) {
+	if err := connection.SetReadDeadline(time.Now().Add(requestReadTimeout)); err != nil {
+		return Request{}, fmt.Errorf("set request deadline: %w", err)
+	}
+	body, err := readFrame(connection, requestMagic, MaxRequestBytes)
+	if err != nil {
+		return Request{}, fmt.Errorf("read request: %w", err)
+	}
+	request, err := decodeRequest(body)
+	if err != nil {
+		return Request{}, fmt.Errorf("decode request: %w", err)
+	}
+	if err := connection.SetReadDeadline(time.Time{}); err != nil {
+		return Request{}, fmt.Errorf("clear request deadline: %w", err)
+	}
+	return request, nil
+}
+
+func writeResponse(connection *net.UnixConn, response Response) error {
+	frame, err := responseFrame(response)
+	if err != nil {
+		return fmt.Errorf("encode response: %w", err)
+	}
+	if err := connection.SetWriteDeadline(time.Now().Add(responseWriteTimeout)); err != nil {
+		return fmt.Errorf("set response deadline: %w", err)
+	}
+	if _, err := connection.Write(frame); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
+	return nil
+}
+
+func closeConnectionOnCancel(ctx context.Context, connection *net.UnixConn, finished <-chan struct{}) {
+	select {
+	case <-ctx.Done():
+		_ = connection.Close()
+	case <-finished:
+	}
+}
+
+func listenSocket(path string, requireRoot bool) (*net.UnixListener, error) {
+	if err := validateSocketParent(filepath.Dir(path), requireRoot); err != nil {
+		return nil, err
+	}
+	if err := prepareSocketPath(path); err != nil {
+		return nil, err
+	}
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+	if err := secureSocket(path, listener, requireRoot); err != nil {
+		return nil, err
+	}
+	return listener, nil
+}
+
+func validateSocketParent(path string, requireRoot bool) error {
+	parent, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !isTrustedSocketDirectory(parent) {
+		return fmt.Errorf("apt broker socket parent is not trusted")
+	}
+	if requireRoot && fileUID(parent) != 0 {
+		return fmt.Errorf("apt broker socket parent is not root-owned")
+	}
+	if requireRoot && parent.Mode().Perm() != 0o755 {
+		return fmt.Errorf("apt broker socket parent mode is not 0755")
+	}
+	return nil
+}
+
+func isTrustedSocketDirectory(info os.FileInfo) bool {
+	return info.IsDir() && info.Mode().Perm()&0o022 == 0
+}
+
+func prepareSocketPath(path string) error {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("apt broker socket already exists")
+}
+
+func secureSocket(path string, listener *net.UnixListener, requireRoot bool) error {
+	fail := func(err error) error {
+		_ = listener.Close()
+		return err
+	}
+	if err := setSocketAccess(path, requireRoot); err != nil {
+		return fail(err)
+	}
+	if err := validateSocket(path, requireRoot); err != nil {
+		return fail(err)
+	}
+	return nil
+}
+
+func setSocketAccess(path string, requireRoot bool) error {
+	if err := os.Chmod(path, 0o666); err != nil {
+		return err
+	}
+	if requireRoot {
+		return os.Chown(path, 0, 0)
+	}
+	return nil
+}
+
+func validateSocket(path string, requireRoot bool) error {
+	info, err := os.Lstat(path)
+	if !isSocketFile(info, err) {
+		return fmt.Errorf("apt broker socket verification failed")
+	}
+	if requireRoot && fileUID(info) != 0 {
+		return fmt.Errorf("apt broker socket is not root-owned")
+	}
+	if info.Mode().Perm() != 0o666 {
+		return fmt.Errorf("apt broker socket mode is not 0666")
+	}
+	return nil
+}
+
+func isSocketFile(info os.FileInfo, err error) bool {
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.Mode()&os.ModeSocket != 0
+}
+
+func removeSocket(path string, listener *net.UnixListener) {
+	_ = listener.Close()
+	if isSocketFile(os.Lstat(path)) {
+		_ = os.Remove(path)
+	}
+}
+
+func (c ServerConfig) helperConfig() helperConfig {
+	return helperConfig{path: c.HelperPath, timeout: c.Timeout, report: c.report}
+}

--- a/internal/aptbroker/server.go
+++ b/internal/aptbroker/server.go
@@ -32,8 +32,10 @@ type ServerConfig struct {
 	MaxConcurrent     int
 	ExpectedPeerUID   uint32
 	RequireRootSocket bool
-	ErrorWriter       io.Writer
-	Ready             func() error
+	// ErrorWriter receives diagnostics from concurrent connection handlers, so
+	// it must be safe for concurrent use. The os.Stderr default is.
+	ErrorWriter io.Writer
+	Ready       func() error
 }
 
 func (c *ServerConfig) normalize() error {
@@ -276,12 +278,12 @@ func bindSocket(path string) (*net.UnixListener, error) {
 // No chown is made: the bind already created the socket owned by the server
 // uid, so the kernel has given us the ownership validateSocket goes on to
 // confirm, and asking for it again by pathname would only add a way to be
-// pointed somewhere else. The mode does have to be set after the bind. That is
-// safe because a privileged deployment sets RequireRootSocket, and
-// validateSocketParent then proves no unprivileged uid can write any ancestor,
-// so none can substitute a symlink for the socket in between; without the flag
-// the server holds no privilege the mode change could abuse. validateSocket
-// re-checks the result with Lstat and fails closed if it is not our socket.
+// pointed somewhere else. The mode does have to be set after the bind, which is
+// safe because validateSocketParent refuses to let a root server reach this
+// point unless every ancestor is root-writable only, so no unprivileged uid can
+// substitute a symlink for the socket in between. A non-root server holds no
+// privilege the mode change could abuse. validateSocket re-checks the result
+// with Lstat and fails closed if it is not our socket.
 func secureSocket(path string, listener *net.UnixListener, requireRoot bool) error {
 	fail := func(err error) error {
 		removeSocket(path, listener)
@@ -304,16 +306,22 @@ func validateSocketParent(path string, requireRoot bool) error {
 	if !isTrustedSocketDirectory(parent) {
 		return fmt.Errorf("apt broker socket parent is not trusted")
 	}
-	if !requireRoot {
-		return nil
+	if requireRoot {
+		if fileUID(parent) != 0 {
+			return fmt.Errorf("apt broker socket parent is not root-owned")
+		}
+		if parent.Mode().Perm() != 0o755 {
+			return fmt.Errorf("apt broker socket parent mode is not 0755")
+		}
 	}
-	if fileUID(parent) != 0 {
-		return fmt.Errorf("apt broker socket parent is not root-owned")
+	// A root server must never operate on a pathname inside a directory an
+	// unprivileged uid can write, whether or not the caller remembered to ask
+	// for it. Deciding this from the running euid rather than the flag keeps the
+	// guarantee from depending on the configuration being correct.
+	if requireRoot || os.Geteuid() == 0 {
+		return validateSocketAncestry(path)
 	}
-	if parent.Mode().Perm() != 0o755 {
-		return fmt.Errorf("apt broker socket parent mode is not 0755")
-	}
-	return validateSocketAncestry(path)
+	return nil
 }
 
 // Checking the immediate parent alone trusts a pathname the bind resolves for

--- a/internal/aptbroker/server_linux_test.go
+++ b/internal/aptbroker/server_linux_test.go
@@ -51,6 +51,21 @@ func TestServerReportsMalformedRequest(t *testing.T) {
 	}
 }
 
+// A privileged socket path must be unreachable from any directory an
+// unprivileged uid can write, so no ancestor can be repointed after validation.
+func TestValidateSocketAncestryRejectsMutableAncestors(t *testing.T) {
+	if err := validateSocketAncestry("/"); err != nil {
+		t.Fatalf("root-owned ancestry was rejected: %v", err)
+	}
+	// /tmp is world-writable, so nothing beneath it can be trusted.
+	if err := validateSocketAncestry("/tmp"); err == nil {
+		t.Fatal("world-writable ancestor was accepted")
+	}
+	if err := validateSocketAncestry(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("missing ancestor was accepted")
+	}
+}
+
 func startTestBroker(t *testing.T) (context.Context, string) {
 	t.Helper()
 	if os.Getuid() == 0 {

--- a/internal/aptbroker/server_linux_test.go
+++ b/internal/aptbroker/server_linux_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package aptbroker
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServeRoundTripPreservesHelperResult(t *testing.T) {
+	ctx, socket := startTestBroker(t)
+	lookup := func(string) (string, bool) { return "noninteractive", true }
+	response, status, err := RunClient(ctx, socket, []string{"apt-get"}, []string{"DEBIAN_FRONTEND"}, lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 37 || response.Status != status {
+		t.Fatalf("client status = %d, response status = %d", status, response.Status)
+	}
+	if string(response.Stdout) != "noninteractive" || !strings.HasSuffix(string(response.Stderr), "fixture-stderr") {
+		t.Fatalf("helper stdout = %q, stderr = %q", response.Stdout, response.Stderr)
+	}
+}
+
+func TestServerReportsMalformedRequest(t *testing.T) {
+	server, client := unixConnectionPair(t)
+	defer server.Close()
+	defer client.Close()
+	if _, err := client.Write([]byte("invalid frame")); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	var diagnostics bytes.Buffer
+	err := handleConnection(context.Background(), server, ServerConfig{ErrorWriter: &diagnostics})
+	if err == nil || diagnostics.Len() != 0 {
+		t.Fatalf("handleConnection() = %v, premature diagnostics = %q", err, diagnostics.String())
+	}
+	ServerConfig{ErrorWriter: &diagnostics}.report(err)
+	if got := diagnostics.String(); got == "" || !strings.Contains(got, "read request") {
+		t.Fatalf("diagnostic = %q", got)
+	}
+}
+
+func startTestBroker(t *testing.T) (context.Context, string) {
+	t.Helper()
+	if os.Getuid() == 0 {
+		t.Skip("round trip requires a non-root client")
+	}
+	socket := filepath.Join(shortSocketDir(t), "broker.sock")
+	helper := writeHelper(t, "printf '%s' \"$DEBIAN_FRONTEND\"\nprintf fixture-stderr >&2\nexit 37\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	finished := make(chan error, 1)
+	go func() {
+		finished <- Serve(ctx, ServerConfig{SocketPath: socket, HelperPath: helper, ExpectedPeerUID: uint32(os.Getuid())})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		awaitTestBrokerShutdown(t, finished)
+	})
+	waitForTestBrokerSocket(t, ctx, socket)
+	return ctx, socket
+}
+
+func waitForTestBrokerSocket(t *testing.T, ctx context.Context, socket string) {
+	t.Helper()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		info, err := os.Lstat(socket)
+		if isSocketFile(info, err) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("broker socket did not become ready: %v", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func awaitTestBrokerShutdown(t *testing.T, finished <-chan error) {
+	t.Helper()
+	select {
+	case err := <-finished:
+		if err != nil {
+			t.Errorf("broker shutdown failed: %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		t.Error("broker did not finish after cancellation")
+	}
+}

--- a/internal/aptbroker/server_test.go
+++ b/internal/aptbroker/server_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package aptbroker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWaitForHandlersHasTerminalBound(t *testing.T) {
+	var handlers sync.WaitGroup
+	handlers.Add(1)
+	if err := waitForHandlers(&handlers, time.Millisecond); err == nil {
+		t.Fatal("handler wait had no terminal bound")
+	}
+	handlers.Done()
+}
+
+func TestPrepareSocketPathRejectsSymlink(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broker.sock")
+	if err := os.Symlink("target", path); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareSocketPath(path); err == nil {
+		t.Fatal("symlink socket path was accepted")
+	}
+}
+
+func TestValidateSocketParentRejectsWritableDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "socket-root")
+	if err := os.Mkdir(path, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSocketParent(path, false); err == nil {
+		t.Fatal("writable socket parent was accepted")
+	}
+}
+
+func TestValidateSocketParentRequiresExactRootMode(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root ownership check requires root")
+	}
+	path := filepath.Join(t.TempDir(), "socket-root")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSocketParent(path, true); err == nil {
+		t.Fatal("root-owned socket parent with mode 0700 was accepted")
+	}
+}
+
+func TestServerConfigRejectsUnsafeLimits(t *testing.T) {
+	for _, config := range []ServerConfig{
+		{ExpectedPeerUID: 0},
+		{ExpectedPeerUID: 1, MaxConcurrent: maxConcurrent + 1},
+		{ExpectedPeerUID: 1, Timeout: MaxTimeout + time.Second},
+	} {
+		if err := config.normalize(); err == nil {
+			t.Fatal("unsafe server configuration was accepted")
+		}
+	}
+}
+
+func TestReserveAdmissionRejectsExcessConnection(t *testing.T) {
+	admitted := make(chan struct{}, maxConcurrent)
+	for range maxConcurrent {
+		if !reserveAdmission(admitted) {
+			t.Fatal("admission closed before the configured limit")
+		}
+	}
+	if reserveAdmission(admitted) {
+		t.Fatal("admission exceeded the configured limit")
+	}
+}
+
+func TestValidatePeerUIDRejectsUntrustedPeers(t *testing.T) {
+	probeErr := errors.New("peer probe failed")
+	for _, test := range []struct {
+		uid      uint32
+		probeErr error
+	}{
+		{uid: 1000, probeErr: probeErr},
+		{uid: 0},
+		{uid: 1001},
+	} {
+		if err := validatePeerUID(test.uid, test.probeErr, 1000); err == nil {
+			t.Fatalf("untrusted peer uid %d was accepted", test.uid)
+		}
+	}
+	if err := validatePeerUID(1000, nil, 1000); err != nil {
+		t.Fatalf("expected peer was rejected: %v", err)
+	}
+}
+
+func TestListenSocketSetsModeAndPreservesReplacement(t *testing.T) {
+	path := filepath.Join(shortSocketDir(t), "broker.sock")
+	listener, err := listenSocket(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode().Perm() != 0o666 || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("socket info = (%v, %v)", info, err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removeSocket(path, listener)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("replacement was removed: %v", err)
+	}
+}
+
+func TestPrepareSocketPathRejectsExistingSocketWithoutRemovingIt(t *testing.T) {
+	path := filepath.Join(shortSocketDir(t), "broker.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	if err := prepareSocketPath(path); err == nil {
+		t.Fatal("managed startup accepted an existing socket")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("existing socket was removed: (%v, %v)", info, err)
+	}
+}
+
+func TestServeRunsReadinessBeforeAccept(t *testing.T) {
+	if validateServerSupport() != nil {
+		t.Skip("server is unsupported on this platform")
+	}
+	path := filepath.Join(shortSocketDir(t), "broker.sock")
+	ready := make(chan struct{})
+	release := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	finished := make(chan error, 1)
+	go func() {
+		finished <- Serve(ctx, ServerConfig{
+			SocketPath:      path,
+			ExpectedPeerUID: uint32(os.Getuid()),
+			Ready: func() error {
+				close(ready)
+				<-release
+				return nil
+			},
+		})
+	}()
+	<-ready
+	connection, err := net.DialTimeout("unix", path, 20*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Write([]byte("not accepted yet")); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	cancel()
+	connection.Close()
+	if err := <-finished; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServeRejectsUnsupportedPlatformBeforeSocketCreation(t *testing.T) {
+	if validateServerSupport() == nil {
+		t.Skip("server is supported on this platform")
+	}
+	path := filepath.Join(t.TempDir(), "broker.sock")
+	err := Serve(context.Background(), ServerConfig{SocketPath: path, ExpectedPeerUID: 1})
+	if err == nil {
+		t.Fatal("unsupported server unexpectedly started")
+	}
+}
+
+func TestHelperConfigurationPreservesExecutionAndDiagnostics(t *testing.T) {
+	var diagnostics bytes.Buffer
+	config := ServerConfig{HelperPath: "/fixture/helper", Timeout: 7 * time.Second, ErrorWriter: &diagnostics}
+	helper := config.helperConfig()
+	if helper.path != config.HelperPath || helper.timeout != config.Timeout {
+		t.Fatalf("helper configuration = %#v", helper)
+	}
+	if helper.report == nil {
+		t.Fatal("helper diagnostic callback is missing")
+	}
+	helper.report(nil)
+	if diagnostics.Len() != 0 {
+		t.Fatalf("nil error produced diagnostics: %q", diagnostics.String())
+	}
+	helper.report(errors.New("fixture cleanup failure"))
+	if got := diagnostics.String(); got != "Workcell apt broker: fixture cleanup failure\n" {
+		t.Fatalf("helper diagnostic = %q", got)
+	}
+}
+
+// A bound socket path must fit the AF_UNIX sun_path limit, which the test name
+// that t.TempDir() embeds overruns under the long TMPDIR that CI sets. Tests
+// that bind a real path need a short directory instead.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	directory, err := os.MkdirTemp("/tmp", "aptbroker-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
+	return directory
+}

--- a/internal/aptbroker/server_test.go
+++ b/internal/aptbroker/server_test.go
@@ -231,6 +231,9 @@ func TestHelperConfigurationPreservesExecutionAndDiagnostics(t *testing.T) {
 // that bind a real path need a short directory instead.
 func shortSocketDir(t *testing.T) string {
 	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("a root server requires a root-writable-only ancestry, which no directory under /tmp has")
+	}
 	directory, err := os.MkdirTemp("/tmp", "aptbroker-")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/aptbroker/server_test.go
+++ b/internal/aptbroker/server_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -103,25 +104,42 @@ func TestValidatePeerUIDRejectsUntrustedPeers(t *testing.T) {
 	}
 }
 
-func TestListenSocketSetsModeAndPreservesReplacement(t *testing.T) {
+// Shutdown must not delete whatever holds the pathname, only a socket that is
+// still ours. net.ListenUnix unlinks the pathname from Close by default, which
+// would run before the guard below ever sees it.
+func TestRemoveSocketPreservesReplacementWhileListenerIsOpen(t *testing.T) {
 	path := filepath.Join(shortSocketDir(t), "broker.sock")
 	listener, err := listenSocket(path, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	info, err := os.Lstat(path)
-	if err != nil || info.Mode().Perm() != 0o666 || info.Mode()&os.ModeSocket == 0 {
-		t.Fatalf("socket info = (%v, %v)", info, err)
-	}
-	if err := listener.Close(); err != nil {
+	if err := os.Remove(path); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	removeSocket(path, listener)
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("replacement was removed: %v", err)
+	body, err := os.ReadFile(path)
+	if err != nil || string(body) != "replacement" {
+		t.Fatalf("replacement was removed at shutdown: (%q, %v)", body, err)
+	}
+}
+
+// The socket mode must come from the bind itself, not from a chmod applied to a
+// pathname afterwards, so a restrictive ambient umask must not leak into it.
+func TestListenSocketBindsSocketWithFinalMode(t *testing.T) {
+	previous := syscall.Umask(0o077)
+	defer syscall.Umask(previous)
+	path := filepath.Join(shortSocketDir(t), "broker.sock")
+	listener, err := listenSocket(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeSocket(path, listener)
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode().Perm() != 0o666 || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("socket info = (%v, %v), want a socket with mode 0666", info, err)
 	}
 }
 

--- a/internal/aptbroker/server_test.go
+++ b/internal/aptbroker/server_test.go
@@ -126,8 +126,8 @@ func TestRemoveSocketPreservesReplacementWhileListenerIsOpen(t *testing.T) {
 	}
 }
 
-// The socket mode must come from the bind itself, not from a chmod applied to a
-// pathname afterwards, so a restrictive ambient umask must not leak into it.
+// Clients reach the broker through the socket, so its mode is fixed by the
+// server and an ambient umask must not leak into it.
 func TestListenSocketBindsSocketWithFinalMode(t *testing.T) {
 	previous := syscall.Umask(0o077)
 	defer syscall.Umask(previous)


### PR DESCRIPTION
Unit 3 of the #651 series (units 1-2 = #668, #674, both merged).

Adds the apt broker's Unix socket server and its SO_PEERCRED admission
control. This is the piece that finally calls `runOwnedHelper`, the helper
runner landed unused in unit 2.

## Contents

5 new files, +834/-0, 1 area, 0 binaries.

- `internal/aptbroker/server.go` (385) — `Serve`, `ServerConfig` and its
  normalization, the accept loop with bounded concurrency and bounded
  handler shutdown, request/response framing with read and write deadlines,
  and the socket lifecycle (trusted-parent validation, refusal to clobber an
  existing socket, mode 0666 verification after bind, removal only when the
  path is still the socket we created).
- `internal/aptbroker/peer_linux.go` (59) — `SO_PEERCRED` peer uid lookup via
  `unix.GetsockoptUcred`, plus `fileUID`. Root peers are refused outright.
- `internal/aptbroker/peer_other.go` (23) — non-Linux stubs; `Serve` fails
  closed on any platform without peer credentials.
- `internal/aptbroker/server_test.go` (240) and
  `internal/aptbroker/server_linux_test.go` (116).

## Admission model

A connection is admitted only when the peer's uid is both non-root and
exactly the configured `ExpectedPeerUID`; credentials come from the kernel
via `SO_PEERCRED`, not from anything the client sends. Failure to read
credentials is a rejection, not a bypass. Admission also takes a slot from a
bounded channel, so a peer that passes the uid check still cannot exceed the
concurrency limit. `validateServerSupport` gates `Serve` before any socket is
created, so a platform with no peer credentials cannot start a server that
would admit unauthenticated clients.

## Reconciliation with units 1-2

The extracted code needed no changes to match the merged package: unit 2's
`runOwnedHelper(ctx, connection, request, helperConfig)` signature and the
`helperConfig{path, timeout, report}` shape are exactly what `server.go`
calls and builds. Unit 2's review fixes (signal-derived 128+N statuses via
`syscall.WaitStatus`, the EINTR retry in the pidfd poll) are untouched.

Two test-side reconciliations:

- The extracted `server_test.go` carried its own `localUnixConnectionPair`
  helper, which builds a connection pair by binding a path under
  `t.TempDir()`. Unit 2 already landed `unixConnectionPair`, a socketpair
  fixture that needs no path at all. Dropped the duplicate and moved
  `TestServerReportsMalformedRequest` alongside the existing fixture.
- Tests that bind a real socket path now take it from a short `/tmp`
  directory rather than `t.TempDir()`, which embeds the test name under an
  already-long CI `TMPDIR` and can overrun the `AF_UNIX` `sun_path` limit.
  Two of the extracted tests already did this by hand; `shortSocketDir`
  replaces the four copies of that pattern.

`golang.org/x/sys` is already a direct dependency, so `go.mod`/`go.sum` are
unchanged.

## Container safety

Unchanged. Nothing execs these binaries yet — `runtime/container/apt-broker.sh`
and the existing `sudo-wrapper.sh` still serve the container's apt broker, and
they stay that way until unit 6.

## Verification

Host (darwin/arm64, go1.27.1):

- `go build ./...`, `GOOS=linux go build ./...` — clean
- `go vet ./...`, `GOOS=linux go vet ./internal/aptbroker/` — clean
- `gofmt -l internal/aptbroker` — empty
- `go test ./internal/aptbroker/... -count=1` and `-race` — ok
- `go test ./... -count=1` — all packages ok, no regressions

Linux lane, run locally in `golang:1.27` with `TMPDIR=/home/runner/work/_temp`
(the `runner.temp` path CI sets) and as a non-root uid so the peer-credential
path is actually exercised rather than skipped:

- `go test ./internal/aptbroker/... -count=1 -race` — 48 tests, PASS

That run covers `TestServeRoundTripPreservesHelperResult` end to end: a real
client dials the real socket, the server admits it on its `SO_PEERCRED` uid,
runs a fixture helper, and the exit status, stdout and stderr survive the
round trip. The two skips are the root-only socket-parent check and the
non-Linux unsupported-platform check, both correctly inapplicable there.



## Socket-path hardening from review

Five rounds of bot review concentrated on the socket pathname, and the result
is meaningfully stronger than what was extracted. Recorded here because the
reasoning matters more than the diff:

- **No automatic unlink.** `net.ListenUnix` returns a listener with
  `unlink: true`, and `Close` unlinks the pathname without checking that it
  still refers to the socket it created. That made `removeSocket`'s
  `isSocketFile` guard unreachable in the real `Serve` flow. `bindSocket` now
  sets `SetUnlinkOnClose(false)`, so the guarded removal is the only thing that
  deletes anything, and the post-bind error paths route through `removeSocket`
  instead of leaving a stale socket that would block the next startup.
- **Root-writable-only ancestry.** `validateSocketParent` walks from the socket
  parent to the filesystem root and requires every ancestor to be a real
  directory (`os.Lstat`, so a symlinked parent is caught rather than followed)
  that is root-owned and not group- or other-writable. This is gated on the
  running euid, not on `RequireRootSocket`, so a root server gets the guarantee
  whether or not the caller asked for it.
- **No chown, and a safe chmod.** The bind already creates the socket owned by
  the server uid, so the chown was redundant and is gone. The mode is still set
  after the bind, which the ancestry rule above makes safe: no unprivileged uid
  can substitute a symlink for the socket. An intermediate umask-based fix was
  tried and rejected — a process-wide umask is worse than the race it closed.

The deployed path `/run/workcell/apt-broker/socket` already satisfies the
ancestry rule (`/`, `/run`, and the broker directory are all root-owned 0755),
so this tightens the invariant without changing the target configuration.

One bot finding was disputed with evidence rather than fixed: an unsigned-commit
report naming `172a1ee3`, a SHA that exists neither locally (`git cat-file`
fails) nor on GitHub (commits API returns 422). Every commit here is signed and
`verified=true`.

Root and non-root Linux lanes were both exercised in a container, since the
ancestry gate behaves differently between them.
