### PR TITLE
Add the apt broker client and server command binaries

### DIFF
--- a/cmd/workcell-apt-broker-client/main.go
+++ b/cmd/workcell-apt-broker-client/main.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/aptbroker"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--sudo-compat" {
+		os.Exit(runSudoCompat(os.Args[2:]))
+	}
+	socketPath := flag.String("socket", aptbroker.DefaultSocketPath, "")
+	preserveCSV := flag.String("preserve-env", "", "")
+	flag.Parse()
+	args := commandArguments(flag.Args())
+	preserve := preservedNames(*preserveCSV)
+	os.Exit(runClient(*socketPath, args, preserve))
+}
+
+func runClient(socketPath string, args, preserve []string) int {
+	response, status, err := aptbroker.RunClient(context.Background(), socketPath, args, preserve, os.LookupEnv)
+	if err != nil {
+		writeClientError(status)
+		return status
+	}
+	_, _ = os.Stdout.Write(response.Stdout)
+	_, _ = os.Stderr.Write(response.Stderr)
+	return status
+}
+
+func commandArguments(args []string) []string {
+	if len(args) > 0 && args[0] == "--" {
+		return args[1:]
+	}
+	return args
+}
+
+func preservedNames(value string) []string {
+	if value == "" {
+		return nil
+	}
+	names := strings.Split(value, ",")
+	result := names[:0]
+	for _, name := range names {
+		if name != "" {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
+func writeClientError(status int) {
+	switch status {
+	case 2:
+		fmt.Fprintln(os.Stderr, "Workcell blocked malformed privileged package request.")
+	case 1:
+		fmt.Fprintln(os.Stderr, "Workcell apt broker is unavailable.")
+	}
+}

--- a/cmd/workcell-apt-broker-client/main_test.go
+++ b/cmd/workcell-apt-broker-client/main_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommandArgumentsRemovesOnlySeparator(t *testing.T) {
+	for _, testCase := range []struct {
+		args []string
+		want []string
+	}{
+		{args: []string{"--", "apt-get", "update"}, want: []string{"apt-get", "update"}},
+		{args: []string{"apt-get", "update"}, want: []string{"apt-get", "update"}},
+		{args: nil, want: nil},
+	} {
+		if got := commandArguments(testCase.args); !reflect.DeepEqual(got, testCase.want) {
+			t.Errorf("commandArguments(%q) = %q, want %q", testCase.args, got, testCase.want)
+		}
+	}
+}
+
+func TestPreservedNamesDropsEmptyFields(t *testing.T) {
+	if got, want := preservedNames("DEBIAN_FRONTEND,,APT_LISTCHANGES_FRONTEND"), []string{"DEBIAN_FRONTEND", "APT_LISTCHANGES_FRONTEND"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("preservedNames() = %q, want %q", got, want)
+	}
+	if got := preservedNames(""); got != nil {
+		t.Fatalf("preservedNames(\"\") = %q, want nil", got)
+	}
+}

--- a/cmd/workcell-apt-broker-client/sudo_compat.go
+++ b/cmd/workcell-apt-broker-client/sudo_compat.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/omkhar/workcell/internal/aptbroker"
+)
+
+const sudoCompatHelperPath = aptbroker.DefaultHelperPath
+
+type sudoCompatOptions struct {
+	preserveCSV string
+	preserveSet bool
+}
+
+func runSudoCompat(args []string) int {
+	command, preserve, status := parseSudoCompatArguments(args)
+	if status != 0 {
+		writeSudoCompatError(status)
+		return status
+	}
+	return runClient(aptbroker.DefaultSocketPath, command, preserve)
+}
+
+func parseSudoCompatArguments(args []string) ([]string, []string, int) {
+	options, index, status := parseSudoCompatOptions(args)
+	if status != 0 {
+		return nil, nil, status
+	}
+	if index >= len(args) {
+		return nil, nil, 2
+	}
+	if args[index] != sudoCompatHelperPath {
+		return nil, nil, 1
+	}
+	return args[index+1:], preservedNames(options.preserveCSV), 0
+}
+
+func parseSudoCompatOptions(args []string) (sudoCompatOptions, int, int) {
+	var options sudoCompatOptions
+	index := 0
+	for index < len(args) {
+		if args[index] == "--" {
+			return options, index + 1, 0
+		}
+		next, handled, status := options.consume(args, index)
+		if status != 0 {
+			return sudoCompatOptions{}, 0, status
+		}
+		if !handled {
+			return options, index, 0
+		}
+		index = next
+	}
+	return options, index, 0
+}
+
+func (options *sudoCompatOptions) consume(args []string, index int) (int, bool, int) {
+	argument := args[index]
+	switch {
+	case argument == "-n":
+		return index + 1, true, 0
+	case argument == "--preserve-env":
+		return options.consumeSeparatePreserve(args, index)
+	case strings.HasPrefix(argument, "--preserve-env="):
+		return options.consumePreserveValue(strings.TrimPrefix(argument, "--preserve-env="), index+1)
+	default:
+		return index, false, 0
+	}
+}
+
+func (options *sudoCompatOptions) consumeSeparatePreserve(args []string, index int) (int, bool, int) {
+	if index+1 >= len(args) {
+		return 0, true, 2
+	}
+	return options.consumePreserveValue(args[index+1], index+2)
+}
+
+func (options *sudoCompatOptions) consumePreserveValue(value string, next int) (int, bool, int) {
+	if options.preserveSet || value == "" || strings.HasPrefix(value, "-") {
+		return 0, true, 2
+	}
+	options.preserveSet = true
+	options.preserveCSV = value
+	return next, true, 0
+}
+
+func writeSudoCompatError(status int) {
+	if status == 2 {
+		fmt.Fprintln(os.Stderr, "Workcell blocked malformed sudo compatibility request.")
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Workcell sudo compatibility mode only permits the package helper.")
+}

--- a/cmd/workcell-apt-broker-client/sudo_compat_test.go
+++ b/cmd/workcell-apt-broker-client/sudo_compat_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSudoCompatArgumentsAcceptsPackageHelper(t *testing.T) {
+	for _, testCase := range []struct {
+		name         string
+		input        []string
+		wantCommand  []string
+		wantPreserve []string
+	}{
+		{
+			name:        "helper-only",
+			input:       []string{sudoCompatHelperPath},
+			wantCommand: []string{},
+		},
+		{
+			name:         "separate-preserve",
+			input:        []string{"-n", "--preserve-env", "DEBIAN_FRONTEND,APT_LISTCHANGES_FRONTEND", "--", sudoCompatHelperPath, "apt-get", "-qq", "update"},
+			wantCommand:  []string{"apt-get", "-qq", "update"},
+			wantPreserve: []string{"DEBIAN_FRONTEND", "APT_LISTCHANGES_FRONTEND"},
+		},
+		{
+			name:         "equals-preserve",
+			input:        []string{"--preserve-env=DEBCONF_NONINTERACTIVE_SEEN", sudoCompatHelperPath, "apt", "install", "example"},
+			wantCommand:  []string{"apt", "install", "example"},
+			wantPreserve: []string{"DEBCONF_NONINTERACTIVE_SEEN"},
+		},
+		{
+			name:        "repeated-noninteractive",
+			input:       []string{"-n", "-n", sudoCompatHelperPath, "apt-get", "update"},
+			wantCommand: []string{"apt-get", "update"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			command, preserve, status := parseSudoCompatArguments(testCase.input)
+			if status != 0 || !reflect.DeepEqual(command, testCase.wantCommand) || !reflect.DeepEqual(preserve, testCase.wantPreserve) {
+				t.Fatalf("parseSudoCompatArguments(%q) = command %q preserve %q status %d, want %q %q 0", testCase.input, command, preserve, status, testCase.wantCommand, testCase.wantPreserve)
+			}
+		})
+	}
+}
+
+func TestParseSudoCompatArgumentsRejectsUnsupportedInvocation(t *testing.T) {
+	for _, input := range [][]string{
+		{"-u", "root", sudoCompatHelperPath},
+		{"--socket", "/tmp/attacker", sudoCompatHelperPath},
+		{"/bin/sh", "-c", "true"},
+		{"--", "/usr/local/libexec/workcell/other-helper.sh"},
+		{"--", "apt-get", "update"},
+	} {
+		_, _, status := parseSudoCompatArguments(input)
+		if status != 1 {
+			t.Errorf("parseSudoCompatArguments(%q) status = %d, want 1", input, status)
+		}
+	}
+}
+
+func TestParseSudoCompatArgumentsRejectsMalformedSyntax(t *testing.T) {
+	for _, input := range [][]string{
+		nil,
+		{},
+		{"-n"},
+		{"--"},
+		{"--preserve-env"},
+		{"--preserve-env", ""},
+		{"--preserve-env", "--", sudoCompatHelperPath},
+		{"--preserve-env=", sudoCompatHelperPath},
+		{"--preserve-env=A", "--preserve-env=B", sudoCompatHelperPath},
+	} {
+		_, _, status := parseSudoCompatArguments(input)
+		if status != 2 {
+			t.Errorf("parseSudoCompatArguments(%q) status = %d, want 2", input, status)
+		}
+	}
+}

--- a/cmd/workcell-apt-broker-server/main.go
+++ b/cmd/workcell-apt-broker-server/main.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/omkhar/workcell/internal/aptbroker"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--start" {
+		if err := startServer(os.Args[2:]); err != nil {
+			fail(err)
+		}
+		return
+	}
+	serve(os.Args[1:])
+}
+
+func serve(arguments []string) {
+	flags := flag.NewFlagSet("workcell-apt-broker-server", flag.ExitOnError)
+	socket := flags.String("socket", aptbroker.DefaultSocketPath, "")
+	peerUID := flags.Uint64("peer-uid", 0, "")
+	concurrency := flags.Int("max-concurrent", 4, "")
+	readyFD := flags.Uint("ready-fd", 0, "")
+	ackFD := flags.Uint("ack-fd", 0, "")
+	if err := flags.Parse(arguments); err != nil {
+		fail(err)
+	}
+	timeout, err := helperTimeout(os.Getenv("WORKCELL_APT_BROKER_HELPER_TIMEOUT_SECONDS"))
+	if err != nil {
+		fail(fmt.Errorf("invalid helper timeout: %w", err))
+	}
+	uid, err := peerUIDValue(*peerUID)
+	if err != nil {
+		fail(err)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ready, err := startupHandshake(uintptr(*readyFD), uintptr(*ackFD))
+	if err != nil {
+		fail(err)
+	}
+	err = aptbroker.Serve(ctx, aptbroker.ServerConfig{SocketPath: *socket, Timeout: timeout, MaxConcurrent: *concurrency, ExpectedPeerUID: uid, RequireRootSocket: true, Ready: ready})
+	if err != nil {
+		fail(err)
+	}
+}
+
+func peerUIDValue(value uint64) (uint32, error) {
+	if value == 0 || value > uint64(^uint32(0)) {
+		return 0, errors.New("invalid peer uid")
+	}
+	return uint32(value), nil
+}
+
+func helperTimeout(raw string) (time.Duration, error) {
+	if raw == "" {
+		return aptbroker.DefaultTimeout, nil
+	}
+	seconds, err := strconv.ParseUint(raw, 10, 31)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(seconds) * time.Second, nil
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, serverDiagnostic(err))
+	os.Exit(1)
+}
+
+func serverDiagnostic(err error) string {
+	return fmt.Sprintf("Workcell apt broker failed: %v", err)
+}

--- a/cmd/workcell-apt-broker-server/main_test.go
+++ b/cmd/workcell-apt-broker-server/main_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omkhar/workcell/internal/aptbroker"
+)
+
+func TestHelperTimeout(t *testing.T) {
+	for _, test := range []struct {
+		raw   string
+		want  time.Duration
+		valid bool
+	}{
+		{"", aptbroker.DefaultTimeout, true},
+		{"7", 7 * time.Second, true},
+		{"bad", 0, false},
+	} {
+		got, err := helperTimeout(test.raw)
+		if (err == nil) != test.valid || got != test.want {
+			t.Fatalf("helperTimeout(%q) = (%s, %v)", test.raw, got, err)
+		}
+	}
+}
+
+func TestServerDiagnosticIncludesLifecycleFailure(t *testing.T) {
+	got := serverDiagnostic(errors.New("handler shutdown exceeded limit"))
+	if !strings.Contains(got, "Workcell apt broker failed:") || !strings.Contains(got, "handler shutdown exceeded limit") {
+		t.Fatalf("server diagnostic = %q", got)
+	}
+}
+
+func TestPeerUIDValueRejectsUnsafeValues(t *testing.T) {
+	for _, value := range []uint64{0, uint64(^uint32(0)) + 1} {
+		if _, err := peerUIDValue(value); err == nil {
+			t.Fatalf("peerUIDValue(%d) succeeded", value)
+		}
+	}
+	if got, err := peerUIDValue(1000); err != nil || got != 1000 {
+		t.Fatalf("peerUIDValue(1000) = (%d, %v)", got, err)
+	}
+}

--- a/cmd/workcell-apt-broker-server/startup_linux.go
+++ b/cmd/workcell-apt-broker-server/startup_linux.go
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/omkhar/workcell/internal/aptbroker"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	serverBinary       = "/usr/local/libexec/workcell/workcell-apt-broker-server"
+	startupLimit       = 5 * time.Second
+	startupReadyByte   = byte('R')
+	startupAcknowledge = byte('A')
+)
+
+type startupProcess interface {
+	Kill() error
+	Wait() (*os.ProcessState, error)
+	Release() error
+}
+
+type startupReader interface {
+	io.Reader
+	SetReadDeadline(time.Time) error
+}
+
+func startServer(arguments []string) error {
+	peerUID, err := startPeerUID(arguments)
+	if err != nil {
+		return err
+	}
+	if err := prepareSocketParent(filepath.Dir(aptbroker.DefaultSocketPath)); err != nil {
+		return err
+	}
+	if err := requireUnusedSocket(aptbroker.DefaultSocketPath); err != nil {
+		return err
+	}
+	if err := validateServerBinary(serverBinary); err != nil {
+		return err
+	}
+	return launchServer(serverBinary, peerUID)
+}
+
+func startPeerUID(arguments []string) (uint32, error) {
+	if len(arguments) != 2 || arguments[0] != "--peer-uid" {
+		return 0, errors.New("start requires --peer-uid")
+	}
+	value, err := strconv.ParseUint(arguments[1], 10, 32)
+	if err != nil {
+		return 0, errors.New("invalid peer uid")
+	}
+	return peerUIDValue(value)
+}
+
+func prepareSocketParent(path string) error {
+	ancestor := filepath.Dir(path)
+	if err := validateStartupDirectory(filepath.Dir(ancestor), false); err != nil {
+		return fmt.Errorf("validate socket root directory: %w", err)
+	}
+	if err := validateStartupDirectory(ancestor, false); err != nil {
+		return fmt.Errorf("validate socket parent directory: %w", err)
+	}
+	if err := createSocketParent(path); err != nil {
+		return err
+	}
+	if err := validateStartupDirectory(path, true); err != nil {
+		return fmt.Errorf("validate socket parent: %w", err)
+	}
+	return nil
+}
+
+func createSocketParent(path string) error {
+	err := os.Mkdir(path, 0o755)
+	if errors.Is(err, os.ErrExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("create socket parent: %w", err)
+	}
+	return normalizeCreatedSocketParent(path)
+}
+
+func normalizeCreatedSocketParent(path string) error {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open new socket parent: %w", err)
+	}
+	defer unix.Close(fd)
+	if err := unix.Fchmod(fd, 0o755); err != nil {
+		return fmt.Errorf("set new socket parent mode: %w", err)
+	}
+	var info unix.Stat_t
+	if err := unix.Fstat(fd, &info); err != nil {
+		return fmt.Errorf("inspect new socket parent: %w", err)
+	}
+	return validateCreatedSocketParent(info)
+}
+
+func validateCreatedSocketParent(info unix.Stat_t) error {
+	if info.Uid != 0 {
+		return errors.New("new socket parent is not root-owned")
+	}
+	if info.Mode&unix.S_IFMT != unix.S_IFDIR {
+		return errors.New("new socket parent is not a directory")
+	}
+	if info.Mode&0o777 != 0o755 {
+		return errors.New("new socket parent metadata is not trusted")
+	}
+	return nil
+}
+
+func validateStartupDirectory(path string, exactMode bool) error {
+	info, err := os.Lstat(path)
+	if !isStartupDirectory(info, err) {
+		return errors.New("directory is not trusted")
+	}
+	if !hasTrustedStartupMode(info) {
+		return errors.New("directory ownership or mode is not trusted")
+	}
+	if exactMode && info.Mode().Perm() != 0o755 {
+		return errors.New("directory mode is not 0755")
+	}
+	return nil
+}
+
+func isStartupDirectory(info os.FileInfo, err error) bool {
+	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0
+}
+
+func hasTrustedStartupMode(info os.FileInfo) bool {
+	return fileUID(info) == 0 && info.Mode().Perm()&0o022 == 0
+}
+
+func validateServerBinary(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect server binary: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o022 != 0 {
+		return errors.New("server binary is not trusted")
+	}
+	if fileUID(info) != 0 {
+		return errors.New("server binary is not root-owned")
+	}
+	return nil
+}
+
+func requireUnusedSocket(path string) error {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect existing server socket: %w", err)
+	}
+	return errors.New("apt broker socket already exists")
+}
+
+func launchServer(binary string, peerUID uint32) error {
+	readyReader, readyWriter, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer readyReader.Close()
+	ackReader, ackWriter, err := os.Pipe()
+	if err != nil {
+		readyWriter.Close()
+		return err
+	}
+	defer ackWriter.Close()
+	command := exec.Command(binary, "--socket", aptbroker.DefaultSocketPath, "--peer-uid", strconv.FormatUint(uint64(peerUID), 10), "--ready-fd", "3", "--ack-fd", "4")
+	command.Env = fixedServerEnvironment()
+	command.Stdin = nil
+	command.Stdout = nil
+	command.Stderr = os.Stderr
+	command.ExtraFiles = []*os.File{readyWriter, ackReader}
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := command.Start(); err != nil {
+		readyWriter.Close()
+		ackReader.Close()
+		return err
+	}
+	readyWriter.Close()
+	ackReader.Close()
+	return finishStartup(command.Process, readyReader, ackWriter, func() error {
+		return validateStartedSocket(aptbroker.DefaultSocketPath)
+	})
+}
+
+func fixedServerEnvironment() []string {
+	return []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"LC_ALL=C",
+		"LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so",
+		"WORKCELL_APT_BROKER_HELPER_TIMEOUT_SECONDS=" + os.Getenv("WORKCELL_APT_BROKER_HELPER_TIMEOUT_SECONDS"),
+	}
+}
+
+func finishStartup(process startupProcess, ready startupReader, acknowledge io.Writer, validateSocket func() error) error {
+	if err := completeStartup(ready, acknowledge, validateSocket); err != nil {
+		return stopStartupProcess(process, err)
+	}
+	// os.Process.Release cannot fail on Linux. Keep the return value so a
+	// future platform implementation cannot silently change this contract.
+	return process.Release()
+}
+
+func completeStartup(ready startupReader, acknowledge io.Writer, validateSocket func() error) error {
+	body, err := readStartupReady(ready)
+	if err != nil || !bytes.Equal(body, []byte{startupReadyByte}) {
+		return errors.Join(errors.New("invalid server readiness response"), err)
+	}
+	if err := validateSocket(); err != nil {
+		return err
+	}
+	if _, err := acknowledge.Write([]byte{startupAcknowledge}); err != nil {
+		return fmt.Errorf("acknowledge server readiness: %w", err)
+	}
+	return nil
+}
+
+func readStartupReady(ready startupReader) ([]byte, error) {
+	if err := ready.SetReadDeadline(time.Now().Add(startupLimit)); err != nil {
+		return nil, err
+	}
+	return io.ReadAll(io.LimitReader(ready, 2))
+}
+
+func stopStartupProcess(process startupProcess, cause error) error {
+	killErr := process.Kill()
+	_, waitErr := process.Wait()
+	return errors.Join(cause, killErr, waitErr)
+}
+
+func startupHandshake(readyFD, acknowledgeFD uintptr) (func() error, error) {
+	if readyFD == 0 && acknowledgeFD == 0 {
+		return nil, nil
+	}
+	if !validStartupDescriptors(readyFD, acknowledgeFD) {
+		return nil, errors.New("invalid startup handshake descriptors")
+	}
+	ready := os.NewFile(readyFD, "startup-ready")
+	acknowledge := os.NewFile(acknowledgeFD, "startup-acknowledge")
+	return func() error {
+		defer acknowledge.Close()
+		if err := writeStartupReady(ready); err != nil {
+			return err
+		}
+		return readStartupAcknowledgement(acknowledge)
+	}, nil
+}
+
+func validStartupDescriptors(readyFD, acknowledgeFD uintptr) bool {
+	return readyFD >= 3 && acknowledgeFD >= 3 && readyFD != acknowledgeFD
+}
+
+func writeStartupReady(ready *os.File) error {
+	_, writeErr := ready.Write([]byte{startupReadyByte})
+	return errors.Join(writeErr, ready.Close())
+}
+
+func readStartupAcknowledgement(acknowledge *os.File) error {
+	var ack [1]byte
+	if _, err := io.ReadFull(acknowledge, ack[:]); err != nil {
+		return err
+	}
+	if ack[0] != startupAcknowledge {
+		return errors.New("invalid startup acknowledgement")
+	}
+	return nil
+}
+
+func validateStartedSocket(path string) error {
+	if err := validateStartedSocketParent(filepath.Dir(path)); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if !isStartedSocket(info, err) {
+		return errors.New("started server socket is invalid")
+	}
+	if fileUID(info) != 0 || info.Mode().Perm() != 0o666 {
+		return errors.New("started server socket metadata is invalid")
+	}
+	return nil
+}
+
+func isStartedSocket(info os.FileInfo, err error) bool {
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.Mode()&os.ModeSocket != 0
+}
+
+func validateStartedSocketParent(path string) error {
+	if err := validateStartupDirectory(path, true); err != nil {
+		return fmt.Errorf("started server socket parent is invalid: %w", err)
+	}
+	return nil
+}
+
+func fileUID(info os.FileInfo) uint32 {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ^uint32(0)
+	}
+	return stat.Uid
+}

