### PR TITLE
^b Track every heredoc delimiter in workflow script parsing (second heredoc body now fails the test; review finding)

### DIFF
--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -302,6 +302,34 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind a quoted word left open across lines",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : \"text\n" +
+				"          \" <<'PLAN'\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind an array-subscript shift",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          B=0; : <<'A'; a[1<<B]=4\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -249,6 +249,31 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden in a heredoc opened inside a quoted command substitution",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : \"$(cat <<'PLAN'\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN\n" +
+				"          )\"",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind a subshell that reads as an arithmetic opener",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : $((true) ) <<'PLAN'\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -207,6 +207,33 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind an arithmetic shift that desynchronises the queue",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : <<'A'; x=$((x << B))\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind an escaped quote that masks the opener",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : \\\" <<'PLAN' \"\"\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -179,6 +179,19 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands replaced by the second body of two heredocs",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          cat <<'NOTE' <<'PLAN' >/dev/null\n" +
+				"          NOTE\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -222,6 +222,21 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind a parameter expansion that desynchronises the queue",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : <<'A' ${x:-<<B}\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name: "real commands hidden behind an escaped quote that masks the opener",
 			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
 				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -274,6 +274,34 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind a quoted parenthesis that ends the group early",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : \"$(printf '%s' ')'; cat <<'PLAN'\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN\n" +
+				"          )\"",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind a legacy arithmetic shift",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          B=0; : <<'A'; echo $[1 << B]\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -192,6 +192,21 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind a quoted delimiter that desynchronises the queue",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : <<'A' \"text <<B\"\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -215,12 +215,12 @@ var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 func commandArgs(script, command string) [][]string {
 	var invocations [][]string
 	var current strings.Builder
