### PR TITLE
Fail closed on a release assets directory the inventory walk cannot read

### DIFF
--- a/internal/testkit/release_outputs_verify_test.go
+++ b/internal/testkit/release_outputs_verify_test.go
@@ -72,10 +72,14 @@ func TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir(t *testing.T) {
 	}
 
 	// Negative control: the same directory reached by its real path must clear
-	// the symlink gate, so the check above rejects the symlink rather than
-	// anything else about the fixture.
-	if _, out := runReleaseOutputsInventoryGuard(t, assets); strings.Contains(out, rejection) {
-		t.Fatalf("non-symlinked assets directory was rejected as a symlink\n%s", out)
+	// the symlink gate and reach the walk, so the check above rejects the
+	// symlink rather than anything else about the fixture. Reaching the walk on
+	// an empty directory also exercises the count assertion, which is what
+	// catches a walk that completed successfully having seen nothing -- the
+	// state a symlinked directory produces once the gate above is removed.
+	if code, out := runReleaseOutputsInventoryGuard(t, assets); code == 0 ||
+		!strings.Contains(out, "release directory listing is incomplete: read 0 of") {
+		t.Fatalf("expected the real path to reach the inventory count check, got %d\n%s", code, out)
 	}
 }
 
@@ -84,8 +88,8 @@ func TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir(t *testing.T) {
 // Bash does not propagate, so a directory that permits traversal but not
 // listing left the inventory loop with nothing to read while every per-asset
 // check still opened the names it already expected. The verifier exited 0 with
-// an unexpected file present but unseen. The walk must now assert it observed
-// the whole inventory rather than trusting that it ran.
+// an unexpected file present but unseen. The walk must now observe `find`
+// running to completion rather than inferring success from what it emitted.
 func TestVerifyReleaseOutputsRejectsUnlistableAssetsDir(t *testing.T) {
 	t.Parallel()
 	if os.Geteuid() == 0 {
@@ -111,7 +115,9 @@ func TestVerifyReleaseOutputsRejectsUnlistableAssetsDir(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(assets, 0o755) })
 
-	const rejection = "release directory listing is incomplete"
+	// The walk must reject because `find` did not run to completion, not because
+	// of what it managed to emit before failing.
+	const rejection = "release directory listing failed"
 	code, out := runReleaseOutputsInventoryGuard(t, assets)
 	if code == 0 || !strings.Contains(out, rejection) {
 		t.Fatalf("expected an unlistable assets directory to fail closed, got %d\n%s", code, out)

--- a/internal/testkit/release_outputs_verify_test.go
+++ b/internal/testkit/release_outputs_verify_test.go
@@ -11,6 +11,35 @@ import (
 	"testing"
 )
 
+// runReleaseOutputsInventoryGuard runs the shipped release-output verifier
+// against one assets directory and reports its exit status and combined output.
+// The guards under test here reject before any signature check, so these runs
+// need no cosign or gh stub.
+func runReleaseOutputsInventoryGuard(t *testing.T, dir string) (int, string) {
+	t.Helper()
+	digest := strings.Repeat("c", 40)
+	cmd := exec.Command(
+		filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh"),
+		"--assets-dir", dir,
+		"--repo", "omkhar/workcell",
+		"--tag", "v1.2.3",
+		"--image-repository", "ghcr.io/omkhar/workcell",
+		"--source-digest", digest,
+		"--workflow-digest", digest,
+	)
+	// Bash startup files are cleared so caller state cannot reach the verifier.
+	cmd.Env = []string{"BASH_ENV=", "ENV="}
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("running release-output verifier: %v\n%s", err, out)
+	}
+	return exitErr.ExitCode(), string(out)
+}
+
 // TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir covers a fail-open path in
 // scripts/verify-release-outputs.sh. `find` emits no children for a
 // command-line symlink, so a symlinked --assets-dir skipped the directory
@@ -20,45 +49,60 @@ import (
 // symlink itself, before any signature check.
 func TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir(t *testing.T) {
 	t.Parallel()
-	script := filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh")
-	digest := strings.Repeat("c", 40)
 	assets := t.TempDir()
 	link := filepath.Join(t.TempDir(), "assets-link")
 	if err := os.Symlink(assets, link); err != nil {
 		t.Fatal(err)
 	}
 
-	run := func(dir string) (int, string) {
-		t.Helper()
-		cmd := exec.Command(script,
-			"--assets-dir", dir,
-			"--repo", "omkhar/workcell",
-			"--tag", "v1.2.3",
-			"--image-repository", "ghcr.io/omkhar/workcell",
-			"--source-digest", digest,
-			"--workflow-digest", digest,
-		)
-		cmd.Env = []string{"BASH_ENV=", "ENV="}
-		out, err := cmd.CombinedOutput()
-		if err == nil {
-			return 0, string(out)
-		}
-		exitErr, ok := err.(*exec.ExitError)
-		if !ok {
-			t.Fatalf("running release-output verifier: %v\n%s", err, out)
-		}
-		return exitErr.ExitCode(), string(out)
-	}
-
 	const rejection = "assets directory must not be a symlink"
-	if code, out := run(link); code == 0 || !strings.Contains(out, rejection) {
+	if code, out := runReleaseOutputsInventoryGuard(t, link); code == 0 || !strings.Contains(out, rejection) {
 		t.Fatalf("expected symlinked assets directory rejection, got %d\n%s", code, out)
 	}
 
 	// Negative control: the same directory reached by its real path must clear
 	// the symlink gate, so the check above rejects the symlink rather than
 	// anything else about the fixture.
-	if _, out := run(assets); strings.Contains(out, rejection) {
+	if _, out := runReleaseOutputsInventoryGuard(t, assets); strings.Contains(out, rejection) {
 		t.Fatalf("non-symlinked assets directory was rejected as a symlink\n%s", out)
+	}
+}
+
+// TestVerifyReleaseOutputsRejectsUnlistableAssetsDir covers a second fail-open
+// in the same walk. `find` runs in a process substitution, whose nonzero exit
+// Bash does not propagate, so a directory that permits traversal but not
+// listing left the inventory loop with nothing to read while every per-asset
+// check still opened the names it already expected. The verifier exited 0 with
+// an unexpected file present but unseen. The walk must now assert it observed
+// the whole inventory rather than trusting that it ran.
+func TestVerifyReleaseOutputsRejectsUnlistableAssetsDir(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission bits, so enumeration cannot be denied")
+	}
+	assets := t.TempDir()
+	// One decoy file: enumerable, the walk rejects it by name; unenumerable, it
+	// is exactly what the fail-open used to hide.
+	if err := os.WriteFile(filepath.Join(assets, "attacker.bin"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Negative control first, while the directory is still readable: the walk
+	// sees the decoy and rejects it by name, proving the fixture is enumerable
+	// and the assertion below is not passing on an inert path.
+	if code, out := runReleaseOutputsInventoryGuard(t, assets); code == 0 || !strings.Contains(out, "unexpected release file: attacker.bin") {
+		t.Fatalf("expected the readable fixture to be rejected by name, got %d\n%s", code, out)
+	}
+
+	// Execute-only: traversal succeeds, enumeration is denied.
+	if err := os.Chmod(assets, 0o111); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(assets, 0o755) })
+
+	const rejection = "release directory listing is incomplete"
+	code, out := runReleaseOutputsInventoryGuard(t, assets)
+	if code == 0 || !strings.Contains(out, rejection) {
+		t.Fatalf("expected an unlistable assets directory to fail closed, got %d\n%s", code, out)
 	}
 }

--- a/internal/testkit/release_outputs_verify_test.go
+++ b/internal/testkit/release_outputs_verify_test.go
@@ -4,6 +4,7 @@
 package testkit
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,13 +14,23 @@ import (
 
 // runReleaseOutputsInventoryGuard runs the shipped release-output verifier
 // against one assets directory and reports its exit status and combined output.
-// The guards under test here reject before any signature check, so these runs
-// need no cosign or gh stub.
+//
+// The run goes through a driver that sources the verifier and defines cosign as
+// a shell function. The verifier pins PATH to a fixed trusted list, so a stub
+// cannot be placed on PATH, but a function satisfies its `command -v cosign`
+// precondition on a machine without cosign installed. The stub is never called:
+// both guards under test reject before any signature verification.
 func runReleaseOutputsInventoryGuard(t *testing.T, dir string) (int, string) {
 	t.Helper()
+	driver := filepath.Join(t.TempDir(), "release-outputs-inventory-driver.sh")
+	script := fmt.Sprintf("#!/bin/bash\nsource %q\ncosign() { return 0; }\nmain \"$@\"\n",
+		filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh"))
+	if err := os.WriteFile(driver, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	digest := strings.Repeat("c", 40)
-	cmd := exec.Command(
-		filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh"),
+	cmd := exec.Command(driver,
 		"--assets-dir", dir,
 		"--repo", "omkhar/workcell",
 		"--tag", "v1.2.3",

--- a/internal/testkit/release_outputs_verify_test.go
+++ b/internal/testkit/release_outputs_verify_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir covers a fail-open path in
+// scripts/verify-release-outputs.sh. `find` emits no children for a
+// command-line symlink, so a symlinked --assets-dir skipped the directory
+// inventory walk entirely, while every per-asset `-f && ! -L` check still
+// resolved through the symlinked parent and passed. The verifier exited 0 for a
+// release directory holding an unexpected file. The run must fail closed on the
+// symlink itself, before any signature check.
+func TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir(t *testing.T) {
+	t.Parallel()
+	script := filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh")
+	digest := strings.Repeat("c", 40)
+	assets := t.TempDir()
+	link := filepath.Join(t.TempDir(), "assets-link")
+	if err := os.Symlink(assets, link); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(dir string) (int, string) {
+		t.Helper()
+		cmd := exec.Command(script,
+			"--assets-dir", dir,
+			"--repo", "omkhar/workcell",
+			"--tag", "v1.2.3",
+			"--image-repository", "ghcr.io/omkhar/workcell",
+			"--source-digest", digest,
+			"--workflow-digest", digest,
+		)
+		cmd.Env = []string{"BASH_ENV=", "ENV="}
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			return 0, string(out)
+		}
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("running release-output verifier: %v\n%s", err, out)
+		}
+		return exitErr.ExitCode(), string(out)
+	}
+
+	const rejection = "assets directory must not be a symlink"
+	if code, out := run(link); code == 0 || !strings.Contains(out, rejection) {
+		t.Fatalf("expected symlinked assets directory rejection, got %d\n%s", code, out)
+	}
+
+	// Negative control: the same directory reached by its real path must clear
+	// the symlink gate, so the check above rejects the symlink rather than
+	// anything else about the fixture.
+	if _, out := run(assets); strings.Contains(out, rejection) {
+		t.Fatalf("non-symlinked assets directory was rejected as a symlink\n%s", out)
+	}
+}

--- a/scripts/verify-release-outputs.sh
+++ b/scripts/verify-release-outputs.sh
@@ -269,11 +269,21 @@ main() {
   done
 
   EXPECTED_ASSETS=("${DATA_ASSETS[@]}" "${SIGNATURE_ASSETS[@]}")
+  listed_count=0
   while IFS= read -r -d '' path; do
     require_regular_file "${path}"
     asset="${path##*/}"
     contains_asset "${asset}" "${EXPECTED_ASSETS[@]}" || fail "unexpected release file: ${asset}"
+    listed_count=$((listed_count + 1))
   done < <(find "${ASSETS_DIR}" -mindepth 1 -maxdepth 1 -print0)
+
+  # Bash does not propagate a process-substitution failure, so a `find` that
+  # cannot enumerate the directory -- traversable but not listable, for one --
+  # leaves the loop above with nothing to read and every unexpected file unseen.
+  # Assert the walk actually observed the whole inventory instead of trusting
+  # that it ran: the per-asset checks below only open names they already expect.
+  [[ "${listed_count}" -eq "${#EXPECTED_ASSETS[@]}" ]] ||
+    fail "release directory listing is incomplete: read ${listed_count} of ${#EXPECTED_ASSETS[@]} expected entries"
 
   for asset in "${DATA_ASSETS[@]}" "${SIGNATURE_ASSETS[@]}"; do
     require_regular_file "${ASSETS_DIR}/${asset}"

--- a/scripts/verify-release-outputs.sh
+++ b/scripts/verify-release-outputs.sh
@@ -226,6 +226,10 @@ main() {
   done
 
   [[ -n "${ASSETS_DIR}" && -d "${ASSETS_DIR}" ]] || fail "assets directory is required"
+  # A symlinked assets directory makes the inventory walk below emit nothing --
+  # `find` does not descend a command-line symlink -- while the per-asset checks
+  # still resolve through it, so an unexpected file would pass unseen.
+  [[ ! -L "${ASSETS_DIR}" ]] || fail "assets directory must not be a symlink: ${ASSETS_DIR}"
   validate_repository "${REPOSITORY}" || fail "invalid repository: ${REPOSITORY}"
   validate_release_tag "${TAG}" || fail "invalid release tag: ${TAG}"
   [[ "${IMAGE_REPOSITORY}" == "ghcr.io/${REPOSITORY}" ]] ||

--- a/scripts/verify-release-outputs.sh
+++ b/scripts/verify-release-outputs.sh
@@ -269,19 +269,29 @@ main() {
   done
 
   EXPECTED_ASSETS=("${DATA_ASSETS[@]}" "${SIGNATURE_ASSETS[@]}")
+  # Bash does not propagate a process-substitution failure, so `find` errors are
+  # invisible to the loop below. Emit a lone NUL after a successful `find` and
+  # treat it as a completion sentinel: the loop reads it as an empty path, which
+  # `find` itself can never produce. A truncated walk therefore fails closed
+  # instead of leaving the per-asset checks, which only open names they already
+  # expect, to report success over an inventory that was never read.
   listed_count=0
+  walk_completed=0
   while IFS= read -r -d '' path; do
+    if [[ -z "${path}" ]]; then
+      walk_completed=1
+      continue
+    fi
     require_regular_file "${path}"
     asset="${path##*/}"
     contains_asset "${asset}" "${EXPECTED_ASSETS[@]}" || fail "unexpected release file: ${asset}"
     listed_count=$((listed_count + 1))
-  done < <(find "${ASSETS_DIR}" -mindepth 1 -maxdepth 1 -print0)
+  done < <(find "${ASSETS_DIR}" -mindepth 1 -maxdepth 1 -print0 && printf '\0')
 
-  # Bash does not propagate a process-substitution failure, so a `find` that
-  # cannot enumerate the directory -- traversable but not listable, for one --
-  # leaves the loop above with nothing to read and every unexpected file unseen.
-  # Assert the walk actually observed the whole inventory instead of trusting
-  # that it ran: the per-asset checks below only open names they already expect.
+  [[ "${walk_completed}" -eq 1 ]] || fail "release directory listing failed"
+  # A completed walk can still observe nothing: `find` exits 0 without descending
+  # a command-line symlink. Assert it saw the whole inventory, not just that it
+  # ran to completion.
   [[ "${listed_count}" -eq "${#EXPECTED_ASSETS[@]}" ]] ||
     fail "release directory listing is incomplete: read ${listed_count} of ${#EXPECTED_ASSETS[@]} expected entries"
 


### PR DESCRIPTION
## Summary

Two fail-open defects in `scripts/verify-release-outputs.sh`, both in the same directory-inventory walk. In each case the walk silently observed nothing while every later per-asset check still passed, so the verifier printed `Verified release outputs for v1.2.3.` and exited 0 for a release directory containing an unexpected `attacker.bin`. The "no unexpected release file" invariant was the only check that could have caught it, and it was the one skipped.

### 1. Symlinked assets directory

`find` does not descend a command-line symlink, so

```
while IFS= read -r -d '' path; do ... done < <(find "${ASSETS_DIR}" -mindepth 1 -maxdepth 1 -print0)
```

produced no entries and its loop body never ran. The per-asset checks use `-f && ! -L`, which resolve *through* the symlinked parent and see ordinary regular files, so all of them passed.

Fixed by rejecting a symlinked assets directory rather than following it. `test -L` is true on exactly the paths `find` refuses to descend — including the trailing-slash case, where `-L` is false and `find` *does* descend — so the guard matches the walk it protects instead of over-reaching, and keeps the script's existing `-f && ! -L` posture.

### 2. Unlistable assets directory

`find` runs in a process substitution, whose nonzero exit Bash does not propagate to the `while` loop. A directory that permits traversal but not listing (mode `0111`) therefore made `find` fail with `Permission denied` while the loop read nothing. The per-asset checks only ever open names they already expect, and traversal permission is enough for that, so they all passed.

Fixed by making the walk observe `find` running to completion. A successful `find` is followed by a lone NUL, which the loop reads as an empty path — something `find` itself can never emit — so the sentinel's absence marks a truncated walk. Bash still does not propagate the process-substitution status, but this does not depend on it.

A second assertion requires the walk to have observed the whole inventory. This covers the state completion cannot see: `find` exits 0 without descending a command-line symlink, so a walk can run to completion having seen nothing. The two guards fail closed on different states, and the symlink guard is kept as well as the precise input-validation gate that rejects before any work.

**Blast radius: release verification only, defense-in-depth.** This verifier has no publication authority; it re-checks outputs the signing job already produced. The signer independently verified the real asset subjects, so no unsigned artifact was ever attested — what was lost is the independent "nothing extra is present" cross-check.

## Testing

Both defects reproduced first against the unfixed script, using a valid nine-asset fixture with an extra `attacker.bin` planted in it and a stubbed `cosign`:

| assets-dir | before | after |
|---|---|---|
| real, readable path | `unexpected release file: attacker.bin`, exit 1 | unchanged, exit 1 |
| **symlink to that directory** | **`Verified release outputs for v1.2.3.`, exit 0** | `assets directory must not be a symlink: ...`, exit 1 |
| **same directory at mode `0111`** | **`Verified release outputs for v1.2.3.`, exit 0** | `release directory listing failed`, exit 1 |
| **`find` emits all 18 entries, then exits nonzero** | **`Verified release outputs for v1.2.3.`, exit 0** | `release directory listing failed`, exit 1 |
| empty readable directory | proceeds past the walk | `release directory listing is incomplete: read 0 of 18 expected entries`, exit 1 |
| readable, `attacker.bin` removed | exit 0 | exit 0 (no false positive) |

Confirmed the symlink guard tracks `find` exactly rather than approximating it: on a bare symlink `find` yields 0 entries and `-L` is true; with a trailing slash `find` yields all entries and `-L` is false.

Two regression tests in `internal/testkit/release_outputs_verify_test.go`, each with a negative control:

- `TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir` — control asserts the same directory reached by its real path clears the symlink gate.
- `TestVerifyReleaseOutputsRejectsUnlistableAssetsDir` — control asserts the fixture *is* enumerable while readable (the walk rejects the decoy by name), so the unlistable assertion cannot pass on an inert path. Skipped under uid 0, which bypasses directory permission bits.

Both run through a driver that sources the verifier and defines `cosign` as a shell function: the verifier pins PATH, so a stub cannot go on PATH, but a function satisfies its `command -v cosign` precondition on a runner without cosign installed. The stub is never called, since both guards reject before any signature verification.

Mutation-checked independently — each of the three guards, reverted alone, fails a test:

| guard reverted | failing test |
|---|---|
| symlink rejection | `TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir` |
| walk completion | `TestVerifyReleaseOutputsRejectsUnlistableAssetsDir` |
| inventory count | `TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir` (its negative control) |

Re-applying each restores a pass. With the completion guard reverted, the late-failure case above again prints `Verified release outputs for v1.2.3.` and exits 0, which is the residual that guard exists to close. Also green: `bash -n`, `shellcheck -x`, `shfmt -ln=bash -i 2 -ci -d`, `gofmt`, `go vet`, `go test ./internal/testkit/ -run 'ReleaseOutputs' -count=1`, and `./scripts/dev-quick-check.sh`.

## Note on #675

#675 expands `internal/testkit/release_outputs_verify_test.go` and has not merged yet, so that file is not on `main`. Both findings were raised there as review threads against a test-only unit that could not fix them. The tests here are deliberately self-contained — uniquely named functions over one uniquely named helper — so they append cleanly rather than colliding with #675's version of the file.