--- a/cmd/workcell-apt-broker-server/startup_linux.go
+++ b/cmd/workcell-apt-broker-server/startup_linux.go
@@ -50,10 +50,12 @@ func startServer(arguments []string) error {
 	if err := requireUnusedSocket(aptbroker.DefaultSocketPath); err != nil {
 		return err
 	}
-	if err := validateServerBinary(serverBinary); err != nil {
+	binary, err := openServerBinary(serverBinary)
+	if err != nil {
 		return err
 	}
-	return launchServer(serverBinary, peerUID)
+	defer binary.Close()
+	return launchServer(binary, peerUID)
 }
 
 func startPeerUID(arguments []string) (uint32, error) {
@@ -146,15 +148,34 @@ func hasTrustedStartupMode(info os.FileInfo) bool {
 	return fileUID(info) == 0 && info.Mode().Perm()&0o022 == 0
 }
 
-func validateServerBinary(path string) error {
-	info, err := os.Lstat(path)
+// A pathname that passes a check and a pathname that exec resolves a moment
+// later are not the same guarantee. Any uid that can repoint a parent directory
+// could substitute another file between the two lookups, and the starter runs
+// as root. The binary is opened once, validated through that descriptor, and
+// later executed through that same descriptor, so exec cannot reach a file the
+// check did not see. O_NOFOLLOW refuses a symlink at the leaf; a swap higher up
+// only changes which file is opened, and the checks below reject it.
+func openServerBinary(path string) (*os.File, error) {
+	binary, err := os.OpenFile(path, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
+		return nil, fmt.Errorf("open server binary: %w", err)
+	}
+	if err := validateServerBinary(binary); err != nil {
+		binary.Close()
+		return nil, err
+	}
+	return binary, nil
+}
+
+func validateServerBinary(binary *os.File) error {
+	var info unix.Stat_t
+	if err := unix.Fstat(int(binary.Fd()), &info); err != nil {
 		return fmt.Errorf("inspect server binary: %w", err)
 	}
-	if !info.Mode().IsRegular() || info.Mode().Perm()&0o022 != 0 {
+	if info.Mode&unix.S_IFMT != unix.S_IFREG || info.Mode&0o022 != 0 {
 		return errors.New("server binary is not trusted")
 	}
-	if fileUID(info) != 0 {
+	if info.Uid != 0 {
 		return errors.New("server binary is not root-owned")
 	}
 	return nil
@@ -171,7 +192,7 @@ func requireUnusedSocket(path string) error {
 	return errors.New("apt broker socket already exists")
 }
 
-func launchServer(binary string, peerUID uint32) error {
+func launchServer(binary *os.File, peerUID uint32) error {
 	readyReader, readyWriter, err := os.Pipe()
 	if err != nil {
 		return err
@@ -183,13 +204,7 @@ func launchServer(binary string, peerUID uint32) error {
 		return err
 	}
 	defer ackWriter.Close()
-	command := exec.Command(binary, "--socket", aptbroker.DefaultSocketPath, "--peer-uid", strconv.FormatUint(uint64(peerUID), 10), "--ready-fd", "3", "--ack-fd", "4")
-	command.Env = fixedServerEnvironment()
-	command.Stdin = nil
-	command.Stdout = nil
-	command.Stderr = os.Stderr
-	command.ExtraFiles = []*os.File{readyWriter, ackReader}
-	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	command := serverCommand(binary, readyWriter, ackReader, peerUID)
 	if err := command.Start(); err != nil {
 		readyWriter.Close()
 		ackReader.Close()
@@ -200,6 +215,34 @@ func launchServer(binary string, peerUID uint32) error {
 	return finishStartup(command.Process, readyReader, ackWriter, func() error {
 		return validateStartedSocket(aptbroker.DefaultSocketPath)
 	})
+}
+
+// exec.Cmd gives the child descriptor 3 upward to ExtraFiles in order, so the
+// entries below decide these numbers. The child then executes itself through
+// the validated descriptor rather than through a pathname exec would resolve a
+// second time. The descriptor stays open in the server: it is read-only on the
+// server's own root-owned binary, and exec.Cmd gives it to no helper process.
+const (
+	startupReadyFD  = 3
+	startupAckFD    = 4
+	startupBinaryFD = 5
+)
+
+func serverCommand(binary, ready, acknowledge *os.File, peerUID uint32) *exec.Cmd {
+	command := exec.Command(
+		"/proc/self/fd/"+strconv.Itoa(startupBinaryFD),
+		"--socket", aptbroker.DefaultSocketPath,
+		"--peer-uid", strconv.FormatUint(uint64(peerUID), 10),
+		"--ready-fd", strconv.Itoa(startupReadyFD),
+		"--ack-fd", strconv.Itoa(startupAckFD),
+	)
+	command.Env = fixedServerEnvironment()
+	command.Stdin = nil
+	command.Stdout = nil
+	command.Stderr = os.Stderr
+	command.ExtraFiles = []*os.File{ready, acknowledge, binary}
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return command
 }
 
 func fixedServerEnvironment() []string {

--- a/cmd/workcell-apt-broker-server/startup_linux.go
+++ b/cmd/workcell-apt-broker-server/startup_linux.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -148,35 +149,55 @@ func hasTrustedStartupMode(info os.FileInfo) bool {
 	return fileUID(info) == 0 && info.Mode().Perm()&0o022 == 0
 }
 
-// A pathname that passes a check and a pathname that exec resolves a moment
-// later are not the same guarantee. Any uid that can repoint a parent directory
-// could substitute another file between the two lookups, and the starter runs
-// as root. The binary is opened once, validated through that descriptor, and
-// later executed through that same descriptor, so exec cannot reach a file the
-// check did not see. O_NOFOLLOW refuses a symlink at the leaf; a swap higher up
-// only changes which file is opened, and the checks below reject it.
+const startupDirectoryFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+
+// Checking a pathname and then letting exec resolve it again are two lookups,
+// and the starter runs as root. O_NOFOLLOW covers only one component, so every
+// directory is opened from its parent and must be root-owned and root-writable
+// only, and the leaf descriptor fstat accepts is the one exec receives.
 func openServerBinary(path string) (*os.File, error) {
-	binary, err := os.OpenFile(path, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	directory, err := unix.Open("/", startupDirectoryFlags, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open server binary root: %w", err)
+	}
+	defer func() { _ = unix.Close(directory) }()
+	names := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	for _, name := range names[:len(names)-1] {
+		if err := validateStartupDescriptor(directory, unix.S_IFDIR); err != nil {
+			return nil, err
+		}
+		next, err := unix.Openat(directory, name, startupDirectoryFlags, 0)
+		if err != nil {
+			return nil, fmt.Errorf("open server binary ancestor %s: %w", name, err)
+		}
+		_ = unix.Close(directory)
+		directory = next
+	}
+	if err := validateStartupDescriptor(directory, unix.S_IFDIR); err != nil {
+		return nil, err
+	}
+	leaf, err := unix.Openat(directory, names[len(names)-1], unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("open server binary: %w", err)
 	}
-	if err := validateServerBinary(binary); err != nil {
+	binary := os.NewFile(uintptr(leaf), path)
+	if err := validateStartupDescriptor(leaf, unix.S_IFREG); err != nil {
 		binary.Close()
 		return nil, err
 	}
 	return binary, nil
 }
 
-func validateServerBinary(binary *os.File) error {
+func validateStartupDescriptor(descriptor int, kind uint32) error {
 	var info unix.Stat_t
-	if err := unix.Fstat(int(binary.Fd()), &info); err != nil {
-		return fmt.Errorf("inspect server binary: %w", err)
+	if err := unix.Fstat(descriptor, &info); err != nil {
+		return fmt.Errorf("inspect server binary path: %w", err)
 	}
-	if info.Mode&unix.S_IFMT != unix.S_IFREG || info.Mode&0o022 != 0 {
-		return errors.New("server binary is not trusted")
+	if info.Mode&unix.S_IFMT != kind {
+		return errors.New("server binary path component has the wrong type")
 	}
-	if info.Uid != 0 {
-		return errors.New("server binary is not root-owned")
+	if info.Uid != 0 || info.Mode&0o022 != 0 {
+		return errors.New("server binary path is writable outside root")
 	}
 	return nil
 }
@@ -217,11 +238,10 @@ func launchServer(binary *os.File, peerUID uint32) error {
 	})
 }
 
-// exec.Cmd gives the child descriptor 3 upward to ExtraFiles in order, so the
-// entries below decide these numbers. The child then executes itself through
-// the validated descriptor rather than through a pathname exec would resolve a
-// second time. The descriptor stays open in the server: it is read-only on the
-// server's own root-owned binary, and exec.Cmd gives it to no helper process.
+// exec.Cmd hands ExtraFiles to the child from descriptor 3 upward, so the order
+// below fixes these numbers and the child execs the validated descriptor rather
+// than a pathname. That descriptor stays open in the server: it is read-only on
+// the server's own binary, and exec.Cmd passes it to no helper process.
 const (
 	startupReadyFD  = 3
 	startupAckFD    = 4
@@ -237,8 +257,6 @@ func serverCommand(binary, ready, acknowledge *os.File, peerUID uint32) *exec.Cm
 		"--ack-fd", strconv.Itoa(startupAckFD),
 	)
 	command.Env = fixedServerEnvironment()
-	command.Stdin = nil
-	command.Stdout = nil
 	command.Stderr = os.Stderr
 	command.ExtraFiles = []*os.File{ready, acknowledge, binary}
 	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/cmd/workcell-apt-broker-server/startup_linux_test.go
+++ b/cmd/workcell-apt-broker-server/startup_linux_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type fixtureStartupProcess struct {
+	log *[]string
+}
+
+func (p fixtureStartupProcess) Kill() error {
+	*p.log = append(*p.log, "kill")
+	return nil
+}
+
+func (p fixtureStartupProcess) Wait() (*os.ProcessState, error) {
+	*p.log = append(*p.log, "wait")
+	return nil, nil
+}
+
+func (p fixtureStartupProcess) Release() error {
+	*p.log = append(*p.log, "release")
+	return nil
+}
+
+type fixtureStartupReader struct {
+	io.Reader
+	deadlineErr error
+}
+
+type fixtureErrorReader struct {
+	err error
+}
+
+func (r fixtureErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r fixtureStartupReader) SetReadDeadline(time.Time) error {
+	return r.deadlineErr
+}
+
+type fixtureStartupWriter struct {
+	log *[]string
+	err error
+}
+
+func (w fixtureStartupWriter) Write(body []byte) (int, error) {
+	*w.log = append(*w.log, "ack")
+	if w.err != nil {
+		return 0, w.err
+	}
+	return len(body), nil
+}
+
+func TestStartPeerUIDRequiresExactArgument(t *testing.T) {
+	for _, arguments := range [][]string{nil, {"--peer-uid"}, {"--peer-uid", "0"}, {"--socket", "1000"}, {"--peer-uid", "1000", "extra"}} {
+		if _, err := startPeerUID(arguments); err == nil {
+			t.Fatalf("startPeerUID(%q) succeeded", arguments)
+		}
+	}
+	if uid, err := startPeerUID([]string{"--peer-uid", "1000"}); err != nil || uid != 1000 {
+		t.Fatalf("startPeerUID() = (%d, %v)", uid, err)
+	}
+}
+
+func TestStartupHandshakeRequiresAcknowledgement(t *testing.T) {
+	readyReader, readyWriter := testPipe(t)
+	defer readyReader.Close()
+	ackReader, ackWriter := testPipe(t)
+	defer ackWriter.Close()
+	handshake, err := startupHandshake(readyWriter.Fd(), ackReader.Fd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	finished := make(chan error, 1)
+	go func() { finished <- handshake() }()
+	ready, err := io.ReadAll(readyReader)
+	if err != nil || !reflect.DeepEqual(ready, []byte{startupReadyByte}) {
+		t.Fatalf("readiness = (%q, %v)", ready, err)
+	}
+	select {
+	case err := <-finished:
+		t.Fatalf("handshake completed before acknowledgement: %v", err)
+	default:
+	}
+	if _, err := ackWriter.Write([]byte{startupAcknowledge}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-finished; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testPipe(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return reader, writer
+}
+
+func TestValidateServerBinaryRejectsWritableFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(path, []byte("fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateServerBinary(path); err == nil {
+		t.Fatal("writable server binary was accepted")
+	}
+}
+
+func TestFixedServerEnvironmentIsMinimal(t *testing.T) {
+	t.Setenv("WORKCELL_APT_BROKER_HELPER_TIMEOUT_SECONDS", "7")
+	want := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"LC_ALL=C",
+		"LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so",
+		"WORKCELL_APT_BROKER_HELPER_TIMEOUT_SECONDS=7",
+	}
+	if got := fixedServerEnvironment(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("server environment = %q", got)
+	}
+}
+
+func TestFinishStartupTransfersOnlyValidatedServer(t *testing.T) {
+	fixtureErr := errors.New("fixture failure")
+	for _, test := range []struct {
+		name        string
+		ready       startupReader
+		validateErr error
+		ackErr      error
+		wantLog     []string
+		wantError   bool
+	}{
+		{name: "success", ready: startupBody("R"), wantLog: []string{"validate", "ack", "release"}},
+		{name: "empty readiness", ready: startupBody(""), wantLog: []string{"kill", "wait"}, wantError: true},
+		{name: "duplicate readiness", ready: startupBody("RR"), wantLog: []string{"kill", "wait"}, wantError: true},
+		{name: "deadline failure", ready: fixtureStartupReader{Reader: bytes.NewReader(nil), deadlineErr: fixtureErr}, wantLog: []string{"kill", "wait"}, wantError: true},
+		{name: "read timeout", ready: fixtureStartupReader{Reader: fixtureErrorReader{err: fixtureErr}}, wantLog: []string{"kill", "wait"}, wantError: true},
+		{name: "socket metadata", ready: startupBody("R"), validateErr: fixtureErr, wantLog: []string{"validate", "kill", "wait"}, wantError: true},
+		{name: "acknowledgement", ready: startupBody("R"), ackErr: fixtureErr, wantLog: []string{"validate", "ack", "kill", "wait"}, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var log []string
+			validate := func() error {
+				log = append(log, "validate")
+				return test.validateErr
+			}
+			writer := fixtureStartupWriter{log: &log, err: test.ackErr}
+			err := finishStartup(fixtureStartupProcess{log: &log}, test.ready, writer, validate)
+			if !reflect.DeepEqual(log, test.wantLog) || (err != nil) != test.wantError {
+				t.Fatalf("finishStartup() = (%v, %v), want (%v, error=%v)", log, err, test.wantLog, test.wantError)
+			}
+		})
+	}
+}
+
+func startupBody(body string) startupReader {
+	return fixtureStartupReader{Reader: bytes.NewBufferString(body)}
+}
+
+func TestPrepareSocketParentRejectsSymlinkWithoutChangingTarget(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root-owned directory fixture requires root")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "socket-root")
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareSocketParent(path); err == nil {
+		t.Fatal("symlink socket parent was accepted")
+	}
+	info, err := os.Stat(target)
+	if err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("symlink target changed: (%v, %v)", info, err)
+	}
+}
+
+func TestCreateSocketParentNormalizesRestrictiveUmask(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root ownership check requires root")
+	}
+	path := filepath.Join(t.TempDir(), "socket-root")
+	oldMask := syscall.Umask(0o077)
+	defer syscall.Umask(oldMask)
+	if err := createSocketParent(path); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o755 {
+		t.Fatalf("created socket parent = (%v, %v)", info, err)
+	}
+}
+
+func TestCreateSocketParentDoesNotModifyExistingDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "socket-root")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := createSocketParent(path); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("existing socket parent changed: (%v, %v)", info, err)
+	}
+}
+
+func TestRequireUnusedSocketRejectsEveryExistingPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "socket")
+	if err := requireUnusedSocket(path); err != nil {
+		t.Fatalf("missing socket was rejected: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("stale fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireUnusedSocket(path); err == nil {
+		t.Fatal("existing socket path was accepted")
+	}
+}

--- a/cmd/workcell-apt-broker-server/startup_linux_test.go
+++ b/cmd/workcell-apt-broker-server/startup_linux_test.go
@@ -12,11 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"strconv"
 	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 type fixtureStartupProcess struct {
@@ -116,46 +117,47 @@ func testPipe(t *testing.T) (*os.File, *os.File) {
 	return reader, writer
 }
 
-func TestOpenServerBinaryRejectsUntrustedFile(t *testing.T) {
-	root := t.TempDir()
-	writable := filepath.Join(root, "writable")
-	if err := os.WriteFile(writable, []byte("fixture"), 0o755); err != nil {
+// The leaf here is an ordinary file the leaf checks alone would accept. Only
+// the ancestor walk refuses it, because a directory above it is writable by any
+// uid, and that is the uid that would swap the leaf.
+func TestOpenServerBinaryRejectsUntrustedAncestry(t *testing.T) {
+	ancestor := filepath.Join(t.TempDir(), "ancestor")
+	path := filepath.Join(ancestor, "server")
+	if err := errors.Join(os.Mkdir(ancestor, 0o777), os.Chmod(ancestor, 0o777), os.WriteFile(path, nil, 0o755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(writable, 0o777); err != nil {
-		t.Fatal(err)
-	}
-	directory := filepath.Join(root, "directory")
-	if err := os.Mkdir(directory, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	trusted := filepath.Join(root, "server")
-	if err := os.WriteFile(trusted, []byte("fixture"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	link := filepath.Join(root, "link")
-	if err := os.Symlink(trusted, link); err != nil {
-		t.Fatal(err)
-	}
-	for name, path := range map[string]string{
-		"writable":  writable,
-		"directory": directory,
-		"symlink":   link,
-		"missing":   filepath.Join(root, "absent"),
-	} {
-		t.Run(name, func(t *testing.T) {
-			binary, err := openServerBinary(path)
-			if err == nil {
-				binary.Close()
-				t.Fatal("untrusted server binary was accepted")
-			}
-		})
+	binary, err := openServerBinary(path)
+	if err == nil {
+		binary.Close()
+		t.Fatal("untrusted server binary path was accepted")
 	}
 }
 
-// The descriptor the child executes must be the descriptor openServerBinary
-// validated, and the handshake flags must name the pipe descriptors. All three
-// numbers come from the ExtraFiles order, so they are asserted together.
+// The type check runs before the ownership check, so a directory never
+// satisfies the leaf and a file never satisfies an ancestor, at any uid.
+func TestValidateStartupDescriptorRejectsWrongType(t *testing.T) {
+	for _, test := range []struct {
+		target string
+		flags  int
+		kind   uint32
+	}{
+		{target: t.TempDir(), flags: startupDirectoryFlags, kind: unix.S_IFREG},
+		{target: os.Args[0], flags: unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_CLOEXEC, kind: unix.S_IFDIR},
+	} {
+		descriptor, err := unix.Open(test.target, test.flags, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateStartupDescriptor(descriptor, test.kind); err == nil {
+			t.Errorf("%s was accepted as type %o", test.target, test.kind)
+		}
+		unix.Close(descriptor)
+	}
+}
+
+// The descriptor the child executes must be the one openServerBinary validated.
+// Both the exec path and the handshake numbers come from the ExtraFiles order,
+// so the order and the path are asserted together.
 func TestServerCommandExecutesTheValidatedDescriptor(t *testing.T) {
 	binary, ready, acknowledge := os.Stdout, os.Stdin, os.Stderr
 	command := serverCommand(binary, ready, acknowledge, 1000)
@@ -163,16 +165,9 @@ func TestServerCommandExecutesTheValidatedDescriptor(t *testing.T) {
 		t.Fatalf("command path = %q, want %q", got, want)
 	}
 	for descriptor, want := range map[int]*os.File{startupReadyFD: ready, startupAckFD: acknowledge, startupBinaryFD: binary} {
-		index := descriptor - 3
-		if index < 0 || index >= len(command.ExtraFiles) || command.ExtraFiles[index] != want {
+		if got := command.ExtraFiles[descriptor-3]; got != want {
 			t.Fatalf("descriptor %d does not carry the expected file", descriptor)
 		}
-	}
-	if !slices.Contains(command.Args, "--ready-fd") || !slices.Contains(command.Args, strconv.Itoa(startupReadyFD)) {
-		t.Fatalf("command args = %q", command.Args)
-	}
-	if !slices.Contains(command.Args, "--ack-fd") || !slices.Contains(command.Args, strconv.Itoa(startupAckFD)) {
-		t.Fatalf("command args = %q", command.Args)
 	}
 }
 

--- a/cmd/workcell-apt-broker-server/startup_linux_test.go
+++ b/cmd/workcell-apt-broker-server/startup_linux_test.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -114,16 +116,63 @@ func testPipe(t *testing.T) (*os.File, *os.File) {
 	return reader, writer
 }
 
-func TestValidateServerBinaryRejectsWritableFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "server")
-	if err := os.WriteFile(path, []byte("fixture"), 0o755); err != nil {
+func TestOpenServerBinaryRejectsUntrustedFile(t *testing.T) {
+	root := t.TempDir()
+	writable := filepath.Join(root, "writable")
+	if err := os.WriteFile(writable, []byte("fixture"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(path, 0o777); err != nil {
+	if err := os.Chmod(writable, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateServerBinary(path); err == nil {
-		t.Fatal("writable server binary was accepted")
+	directory := filepath.Join(root, "directory")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	trusted := filepath.Join(root, "server")
+	if err := os.WriteFile(trusted, []byte("fixture"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(trusted, link); err != nil {
+		t.Fatal(err)
+	}
+	for name, path := range map[string]string{
+		"writable":  writable,
+		"directory": directory,
+		"symlink":   link,
+		"missing":   filepath.Join(root, "absent"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			binary, err := openServerBinary(path)
+			if err == nil {
+				binary.Close()
+				t.Fatal("untrusted server binary was accepted")
+			}
+		})
+	}
+}
+
+// The descriptor the child executes must be the descriptor openServerBinary
+// validated, and the handshake flags must name the pipe descriptors. All three
+// numbers come from the ExtraFiles order, so they are asserted together.
+func TestServerCommandExecutesTheValidatedDescriptor(t *testing.T) {
+	binary, ready, acknowledge := os.Stdout, os.Stdin, os.Stderr
+	command := serverCommand(binary, ready, acknowledge, 1000)
+	if got, want := command.Path, "/proc/self/fd/"+strconv.Itoa(startupBinaryFD); got != want {
+		t.Fatalf("command path = %q, want %q", got, want)
+	}
+	for descriptor, want := range map[int]*os.File{startupReadyFD: ready, startupAckFD: acknowledge, startupBinaryFD: binary} {
+		index := descriptor - 3
+		if index < 0 || index >= len(command.ExtraFiles) || command.ExtraFiles[index] != want {
+			t.Fatalf("descriptor %d does not carry the expected file", descriptor)
+		}
+	}
+	if !slices.Contains(command.Args, "--ready-fd") || !slices.Contains(command.Args, strconv.Itoa(startupReadyFD)) {
+		t.Fatalf("command args = %q", command.Args)
+	}
+	if !slices.Contains(command.Args, "--ack-fd") || !slices.Contains(command.Args, strconv.Itoa(startupAckFD)) {
+		t.Fatalf("command args = %q", command.Args)
 	}
 }
 

--- a/cmd/workcell-apt-broker-server/startup_other.go
+++ b/cmd/workcell-apt-broker-server/startup_other.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build !linux
+
+package main
+
+import "errors"
+
+func startServer([]string) error {
+	return errors.New("apt broker startup is unsupported on this platform")
+}
+
+func startupHandshake(readyFD, acknowledgeFD uintptr) (func() error, error) {
+	if readyFD == 0 && acknowledgeFD == 0 {
+		return nil, nil
+	}
+	return nil, errors.New("apt broker startup is unsupported on this platform")
+}


### PR DESCRIPTION
Unit 4 of the #651 apt broker series. It follows #668 (protocol and client library), #674 (privileged helper runner), and #677 (socket server and SO_PEERCRED admission).

This unit adds the two command binaries that put the broker library on the runtime path. It changes no container asset. The shell broker stays live until unit 6.

## Client

`cmd/workcell-apt-broker-client` sends one request over the broker socket and returns the helper exit status. It writes the helper stdout and stderr without change.

`--sudo-compat` accepts only the sudo argument forms the container wrappers use: `-n`, `--preserve-env NAMES`, `--preserve-env=NAMES`, and `--`. It accepts a command only when the program is the package helper path. It rejects `-u`, `--socket`, any other program, and a repeated or empty `--preserve-env` value. This keeps the compatibility surface from reaching another program.

## Server

`cmd/workcell-apt-broker-server` parses the socket path, the peer uid, and the concurrency limit, then calls `aptbroker.Serve` with `RequireRootSocket` set. It reads the helper timeout from `WORKCELL_APT_BROKER_HELPER_TIMEOUT_SECONDS`. It leaves `ErrorWriter` on its documented `os.Stderr` default. It rejects a zero or out-of-range peer uid.

`--start` prepares the socket parent, validates the server binary, launches the server in a new session with a fixed environment, and completes a pipe handshake. The parent transfers ownership only after the child reports readiness and the started socket passes an owner and mode check. A failed handshake kills the child and reports the cause.

The startup path keeps the same socket invariants the library enforces. It reuses no existing socket path. It requires every directory to be root-owned and not writable outside root. It permits no symlink in a path component. A newly created socket parent is normalized through its own file descriptor, so a restrictive umask cannot leave a wrong mode and no pathname is re-resolved.

`startup_other.go` fails closed on a platform that is not Linux.

## Validation

- `go build ./...` and `GOOS=linux go build ./...`
- `go vet ./...`
- `go test ./... -count=1` on darwin/arm64: all packages pass
- Linux container (`golang:1.27`, uid 0, `TMPDIR` at CI length): `go vet` plus `go test -race -count=1` over `./cmd/workcell-apt-broker-client/... ./cmd/workcell-apt-broker-server/... ./internal/aptbroker/...` all pass
- The root-gated startup tests run rather than skip under uid 0, and pass: symlink socket parent rejected without changing the target, restrictive umask normalized to 0755, an existing directory left unchanged, and every existing socket path rejected
- PR shape: files=9 lines=995 areas=1 binary_files=0

## Next

Unit 5 and unit 6 remain. Unit 6 moves the container from the shell broker to these binaries.