-	var heredoc string
+	var heredocs []string
 	for line := range strings.Lines(script) {
 		trimmed := strings.TrimSpace(line)
-		if heredoc != "" {
-			if trimmed == heredoc {
-				heredoc = ""
+		if len(heredocs) > 0 {
+			if trimmed == heredocs[0] {
+				heredocs = heredocs[1:]
 			}
 			continue
 		}
@@ -235,8 +235,10 @@ func commandArgs(script, command string) [][]string {
 		current.Reset()
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		if match := heredocPattern.FindStringSubmatch(strings.ReplaceAll(logical, "<<<", " ")); match != nil {
-			heredoc = cmp.Or(match[1], match[2], match[3])
+		// Every delimiter on the line opens a body, and bash reads them in the
+		// order they appear, so they are queued rather than overwritten.
+		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
+			heredocs = append(heredocs, cmp.Or(match[1], match[2], match[3]))
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -4,7 +4,6 @@
 package metadatautil
 
 import (
-	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -205,10 +204,106 @@ func validateReleaseAssembly(document workflowDocument) error {
 	return nil
 }
 
-// heredocPattern consumes quoted words before it reads a redirection, so that
-// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
-// third alternative captures, and it captures the delimiter it opens.
-var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+// heredocDelimiters returns the delimiters that line opens, in the order bash
+// reads their bodies. It scans the line instead of matching a pattern, so that
+// an escape, a quoted word, a here-string and an arithmetic shift are each read
+// the way bash reads them and none of them can hide or invent a redirection.
+func heredocDelimiters(line string) []string {
+	var delimiters []string
+	arithmetic := 0
+	for index := 0; index < len(line); {
+		rest := line[index:]
+		switch {
+		case rest[0] == '\\':
+			index += 2
+		case rest[0] == '\'' || rest[0] == '"':
+			index += quotedWidth(rest)
+		case strings.HasPrefix(rest, "$(("):
+			arithmetic++
+			index += 3
+		case strings.HasPrefix(rest, "(("):
+			arithmetic++
+			index += 2
+		case strings.HasPrefix(rest, "))") && arithmetic > 0:
+			arithmetic--
+			index += 2
+		case strings.HasPrefix(rest, "<<<"):
+			index += 3
+		case strings.HasPrefix(rest, "<<") && arithmetic > 0:
+			// A << inside an arithmetic expansion is a shift, not a redirection.
+			index += 2
+		case strings.HasPrefix(rest, "<<"):
+			delimiter, width := heredocDelimiter(rest)
+			if delimiter != "" {
+				delimiters = append(delimiters, delimiter)
+			}
+			index += width
+		default:
+			index++
+		}
+	}
+	return delimiters
+}
+
+// quotedWidth returns the length of the quoted word that opens text, or the
+// length of text when that word is unterminated. A backslash escapes the next
+// byte inside a double-quoted word and is literal inside a single-quoted one.
+func quotedWidth(text string) int {
+	quote := text[0]
+	for index := 1; index < len(text); index++ {
+		if quote == '"' && text[index] == '\\' {
+			index++
+			continue
+		}
+		if text[index] == quote {
+			return index + 1
+		}
+	}
+	return len(text)
+}
+
+// heredocDelimiter reads the delimiter of the heredoc redirection that opens
+// text, and returns it with the width of the redirection. The delimiter is
+// empty when the redirection names none, and the width always passes the
+// operator so that the scan makes progress.
+func heredocDelimiter(text string) (string, int) {
+	index := len("<<")
+	if index < len(text) && text[index] == '-' {
+		index++
+	}
+	for index < len(text) && (text[index] == ' ' || text[index] == '\t') {
+		index++
+	}
+	if index >= len(text) {
+		return "", index
+	}
+	if quote := text[index]; quote == '\'' || quote == '"' {
+		word := text[index : index+quotedWidth(text[index:])]
+		if len(word) < 2 || word[len(word)-1] != quote {
+			return "", index + len(word)
+		}
+		return word[1 : len(word)-1], index + len(word)
+	}
+	// A backslash before the delimiter quotes it, as in <<\EOF.
+	if text[index] == '\\' {
+		index++
+	}
+	end := index
+	for end < len(text) && isDelimiterByte(text[end]) {
+		end++
+	}
+	if end == index || (text[index] >= '0' && text[index] <= '9') {
+		return "", max(end, len("<<"))
+	}
+	return text[index:end], end
+}
+
+func isDelimiterByte(character byte) bool {
+	return character == '_' ||
+		character >= 'a' && character <= 'z' ||
+		character >= 'A' && character <= 'Z' ||
+		character >= '0' && character <= '9'
+}
 
 var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 
@@ -236,16 +331,9 @@ func commandArgs(script, command string) [][]string {
 		}
 		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
 		current.Reset()
-		// Here-strings are blanked first so that a redirection such as
-		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
 		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten. A match
-		// with no capture is a consumed quoted word, not a redirection.
-		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
-				heredocs = append(heredocs, delimiter)
-			}
-		}
+		// order they appear, so they are queued rather than overwritten.
+		heredocs = append(heredocs, heredocDelimiters(logical)...)
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))
 		}

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -210,12 +210,16 @@ func validateReleaseAssembly(document workflowDocument) error {
 // word, a here-string and a parameter expansion are each read the way bash
 // reads them and none of them can hide or invent a redirection.
 //
-// A bracketed group is the one construct this scanner does not resolve:
-// bash re-enters command parsing inside a command substitution, and it decides
-// between arithmetic and a nested subshell by re-parsing the group. Rather than
-// guess, the scan skips a group that cannot open a heredoc at all and fails
-// closed on one that could. A group opens no heredoc when the only << it
-// contains is a here-string, which is what the reviewed workflow uses.
+// The scan never guesses. Where it cannot resolve the line it reports false and
+// the caller drops the whole script, so an unresolved construct can never hide
+// a heredoc that desynchronises the body queue. That covers three cases: a
+// bracketed group, because bash re-enters command parsing inside a command
+// substitution and re-parses the group to choose between arithmetic and a
+// nested subshell; a subscript or arithmetic bracket, which bash also parses as
+// arithmetic; and a word left open at the end of the line, whose quoting state
+// this line-at-a-time scan cannot carry. A group or bracket is skipped only
+// when it cannot open a heredoc at all, which is when the only << it contains
+// is a here-string, and that is what the reviewed workflow uses.
 func heredocDelimiters(line string) ([]string, bool) {
 	var delimiters []string
 	quoted := false
@@ -226,7 +230,11 @@ func heredocDelimiters(line string) ([]string, bool) {
 		case rest[0] == '\\':
 			index += 2
 		case rest[0] == '\'' && !quoted:
-			index += quotedWidth(rest)
+			width, terminated := quotedWidth(rest)
+			if !terminated {
+				return nil, false
+			}
+			index += width
 		case rest[0] == '"':
 			// A double-quoted word is not skipped whole: bash still expands a
 			// command substitution inside it, and that reopens command parsing.
@@ -238,8 +246,9 @@ func heredocDelimiters(line string) ([]string, bool) {
 				return nil, false
 			}
 			index += len(group)
-		case strings.HasPrefix(rest, "$["):
-			// The deprecated $[ ] arithmetic form is read the same way.
+		case rest[0] == '[':
+			// A subscript, a test, and the deprecated $[ ] arithmetic form all
+			// read the same way: bash parses a subscript as arithmetic too.
 			group := rest[:balancedSpanWidth(rest, '[', ']')]
 			if groupCanOpenHeredoc(group) {
 				return nil, false
@@ -267,6 +276,11 @@ func heredocDelimiters(line string) ([]string, bool) {
 			index++
 		}
 	}
+	// A word or expansion still open at the end of the line carries its state
+	// into the next physical line, which this scan does not see.
+	if quoted || expansion > 0 {
+		return nil, false
+	}
 	return delimiters, true
 }
 
@@ -281,7 +295,8 @@ func balancedSpanWidth(text string, open, close byte) int {
 		case character == '\\':
 			index++
 		case character == '\'' || character == '"':
-			index += quotedWidth(text[index:]) - 1
+			width, _ := quotedWidth(text[index:])
+			index += width - 1
 		case character == open:
 			depth++
 		case character == close:
@@ -311,10 +326,11 @@ func groupCanOpenHeredoc(group string) bool {
 	}
 }
 
-// quotedWidth returns the length of the quoted word that opens text, or the
-// length of text when that word is unterminated. A backslash escapes the next
-// byte inside a double-quoted word and is literal inside a single-quoted one.
-func quotedWidth(text string) int {
+// quotedWidth returns the length of the quoted word that opens text and whether
+// that word closes on this line. An unterminated word returns the length of
+// text. A backslash escapes the next byte inside a double-quoted word and is
+// literal inside a single-quoted one.
+func quotedWidth(text string) (int, bool) {
 	quote := text[0]
 	for index := 1; index < len(text); index++ {
 		if quote == '"' && text[index] == '\\' {
@@ -322,10 +338,10 @@ func quotedWidth(text string) int {
 			continue
 		}
 		if text[index] == quote {
-			return index + 1
+			return index + 1, true
 		}
 	}
-	return len(text)
+	return len(text), false
 }
 
 // heredocDelimiter reads the delimiter of the heredoc redirection that opens
@@ -344,11 +360,12 @@ func heredocDelimiter(text string) (string, int) {
 		return "", index
 	}
 	if quote := text[index]; quote == '\'' || quote == '"' {
-		word := text[index : index+quotedWidth(text[index:])]
-		if len(word) < 2 || word[len(word)-1] != quote {
-			return "", index + len(word)
+		width, terminated := quotedWidth(text[index:])
+		word := text[index : index+width]
+		if !terminated {
+			return "", index + width
 		}
-		return word[1 : len(word)-1], index + len(word)
+		return word[1 : len(word)-1], index + width
 	}
 	// A backslash before the delimiter quotes it, as in <<\EOF.
 	if text[index] == '\\' {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -210,7 +210,7 @@ func validateReleaseAssembly(document workflowDocument) error {
 // word, a here-string and a parameter expansion are each read the way bash
 // reads them and none of them can hide or invent a redirection.
 //
-// A parenthesised group is the one construct this scanner does not resolve:
+// A bracketed group is the one construct this scanner does not resolve:
 // bash re-enters command parsing inside a command substitution, and it decides
 // between arithmetic and a nested subshell by re-parsing the group. Rather than
 // guess, the scan skips a group that cannot open a heredoc at all and fails
@@ -233,7 +233,14 @@ func heredocDelimiters(line string) ([]string, bool) {
 			quoted = !quoted
 			index++
 		case strings.HasPrefix(rest, "$("), strings.HasPrefix(rest, "(("):
-			group := rest[:parenGroupWidth(rest)]
+			group := rest[:balancedSpanWidth(rest, '(', ')')]
+			if groupCanOpenHeredoc(group) {
+				return nil, false
+			}
+			index += len(group)
+		case strings.HasPrefix(rest, "$["):
+			// The deprecated $[ ] arithmetic form is read the same way.
+			group := rest[:balancedSpanWidth(rest, '[', ']')]
 			if groupCanOpenHeredoc(group) {
 				return nil, false
 			}
@@ -263,15 +270,21 @@ func heredocDelimiters(line string) ([]string, bool) {
 	return delimiters, true
 }
 
-// parenGroupWidth returns the length of the parenthesised group that opens text,
-// or the length of text when the group does not close on this line.
-func parenGroupWidth(text string) int {
+// balancedSpanWidth returns the length of the bracketed span that opens text at
+// its first open byte, or the length of text when that span does not close on
+// this line. It honours escaping and quoting, so a bracket inside a quoted word
+// cannot end the span early and leave the rest of the line misread.
+func balancedSpanWidth(text string, open, close byte) int {
 	depth := 0
-	for index := strings.IndexByte(text, '('); index >= 0 && index < len(text); index++ {
-		switch text[index] {
-		case '(':
+	for index := strings.IndexByte(text, open); index >= 0 && index < len(text); index++ {
+		switch character := text[index]; {
+		case character == '\\':
+			index++
+		case character == '\'' || character == '"':
+			index += quotedWidth(text[index:]) - 1
+		case character == open:
 			depth++
-		case ')':
+		case character == close:
 			if depth--; depth == 0 {
 				return index + 1
 			}

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -205,29 +205,39 @@ func validateReleaseAssembly(document workflowDocument) error {
 }
 
 // heredocDelimiters returns the delimiters that line opens, in the order bash
-// reads their bodies. It scans the line instead of matching a pattern, so that
-// an escape, a quoted word, a here-string, an arithmetic shift and a parameter
-// expansion are each read the way bash reads them, and none of them can hide or
-// invent a redirection.
-func heredocDelimiters(line string) []string {
+// reads their bodies, and reports whether the line could be resolved at all. It
+// scans the line instead of matching a pattern, so that an escape, a quoted
+// word, a here-string and a parameter expansion are each read the way bash
+// reads them and none of them can hide or invent a redirection.
+//
+// A parenthesised group is the one construct this scanner does not resolve:
+// bash re-enters command parsing inside a command substitution, and it decides
+// between arithmetic and a nested subshell by re-parsing the group. Rather than
+// guess, the scan skips a group that cannot open a heredoc at all and fails
+// closed on one that could. A group opens no heredoc when the only << it
+// contains is a here-string, which is what the reviewed workflow uses.
+func heredocDelimiters(line string) ([]string, bool) {
 	var delimiters []string
-	arithmetic, expansion := 0, 0
+	quoted := false
+	expansion := 0
 	for index := 0; index < len(line); {
 		rest := line[index:]
 		switch {
 		case rest[0] == '\\':
 			index += 2
-		case rest[0] == '\'' || rest[0] == '"':
+		case rest[0] == '\'' && !quoted:
 			index += quotedWidth(rest)
-		case strings.HasPrefix(rest, "$(("):
-			arithmetic++
-			index += 3
-		case strings.HasPrefix(rest, "(("):
-			arithmetic++
-			index += 2
-		case strings.HasPrefix(rest, "))") && arithmetic > 0:
-			arithmetic--
-			index += 2
+		case rest[0] == '"':
+			// A double-quoted word is not skipped whole: bash still expands a
+			// command substitution inside it, and that reopens command parsing.
+			quoted = !quoted
+			index++
+		case strings.HasPrefix(rest, "$("), strings.HasPrefix(rest, "(("):
+			group := rest[:parenGroupWidth(rest)]
+			if groupCanOpenHeredoc(group) {
+				return nil, false
+			}
+			index += len(group)
 		case strings.HasPrefix(rest, "${"):
 			expansion++
 			index += 2
@@ -236,9 +246,9 @@ func heredocDelimiters(line string) []string {
 			index++
 		case strings.HasPrefix(rest, "<<<"):
 			index += 3
-		case strings.HasPrefix(rest, "<<") && (arithmetic > 0 || expansion > 0):
-			// Bash reads a << inside an arithmetic expansion as a shift, and one
-			// inside a parameter expansion as expanded text. Neither redirects.
+		case strings.HasPrefix(rest, "<<") && (quoted || expansion > 0):
+			// Bash reads a << inside a double-quoted word or a parameter
+			// expansion as literal text, not as a redirection.
 			index += 2
 		case strings.HasPrefix(rest, "<<"):
 			delimiter, width := heredocDelimiter(rest)
@@ -250,7 +260,42 @@ func heredocDelimiters(line string) []string {
 			index++
 		}
 	}
-	return delimiters
+	return delimiters, true
+}
+
+// parenGroupWidth returns the length of the parenthesised group that opens text,
+// or the length of text when the group does not close on this line.
+func parenGroupWidth(text string) int {
+	depth := 0
+	for index := strings.IndexByte(text, '('); index >= 0 && index < len(text); index++ {
+		switch text[index] {
+		case '(':
+			depth++
+		case ')':
+			if depth--; depth == 0 {
+				return index + 1
+			}
+		}
+	}
+	return len(text)
+}
+
+// groupCanOpenHeredoc reports whether a parenthesised group contains a
+// redirection that could open a heredoc body. A here-string consumes its word
+// on the same line and opens nothing.
+func groupCanOpenHeredoc(group string) bool {
+	for index := 0; ; {
+		at := strings.Index(group[index:], "<<")
+		if at < 0 {
+			return false
+		}
+		index += at
+		if strings.HasPrefix(group[index:], "<<<") {
+			index += 3
+			continue
+		}
+		return true
+	}
 }
 
 // quotedWidth returns the length of the quoted word that opens text, or the
@@ -340,8 +385,14 @@ func commandArgs(script, command string) [][]string {
 		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
 		current.Reset()
 		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten.
-		heredocs = append(heredocs, heredocDelimiters(logical)...)
+		// order they appear, so they are queued rather than overwritten. A line
+		// the scanner cannot resolve fails the whole script closed: no
+		// invocation is reported, so no requirement can be satisfied by it.
+		opened, resolved := heredocDelimiters(logical)
+		if !resolved {
+			return nil
+		}
+		heredocs = append(heredocs, opened...)
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))
 		}

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -205,7 +205,10 @@ func validateReleaseAssembly(document workflowDocument) error {
 	return nil
 }
 
-var heredocPattern = regexp.MustCompile(`<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+// heredocPattern consumes quoted words before it reads a redirection, so that
+// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
+// third alternative captures, and it captures the delimiter it opens.
+var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
 
 var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 
@@ -236,9 +239,12 @@ func commandArgs(script, command string) [][]string {
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
 		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten.
+		// order they appear, so they are queued rather than overwritten. A match
+		// with no capture is a consumed quoted word, not a redirection.
 		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			heredocs = append(heredocs, cmp.Or(match[1], match[2], match[3]))
+			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
+				heredocs = append(heredocs, delimiter)
+			}
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -206,11 +206,12 @@ func validateReleaseAssembly(document workflowDocument) error {
 
 // heredocDelimiters returns the delimiters that line opens, in the order bash
 // reads their bodies. It scans the line instead of matching a pattern, so that
-// an escape, a quoted word, a here-string and an arithmetic shift are each read
-// the way bash reads them and none of them can hide or invent a redirection.
+// an escape, a quoted word, a here-string, an arithmetic shift and a parameter
+// expansion are each read the way bash reads them, and none of them can hide or
+// invent a redirection.
 func heredocDelimiters(line string) []string {
 	var delimiters []string
-	arithmetic := 0
+	arithmetic, expansion := 0, 0
 	for index := 0; index < len(line); {
 		rest := line[index:]
 		switch {
@@ -227,10 +228,17 @@ func heredocDelimiters(line string) []string {
 		case strings.HasPrefix(rest, "))") && arithmetic > 0:
 			arithmetic--
 			index += 2
+		case strings.HasPrefix(rest, "${"):
+			expansion++
+			index += 2
+		case rest[0] == '}' && expansion > 0:
+			expansion--
+			index++
 		case strings.HasPrefix(rest, "<<<"):
 			index += 3
-		case strings.HasPrefix(rest, "<<") && arithmetic > 0:
-			// A << inside an arithmetic expansion is a shift, not a redirection.
+		case strings.HasPrefix(rest, "<<") && (arithmetic > 0 || expansion > 0):
+			// Bash reads a << inside an arithmetic expansion as a shift, and one
+			// inside a parameter expansion as expanded text. Neither redirects.
 			index += 2
 		case strings.HasPrefix(rest, "<<"):
 			delimiter, width := heredocDelimiter(rest)


### PR DESCRIPTION
Follow-up to #672, which dispositioned this finding to a separate change because the ~2-line fix plus its negative fixture crossed that branch's PR shape line budget (1199/1200).

## The gap

`commandArgs` used `FindStringSubmatch`, so it recorded only the first heredoc delimiter on a line. For `cat <<A <<B` the body of `B` was still read as executable commands. Putting both ORAS copies and the index creation in that second body satisfied `validateReleaseAssembly` while bash only fed the text to `cat`, so no OCI layout was ever created.

Verified before the fix: the new fixture returns a nil error from `ValidateReleaseWorkflowAuthoritySplit`.

```
--- FAIL: .../real_commands_replaced_by_the_second_body_of_two_heredocs
    workflow_validation_test.go:213: ValidateReleaseWorkflowAuthoritySplit() error = <nil>, want "copy both platform images"
```

## The fix

Queue every delimiter the line opens with `FindAllStringSubmatch`, and pop the first one when its terminator line appears, which is the order bash reads the bodies in. The here-string guard and the single-heredoc behaviour are unchanged.

This is the fourth and last variant of the one root cause tracked through #672: full-line comments, heredoc bodies, and inline comments each already have a negative fixture there.

## Validation

- `go build ./...`
- `go test ./internal/metadatautil/ -run 'Workflow|Authority' -count=1`
- `go test ./internal/metadatautil/ -count=1` (full package, includes fuzz seeds)
- `go vet ./internal/metadatautil/`
- `gofmt -l internal/metadatautil/` clean
- new fixture fails without the parser change, passes with it
