### PR TITLE
Load the release workflow from main and bind it to the verified tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1563,6 +1563,13 @@ jobs:
       artifact_id: ${{ steps.upload_signed.outputs.artifact-id }}
       artifact_digest: ${{ steps.upload_signed.outputs.artifact-digest }}
     steps:
+      # The reviewed rechecks below run from the repository, so the signer needs
+      # the verified release commit in its workspace before the first one.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
+          persist-credentials: false
+
       - name: Recheck release tag before signing and image mutation
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  repository_dispatch:
+    types: [release]
 
 permissions: {}
 
@@ -18,7 +17,7 @@ defaults:
     shell: bash --noprofile --norc -euo pipefail {0}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.client_payload.tag }}
   cancel-in-progress: false
 
 env:
@@ -43,14 +42,121 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      actions: read # Verify the required workflow runs for the release commit.
+      contents: read # Verify the annotated release tag and its target commit.
+    outputs:
+      release_commit: ${{ steps.binding.outputs.release_commit }}
+      release_tag: ${{ steps.binding.outputs.release_tag }}
+      tag_object: ${{ steps.binding.outputs.tag_object }}
     steps:
+      - name: Verify signed tag binding before checkout
+        id: binding
+        env:
+          GH_HOST: github.com
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PAYLOAD_JSON: ${{ toJSON(github.event.client_payload) }}
+          RELEASE_TAG: ${{ github.event.client_payload.tag }}
+          EXPECTED_RELEASE_COMMIT: ${{ github.event.client_payload.commit }}
+        run: |
+          # repository_dispatch loads this workflow from the default branch.
+          # This gate uses only fixed runner tools before repository checkout.
+          export PATH="/usr/bin:/bin"
+          expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/heads/main"
+          if [[ "${GITHUB_REF}" != "refs/heads/main" || "${GITHUB_WORKFLOW_REF}" != "${expected_workflow_ref}" ||
+            "${GITHUB_WORKFLOW_SHA}" != "${GITHUB_SHA}" ]]; then
+            echo "Release must use the workflow from the current main commit." >&2
+            exit 2
+          fi
+          payload_keys="$(jq -c 'keys | sort' <<<"${PAYLOAD_JSON}")"
+          if [[ "${payload_keys}" != '["commit","tag"]' ]]; then
+            echo "Release dispatch accepts only tag and commit payload fields." >&2
+            exit 2
+          fi
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9A-Za-z.-]{1,63}$ ]]; then
+            echo "Release dispatch requires one bounded release tag." >&2
+            exit 2
+          fi
+          if [[ "${#EXPECTED_RELEASE_COMMIT}" -ne 40 || "${EXPECTED_RELEASE_COMMIT}" == *[!0-9a-f]* ]]; then
+            echo "Release dispatch requires client_payload.commit as 40 lowercase hexadecimal characters." >&2
+            exit 2
+          fi
+          encoded_tag="$(jq -rn --arg value "${RELEASE_TAG}" '$value | @uri')"
+          ref_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}")"
+          observed_ref="$(jq -r '.ref // empty' <<<"${ref_json}")"
+          object_type="$(jq -r '.object.type // empty' <<<"${ref_json}")"
+          object_sha="$(jq -r '.object.sha // empty' <<<"${ref_json}")"
+          if [[ "${observed_ref}" != "refs/tags/${RELEASE_TAG}" || "${object_type}" != "tag" ]]; then
+            echo "Release requires an annotated tag object." >&2
+            exit 2
+          fi
+          if [[ "${#object_sha}" -ne 40 || "${object_sha}" == *[!0-9a-f]* ]]; then
+            echo "Release tag object has an invalid object ID." >&2
+            exit 2
+          fi
+          tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${object_sha}")"
+          returned_object_sha="$(jq -r '.sha // empty' <<<"${tag_json}")"
+          returned_tag_name="$(jq -r '.tag // empty' <<<"${tag_json}")"
+          target_type="$(jq -r '.object.type // empty' <<<"${tag_json}")"
+          target_sha="$(jq -r '.object.sha // empty' <<<"${tag_json}")"
+          verified="$(jq -r '.verification.verified // false' <<<"${tag_json}")"
+          reason="$(jq -r '.verification.reason // "unknown"' <<<"${tag_json}")"
+          if [[ "${verified}" != "true" || "${reason}" != "valid" ]]; then
+            echo "Release requires a GitHub-verified signed tag." >&2
+            exit 2
+          fi
+          if [[ "${returned_object_sha}" != "${object_sha}" || "${returned_tag_name}" != "${RELEASE_TAG}" ||
+            "${target_type}" != "commit" || "${target_sha}" != "${EXPECTED_RELEASE_COMMIT}" ]]; then
+            echo "Release tag does not target the requested release commit." >&2
+            exit 2
+          fi
+          if [[ "${target_sha}" != "${GITHUB_WORKFLOW_SHA}" ]]; then
+            echo "Release tag must target the current main workflow commit." >&2
+            exit 2
+          fi
+          runs_response="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?branch=main&event=push&head_sha=${target_sha}&per_page=100")"
+          run_count="$(jq -r '.total_count // -1' <<<"${runs_response}")"
+          if [[ ! "${run_count}" =~ ^[0-9]+$ || "${run_count}" -gt 100 ]]; then
+            echo "Release commit workflow-run inventory is invalid or exceeds 100 entries." >&2
+            exit 2
+          fi
+          main_runs="$(jq --arg target "${target_sha}" \
+            '[.workflow_runs[]
+              | select(.event == "push" and .head_branch == "main" and .head_sha == $target)]
+              | group_by(.path)
+              | map(max_by([.id, .run_attempt]))' \
+            <<<"${runs_response}")"
+          expected_paths='[".github/workflows/ci.yml",".github/workflows/codeql.yml",".github/workflows/docs.yml",".github/workflows/hosted-controls.yml",".github/workflows/scorecard.yml",".github/workflows/security.yml"]'
+          observed_paths="$(jq -c '[.[].path] | sort' <<<"${main_runs}")"
+          if [[ "${observed_paths}" != "${expected_paths}" ]]; then
+            echo "Release commit does not have the exact required main workflow set." >&2
+            printf 'Expected: %s\nObserved: %s\n' "${expected_paths}" "${observed_paths}" >&2
+            exit 2
+          fi
+          unready_runs="$(jq -r \
+            '.[] | select(.status != "completed" or .conclusion != "success") | "\(.name) (\(.status), \(.conclusion))"' \
+            <<<"${main_runs}")"
+          if [[ -n "${unready_runs}" ]]; then
+            echo "Release commit has incomplete or unsuccessful main workflows:" >&2
+            printf '%s\n' "${unready_runs}" >&2
+            exit 2
+          fi
+          {
+            echo "release_commit=${target_sha}"
+            echo "release_tag=${RELEASE_TAG}"
+            echo "tag_object=${object_sha}"
+          } >>"${GITHUB_OUTPUT}"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Classify release tag
-        run: go run ./cmd/workcell-hostutil release classify-tag "${GITHUB_REF_NAME}" >/dev/null
+        env:
+          RELEASE_TAG: ${{ steps.binding.outputs.release_tag }}
+        run: go run ./cmd/workcell-hostutil release classify-tag "${RELEASE_TAG}" >/dev/null
 
   codeql-preflight:
     name: Release CodeQL (${{ matrix.language }})
@@ -74,6 +180,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           persist-credentials: false
 
       - if: ${{ !github.event.repository.private || vars.WORKCELL_ENABLE_PRIVATE_CODE_SCANNING == 'true' }}
@@ -99,6 +206,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     needs: tag-policy
+    env:
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       contents: read
     outputs:
@@ -107,12 +216,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -157,6 +267,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: tag-policy
+    env:
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       contents: read
     outputs:
@@ -165,12 +277,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -208,6 +321,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           persist-credentials: false
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -235,16 +349,19 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     needs: tag-policy
+    env:
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           persist-credentials: false
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -288,6 +405,10 @@ jobs:
       - tag-policy
       - preflight-amd64-repro
       - preflight-arm64-repro
+    env:
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
+      RELEASE_TAG_OBJECT: ${{ needs.tag-policy.outputs.tag_object }}
     environment:
       name: hosted-controls-audit
     permissions:
@@ -300,89 +421,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
-
-      - name: Require tag commit on main
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # Use the GitHub compare API (via gh, which is pre-authenticated) to
-          # verify that the tagged commit is an ancestor of main.  The git-fetch
-          # approach requires re-authenticating against a private repo and has
-          # proven unreliable with the actions/checkout credential cleanup.
-          if ! cmp_status="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/compare/${GITHUB_SHA}...main" \
-            --jq '.status')"; then
-            echo "Could not verify whether tagged commit ${GITHUB_SHA} is on main." >&2
-            exit 1
-          fi
-          case "${cmp_status}" in
-            ahead|identical) ;;
-            *)
-              echo "Tagged commit ${GITHUB_SHA} is not an ancestor of main (compare status: ${cmp_status:-error})" >&2
-              exit 1
-              ;;
-          esac
-
-      - name: Require main checks green for tagged commit
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # Per AGENTS.md ("Wait for the merged main commit to finish required
-          # GitHub Actions workflows successfully before pushing the signed
-          # release tag"), block release publication if check-runs on the
-          # tagged commit show failures or unfinished work.  Tag-ancestry
-          # alone is not enough: a tag pushed before main CI completes, or
-          # against a red main, must not produce a release.
-          # Fail closed when nothing has registered yet: a tag pushed inside
-          # the registration window would otherwise see zero check-runs and
-          # sail through both filters below. GitHub Actions check suites for
-          # main-push workflows register at event delivery, so an empty set
-          # means main CI has not started for this commit. Scope to the
-          # github-actions app on main: third-party app suites (for example
-          # kusari-inspector) can sit queued forever on main commits.
-          suites="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-suites" \
-            --paginate \
-            --jq '[.check_suites[] | select(.app.slug == "github-actions" and .head_branch == "main")]')"
-          if [[ "$(jq 'length' <<<"${suites}")" -eq 0 ]]; then
-            echo "Tagged commit ${GITHUB_SHA} has no registered main workflow check suites yet." >&2
-            echo "Wait for main checks to register and finish before re-running this release." >&2
-            exit 1
-          fi
-          incomplete_suites="$(jq -r '.[] | select(.status != "completed") | "check suite \(.id) (\(.status))"' <<<"${suites}")"
-          if [[ -n "${incomplete_suites}" ]]; then
-            echo "Tagged commit ${GITHUB_SHA} has main workflow check suites not yet completed:" >&2
-            printf '%s\n' "${incomplete_suites}" >&2
-            echo "Wait for main checks to finish before re-running this release." >&2
-            exit 1
-          fi
-          failed="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
-            --paginate \
-            --jq '.check_runs[] | select(.status == "completed" and (.conclusion | IN("failure","cancelled","timed_out","action_required","stale"))) | "\(.name) (\(.conclusion))"')"
-          if [[ -n "${failed}" ]]; then
-            echo "Tagged commit ${GITHUB_SHA} has failed required checks:" >&2
-            printf '%s\n' "${failed}" >&2
-            exit 1
-          fi
-          pending="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
-            --paginate \
-            --jq '.check_runs[] | select(.status != "completed" and (.name | startswith("Release ") | not)) | .name')"
-          if [[ -n "${pending}" ]]; then
-            echo "Tagged commit ${GITHUB_SHA} has check-runs not yet completed:" >&2
-            printf '%s\n' "${pending}" >&2
-            echo "Wait for main checks to finish before re-running this release." >&2
-            exit 1
-          fi
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - name: Verify release tag signature
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${GITHUB_REF_NAME}"
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"
 
       - name: Verify GitHub-hosted controls
         env:
@@ -399,7 +449,7 @@ jobs:
       - name: Verify build input manifest
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
-          WORKCELL_BUILD_INPUT_REF: ${{ github.sha }}
+          WORKCELL_BUILD_INPUT_REF: ${{ needs.tag-policy.outputs.release_commit }}
         run: ./scripts/verify-build-input-manifest.sh
 
       - name: Verify control-plane manifest
@@ -408,7 +458,7 @@ jobs:
       - name: Generate preflight build input manifest
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
-          WORKCELL_BUILD_INPUT_REF: ${{ github.sha }}
+          WORKCELL_BUILD_INPUT_REF: ${{ needs.tag-policy.outputs.release_commit }}
         run: |
           mkdir -p dist
           ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs-preflight.json
@@ -480,7 +530,7 @@ jobs:
         run: |
           docker build \
             -f tools/validator/Dockerfile \
-            -t "workcell-validator:${GITHUB_SHA}" \
+            -t "workcell-validator:${RELEASE_COMMIT}" \
             .
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -508,7 +558,7 @@ jobs:
             -e GOMODCACHE="${validator_cache}/go-mod" \
             -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
             -e TMPDIR="${validator_tmp}" \
-            "workcell-validator:${GITHUB_SHA}" \
+            "workcell-validator:${RELEASE_COMMIT}" \
             -lc '
               set -euo pipefail
               mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"
@@ -522,10 +572,10 @@ jobs:
         env:
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
           WORKCELL_RELEASE_BUNDLE_MANIFEST_PATH: dist/workcell-release-bundle-preflight.json
-          WORKCELL_RELEASE_BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz
-          WORKCELL_RELEASE_BUNDLE_PREFIX: workcell-${{ github.ref_name }}
-          WORKCELL_RELEASE_BUNDLE_REF: ${{ github.sha }}
-          WORKCELL_VALIDATOR_IMAGE: workcell-validator:${{ github.sha }}
+          WORKCELL_RELEASE_BUNDLE_NAME: workcell-${{ env.RELEASE_TAG }}.tar.gz
+          WORKCELL_RELEASE_BUNDLE_PREFIX: workcell-${{ env.RELEASE_TAG }}
+          WORKCELL_RELEASE_BUNDLE_REF: ${{ needs.tag-policy.outputs.release_commit }}
+          WORKCELL_VALIDATOR_IMAGE: workcell-validator:${{ needs.tag-policy.outputs.release_commit }}
         run: ./scripts/verify-release-bundle.sh
 
       - name: Build preflight release install artifacts
@@ -540,7 +590,7 @@ jobs:
           validator_cache="${validator_home}/.cache"
           validator_tmp="${validator_home}/.tmp"
           mkdir -p dist/release-install
-          bundle="workcell-${GITHUB_REF_NAME}.tar.gz"
+          bundle="workcell-${RELEASE_TAG}.tar.gz"
           docker run --rm \
             --user "${validator_uid}:${validator_gid}" \
             --entrypoint /bin/bash \
@@ -551,10 +601,10 @@ jobs:
             -e XDG_CACHE_HOME="${validator_cache}" \
             -e TMPDIR="${validator_tmp}" \
             -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
-            -e ARCHIVE_REF="${GITHUB_SHA}" \
+            -e ARCHIVE_REF="${RELEASE_COMMIT}" \
             -e BUNDLE_NAME="${bundle}" \
-            -e BUNDLE_PREFIX="workcell-${GITHUB_REF_NAME}/" \
-            "workcell-validator:${GITHUB_SHA}" \
+            -e BUNDLE_PREFIX="workcell-${RELEASE_TAG}/" \
+            "workcell-validator:${RELEASE_COMMIT}" \
             -lc '
               set -euo pipefail
               mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${TMPDIR}"
@@ -570,7 +620,7 @@ jobs:
             '
           bundle_sha="$(sha256sum "dist/release-install/${bundle}" | awk '{print $1}')"
           ./scripts/generate-homebrew-formula.sh \
-            "${GITHUB_REF_NAME}" \
+            "${RELEASE_TAG}" \
             "${bundle_sha}" \
             dist/release-install/workcell.rb \
             --repository "${GITHUB_REPOSITORY}"
@@ -658,7 +708,7 @@ jobs:
         with:
           name: workcell-release-install-candidate
           path: |
-            dist/release-install/workcell-${{ github.ref_name }}.tar.gz
+            dist/release-install/workcell-${{ env.RELEASE_TAG }}.tar.gz
             dist/release-install/workcell.rb
           retention-days: 90
 
@@ -669,6 +719,8 @@ jobs:
     needs:
       - tag-policy
       - preflight
+    env:
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
     permissions:
       contents: read
     strategy:
@@ -682,6 +734,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           persist-credentials: false
 
       - name: Verify release asset ACL handling
@@ -750,7 +803,7 @@ jobs:
           mkdir -p "${tap_dir}/Formula"
           cp dist/install/workcell.rb "${tap_dir}/Formula/workcell.rb"
           formula_path="${tap_dir}/Formula/workcell.rb"
-          expected_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/$(basename "${bundle_path}")"
+          expected_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/$(basename "${bundle_path}")"
           grep -F "url \"${expected_url}\"" "${formula_path}" >/dev/null
           BUNDLE_FILE_URL="file://${bundle_path}" perl -0pi -e 's{^  url ".*"$}{"  url \"" . $ENV{BUNDLE_FILE_URL} . "\""}me' "${formula_path}"
           brew install "${tap_name}/workcell"
@@ -775,6 +828,9 @@ jobs:
       - preflight-arm64-copilot-runtime
       - preflight-container-smoke
       - install-verification
+    env:
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       contents: read
     outputs:
@@ -784,12 +840,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -822,7 +879,7 @@ jobs:
           go run ./cmd/workcell-citools create-release-image-handoff \
             "${RUNNER_TEMP}/workcell-amd64.oci.tar" \
             "${RUNNER_TEMP}/workcell-amd64-handoff.json" \
-            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${RELEASE_TAG}" "${RELEASE_COMMIT}" \
             linux/amd64 "${IMAGE_DIGEST}" "${PREFLIGHT_DIGEST}" "${PREFLIGHT_CONFIG_DIGEST}"
 
       - id: upload_amd64
@@ -848,6 +905,9 @@ jobs:
       - preflight-arm64-copilot-runtime
       - preflight-container-smoke
       - install-verification
+    env:
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       contents: read
     outputs:
@@ -857,12 +917,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -898,7 +959,7 @@ jobs:
           go run ./cmd/workcell-citools create-release-image-handoff \
             "${RUNNER_TEMP}/workcell-arm64.oci.tar" \
             "${RUNNER_TEMP}/workcell-arm64-handoff.json" \
-            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${RELEASE_TAG}" "${RELEASE_COMMIT}" \
             linux/arm64 "${IMAGE_DIGEST}" "${PREFLIGHT_DIGEST}" "${PREFLIGHT_CONFIG_DIGEST}"
 
       - id: upload_arm64
@@ -920,6 +981,9 @@ jobs:
       - install-verification
       - build-amd64-image
       - build-arm64-image
+    env:
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       contents: read
     outputs:
@@ -928,6 +992,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -957,7 +1022,7 @@ jobs:
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -995,7 +1060,7 @@ jobs:
         run: |
           set -euo pipefail
           bound="dist/preflight-subjects"
-          bundle="workcell-${GITHUB_REF_NAME}.tar.gz"
+          bundle="workcell-${RELEASE_TAG}.tar.gz"
           amd64_digest="$(jq -r '.platforms["linux/amd64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)"
           amd64_config="$(jq -r '.platforms["linux/amd64"].config_digest' dist/preflight/workcell-runtime-preflight.json)"
           arm64_digest="$(jq -r '.platforms["linux/arm64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)"
@@ -1007,25 +1072,25 @@ jobs:
           mkdir -p "${amd64_layout}" "${arm64_layout}" "${source_root}"
           go run ./cmd/workcell-citools create-release-image-handoff \
             dist/image-amd64/workcell-amd64.oci.tar "${RUNNER_TEMP}/validated-amd64.json" \
-            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${RELEASE_TAG}" "${RELEASE_COMMIT}" \
             linux/amd64 "${AMD64_IMAGE_DIGEST}" "${amd64_digest}" "${amd64_config}"
           go run ./cmd/workcell-citools create-release-image-handoff \
             dist/image-arm64/workcell-arm64.oci.tar "${RUNNER_TEMP}/validated-arm64.json" \
-            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" \
+            "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${RELEASE_TAG}" "${RELEASE_COMMIT}" \
             linux/arm64 "${ARM64_IMAGE_DIGEST}" "${arm64_digest}" "${arm64_config}"
           tar -xf dist/image-amd64/workcell-amd64.oci.tar -C "${amd64_layout}"
           tar -xf dist/image-arm64/workcell-arm64.oci.tar -C "${arm64_layout}"
           oras cp --recursive --from-oci-layout "${amd64_layout}@${amd64_digest}" --to-oci-layout "${release_layout}:amd64"
           oras cp --recursive --from-oci-layout "${arm64_layout}@${arm64_digest}" --to-oci-layout "${release_layout}:arm64"
-          oras manifest index create --oci-layout "${release_layout}:${GITHUB_REF_NAME}" amd64 arm64 >/dev/null
+          oras manifest index create --oci-layout "${release_layout}:${RELEASE_TAG}" amd64 arm64 >/dev/null
           mkdir -p "${bound}"
           cp "dist/preflight-install/${bundle}" "${bound}/${bundle}"
           cp dist/preflight-install/workcell.rb "${bound}/workcell.rb"
           cp dist/preflight/workcell-build-inputs-preflight.json "${bound}/workcell-build-inputs.json"
           cp dist/preflight/workcell-control-plane-preflight.json "${bound}/workcell-control-plane.json"
-          printf '%s@%s\n' "${IMAGE_NAME}" "$(oras resolve --oci-layout "${release_layout}:${GITHUB_REF_NAME}")" > "${bound}/workcell-image.digest"
+          printf '%s@%s\n' "${IMAGE_NAME}" "$(oras resolve --oci-layout "${release_layout}:${RELEASE_TAG}")" > "${bound}/workcell-image.digest"
           tar -xzf "${bound}/${bundle}" -C "${source_root}"
-          syft scan "dir:${source_root}/workcell-${GITHUB_REF_NAME}" -o "spdx-json=${bound}/workcell-source.spdx.json"
+          syft scan "dir:${source_root}/workcell-${RELEASE_TAG}" -o "spdx-json=${bound}/workcell-source.spdx.json"
           syft scan "oci-dir:${release_layout}" -o "spdx-json=${bound}/workcell-image.spdx.json"
           ./scripts/generate-builder-environment-manifest.sh "${bound}/workcell-builder-environment.json"
           ./scripts/generate-release-checksums.sh "${bound}/SHA256SUMS" \
@@ -1058,6 +1123,10 @@ jobs:
       - build-amd64-image
       - build-arm64-image
       - bind-release-subjects
+    env:
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
+      RELEASE_TAG_OBJECT: ${{ needs.tag-policy.outputs.tag_object }}
     permissions:
       contents: read
     outputs:
@@ -1067,8 +1136,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Recheck release tag before release assembly
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"
 
       - name: Download preflight binding manifests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1096,7 +1171,7 @@ jobs:
 
       - id: source_date
         name: Compute source date epoch
-        run: echo "epoch=$(git log -1 --pretty=%ct "${GITHUB_SHA}")" >> "${GITHUB_OUTPUT}"
+        run: echo "epoch=$(git log -1 --pretty=%ct "${RELEASE_COMMIT}")" >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
@@ -1123,7 +1198,7 @@ jobs:
         run: |
           docker build \
             -f tools/validator/Dockerfile \
-            -t "workcell-validator:${GITHUB_SHA}" \
+            -t "workcell-validator:${RELEASE_COMMIT}" \
             .
 
       - name: Prepare release bundle
@@ -1131,7 +1206,7 @@ jobs:
           WORKCELL_BUILDKIT_IMAGE: ${{ env.WORKCELL_BUILDKIT_IMAGE }}
           WORKCELL_BUILDX_VERSION: ${{ env.WORKCELL_BUILDX_VERSION }}
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
-          WORKCELL_BUILD_INPUT_REF: ${{ github.sha }}
+          WORKCELL_BUILD_INPUT_REF: ${{ needs.tag-policy.outputs.release_commit }}
           WORKCELL_COSIGN_VERSION: ${{ env.WORKCELL_COSIGN_VERSION }}
           WORKCELL_QEMU_IMAGE: ${{ env.WORKCELL_QEMU_IMAGE }}
           WORKCELL_SYFT_VERSION: ${{ env.WORKCELL_SYFT_VERSION }}
@@ -1143,7 +1218,7 @@ jobs:
           validator_home="/tmp/workcell-home-${validator_uid}"
           validator_cache="${validator_home}/.cache"
           validator_tmp="${validator_home}/.tmp"
-          bundle="workcell-${GITHUB_REF_NAME}.tar.gz"
+          bundle="workcell-${RELEASE_TAG}.tar.gz"
           echo "BUNDLE_NAME=${bundle}" >> "${GITHUB_ENV}"
           docker run --rm \
             --user "${validator_uid}:${validator_gid}" \
@@ -1155,10 +1230,10 @@ jobs:
             -e XDG_CACHE_HOME="${validator_cache}" \
             -e TMPDIR="${validator_tmp}" \
             -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH}" \
-            -e ARCHIVE_REF="${GITHUB_SHA}" \
+            -e ARCHIVE_REF="${RELEASE_COMMIT}" \
             -e BUNDLE_NAME="${bundle}" \
-            -e BUNDLE_PREFIX="workcell-${GITHUB_REF_NAME}/" \
-            "workcell-validator:${GITHUB_SHA}" \
+            -e BUNDLE_PREFIX="workcell-${RELEASE_TAG}/" \
+            "workcell-validator:${RELEASE_COMMIT}" \
             -lc '
               set -euo pipefail
               mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${TMPDIR}"
@@ -1174,7 +1249,7 @@ jobs:
             '
           mkdir -p dist/source-tree
           tar -xzf "dist/${bundle}" -C dist/source-tree
-          ln -sfn "source-tree/workcell-${GITHUB_REF_NAME}" dist/release-source
+          ln -sfn "source-tree/workcell-${RELEASE_TAG}" dist/release-source
           echo "RELEASE_SOURCE_ROOT=dist/release-source" >> "${GITHUB_ENV}"
           ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs.json
 
@@ -1208,7 +1283,7 @@ jobs:
       - name: Regenerate build input manifest from archived source tree
         env:
           WORKCELL_BUILD_INPUT_ROOT: ${{ github.workspace }}/dist/release-source
-          WORKCELL_BUILD_INPUT_REF: ${{ github.sha }}
+          WORKCELL_BUILD_INPUT_REF: ${{ needs.tag-policy.outputs.release_commit }}
           SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
         run: ./scripts/generate-build-input-manifest.sh dist/workcell-build-inputs-archived.json
 
@@ -1223,7 +1298,7 @@ jobs:
         run: |
           bundle_sha="$(sha256sum "dist/${BUNDLE_NAME}" | awk '{print $1}')"
           ./scripts/generate-homebrew-formula.sh \
-            "${GITHUB_REF_NAME}" \
+            "${RELEASE_TAG}" \
             "${bundle_sha}" \
             dist/workcell.rb \
             --repository "${GITHUB_REPOSITORY}"
@@ -1274,8 +1349,8 @@ jobs:
             jq -e \
               --arg repository "${GITHUB_REPOSITORY}" \
               --arg run_id "${GITHUB_RUN_ID}" \
-              --arg tag "${GITHUB_REF_NAME}" \
-              --arg commit "${GITHUB_SHA}" \
+              --arg tag "${RELEASE_TAG}" \
+              --arg commit "${RELEASE_COMMIT}" \
               --arg platform "linux/${arch}" \
               '.repository == $repository and .run_id == $run_id and .tag == $tag and .commit == $commit and .platform == $platform' \
               "${handoff}" >/dev/null
@@ -1390,9 +1465,9 @@ jobs:
             "dist/image-arm64/layout@${ARM64_DIGEST}" \
             --to-oci-layout dist/release-image:arm64
           oras manifest index create --oci-layout \
-            "dist/release-image:${GITHUB_REF_NAME}" \
+            "dist/release-image:${RELEASE_TAG}" \
             amd64 arm64 >/dev/null
-          manifest_json="$(oras manifest fetch --oci-layout "dist/release-image:${GITHUB_REF_NAME}")"
+          manifest_json="$(oras manifest fetch --oci-layout "dist/release-image:${RELEASE_TAG}")"
           image_manifests_json="$(jq -c '.manifests' <<<"${manifest_json}")"
           platform_arches="$(jq -r '[.[].platform.architecture] | @json' <<<"${image_manifests_json}")"
           if [[ "${platform_arches}" != '["amd64","arm64"]' ]]; then
@@ -1400,7 +1475,7 @@ jobs:
             exit 1
           fi
 
-          digest="$(oras resolve --oci-layout "dist/release-image:${GITHUB_REF_NAME}")"
+          digest="$(oras resolve --oci-layout "dist/release-image:${RELEASE_TAG}")"
           test "${digest}" = "sha256:$(printf '%s' "${manifest_json}" | sha256sum | awk '{print $1}')"
 
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
@@ -1429,8 +1504,8 @@ jobs:
           jq -n \
             --arg repository "${GITHUB_REPOSITORY}" \
             --arg run_id "${GITHUB_RUN_ID}" \
-            --arg tag "${GITHUB_REF_NAME}" \
-            --arg commit "${GITHUB_SHA}" \
+            --arg tag "${RELEASE_TAG}" \
+            --arg commit "${RELEASE_COMMIT}" \
             --arg image_digest "${IMAGE_DIGEST}" \
             --arg amd64_manifest "$(jq -r '.platforms["linux/amd64"].image_manifest_digest' dist/preflight/workcell-runtime-preflight.json)" \
             --arg amd64_config "$(jq -r '.platforms["linux/amd64"].config_digest' dist/preflight/workcell-runtime-preflight.json)" \
@@ -1472,7 +1547,7 @@ jobs:
       - release
     environment:
       name: release
-      url: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}
     permissions:
       artifact-metadata: write # Publish GitHub artifact attestations.
       attestations: write # Create GitHub attestations for reviewed subjects.
@@ -1480,11 +1555,19 @@ jobs:
       id-token: write # Request the keyless signing identity.
       packages: write # Upload the validated OCI layout and its signatures.
     env:
-      BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
+      RELEASE_TAG_OBJECT: ${{ needs.tag-policy.outputs.tag_object }}
+      BUNDLE_NAME: workcell-${{ needs.tag-policy.outputs.release_tag }}.tar.gz
     outputs:
       artifact_id: ${{ steps.upload_signed.outputs.artifact-id }}
       artifact_digest: ${{ steps.upload_signed.outputs.artifact-digest }}
     steps:
+      - name: Recheck release tag before signing and image mutation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"
+
       - name: Download bound unsigned release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1515,8 +1598,8 @@ jobs:
           jq -e \
             --arg repository "${GITHUB_REPOSITORY}" \
             --arg run_id "${GITHUB_RUN_ID}" \
-            --arg tag "${GITHUB_REF_NAME}" \
-            --arg commit "${GITHUB_SHA}" \
+            --arg tag "${RELEASE_TAG}" \
+            --arg commit "${RELEASE_COMMIT}" \
             --arg image_digest "${EXPECTED_IMAGE_DIGEST}" \
             '.repository == $repository and .run_id == $run_id and .tag == $tag and .commit == $commit and .image_digest == $image_digest' \
             dist/workcell-release-handoff.json >/dev/null
@@ -1564,6 +1647,11 @@ jobs:
           install -m 0755 "${RUNNER_TEMP}/oras" "${RUNNER_TEMP}/bin/oras"
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
+      - name: Recheck release tag before named image publication
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"
+
       - name: Publish bound OCI layout
         env:
           IMAGE_DIGEST: ${{ needs.release.outputs.image_digest }}
@@ -1573,8 +1661,8 @@ jobs:
           while IFS= read -r blob; do
             test "$(sha256sum "${blob}" | awk '{print $1}')" = "$(basename "${blob}")"
           done < <(find "${RUNNER_TEMP}/release-image/blobs/sha256" -type f -print)
-          test "$(oras resolve --oci-layout "${RUNNER_TEMP}/release-image:${GITHUB_REF_NAME}")" = "${IMAGE_DIGEST}"
-          manifest_json="$(oras manifest fetch --oci-layout "${RUNNER_TEMP}/release-image:${GITHUB_REF_NAME}")"
+          test "$(oras resolve --oci-layout "${RUNNER_TEMP}/release-image:${RELEASE_TAG}")" = "${IMAGE_DIGEST}"
+          manifest_json="$(oras manifest fetch --oci-layout "${RUNNER_TEMP}/release-image:${RELEASE_TAG}")"
           test "$(jq -c '[.manifests[] | {digest,platform}]' <<<"${manifest_json}")" = \
             "$(jq -c '[{digest:.platforms["linux/amd64"].manifest_digest,platform:{architecture:"amd64",os:"linux"}},{digest:.platforms["linux/arm64"].manifest_digest,platform:{architecture:"arm64",os:"linux"}}]' dist/workcell-release-handoff.json)"
           for arch in amd64 arm64; do
@@ -1583,9 +1671,9 @@ jobs:
             test "$(jq -r '.config.digest' "${RUNNER_TEMP}/release-image/blobs/sha256/${manifest_digest#sha256:}")" = "${config_digest}"
           done
           oras cp --recursive --from-oci-layout \
-            "${RUNNER_TEMP}/release-image:${GITHUB_REF_NAME}" \
-            "${IMAGE_NAME}:${GITHUB_REF_NAME},sha-${GITHUB_SHA}"
-          test "$(oras resolve "${IMAGE_NAME}:${GITHUB_REF_NAME}")" = "${IMAGE_DIGEST}"
+            "${RUNNER_TEMP}/release-image:${RELEASE_TAG}" \
+            "${IMAGE_NAME}:${RELEASE_TAG},sha-${RELEASE_COMMIT}"
+          test "$(oras resolve "${IMAGE_NAME}:${RELEASE_TAG}")" = "${IMAGE_DIGEST}"
 
       - name: Sign release image
         env:
@@ -1756,8 +1844,8 @@ jobs:
       - tag-policy
       - sign-release
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
-      RELEASE_COMMIT: ${{ github.sha }}
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
     permissions:
       actions: read # Download the sealed artifact from the signing job.
       attestations: read # Read GitHub artifact attestations.
@@ -1766,6 +1854,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -1814,8 +1903,9 @@ jobs:
       - sign-release
       - verify-release-outputs
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
-      RELEASE_COMMIT: ${{ github.sha }}
+      RELEASE_TAG: ${{ needs.tag-policy.outputs.release_tag }}
+      RELEASE_COMMIT: ${{ needs.tag-policy.outputs.release_commit }}
+      RELEASE_TAG_OBJECT: ${{ needs.tag-policy.outputs.tag_object }}
     environment:
       name: hosted-controls-audit
     permissions:
@@ -1826,6 +1916,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.tag-policy.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -1868,11 +1959,11 @@ jobs:
       - name: Verify release tag signature
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${GITHUB_REF_NAME}"
+        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"
 
       - name: Recheck hosted controls and publish GitHub release assets
         env:
-          BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz
+          BUNDLE_NAME: workcell-${{ env.RELEASE_TAG }}.tar.gz
           GITHUB_TOKEN: ${{ github.token }}
           WORKCELL_HOSTED_CONTROLS_REQUIRED: "1"
           WORKCELL_HOSTED_CONTROLS_TOKEN: ${{ secrets.WORKCELL_HOSTED_CONTROLS_TOKEN }}
@@ -1882,7 +1973,8 @@ jobs:
           # the default Actions token for release mutations.
           ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"
           unset WORKCELL_HOSTED_CONTROLS_TOKEN
-          ./scripts/publish-github-release.sh "${GITHUB_REF_NAME}" \
+          ./scripts/publish-github-release.sh "${RELEASE_TAG}" \
+            --expected-tag-object "${RELEASE_TAG_OBJECT}" \
             --immutable-releases-preverified-by-hosted-controls \
             "dist/${BUNDLE_NAME}" \
             "dist/${BUNDLE_NAME}.sigstore.json" \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,11 +57,12 @@ offline install. You can also give it a local attestation with `--bundle`.
 
 The regex below anchors and escapes the fixed identity text (`^…\.…$`). The
 release workflow always runs from `main`, so no part of the identity varies.
-`verify-release-artifact.sh` uses the same expression. It also accepts the one
-exact `refs/tags/TAG` identity when you give it `--tag`, because a release
-published before the dispatch trigger was signed from the pushed tag.
-`install-release.sh` passes the version you requested, so verifying an older
-release needs no extra step.
+`verify-release-artifact.sh` uses the same expression. It accepts an exact
+`refs/tags/TAG` identity only for the closed set of releases published before
+the dispatch trigger, which it names in `TAG_SIGNED_RELEASES`. Every later
+release must present the `main` identity, so a tag pushed after the change
+cannot sign a release. `install-release.sh` passes the version you requested,
+so verifying one of those historical releases needs no extra step.
 
 ```bash
 cosign verify-blob SHA256SUMS \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,11 @@ offline install. You can also give it a local attestation with `--bundle`.
 
 The regex below anchors and escapes the fixed identity text (`^…\.…$`). The
 release workflow always runs from `main`, so no part of the identity varies.
-`verify-release-artifact.sh` uses the same expression.
+`verify-release-artifact.sh` uses the same expression. It also accepts the one
+exact `refs/tags/TAG` identity when you give it `--tag`, because a release
+published before the dispatch trigger was signed from the pushed tag.
+`install-release.sh` passes the version you requested, so verifying an older
+release needs no extra step.
 
 ```bash
 cosign verify-blob SHA256SUMS \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,6 +64,11 @@ release must present the `main` identity, so a tag pushed after the change
 cannot sign a release. `install-release.sh` passes the version you requested,
 so verifying one of those historical releases needs no extra step.
 
+The manual commands below pin the `main` identity. To verify one of the
+historical releases by hand, `v1.0.2` among them, replace `refs/heads/main`
+with `refs/tags/` and that exact tag. Prefer `verify-release-artifact.sh`,
+which selects the identity for you.
+
 ```bash
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,20 +55,20 @@ steps can run offline with the downloaded Sigstore bundle.
 The GitHub attestation step requires network access by default. Omit it for an
 offline install. You can also give it a local attestation with `--bundle`.
 
-The regex below anchors and escapes the fixed identity text (`^…\.…$`). Thus,
-only the release tag is variable. `verify-release-artifact.sh` uses the same
-expression.
+The regex below anchors and escapes the fixed identity text (`^…\.…$`). The
+release workflow always runs from `main`, so no part of the identity varies.
+`verify-release-artifact.sh` uses the same expression.
 
 ```bash
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/heads/main$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
 # needs network; pins the same anchored/escaped identity regex + OIDC issuer that
 # install-release.sh --attestation uses (not --signer-workflow, which can over-match).
 gh attestation verify workcell-vX.Y.Z.tar.gz --repo omkhar/workcell \
-  --cert-identity-regex '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/tags/.+$' \
+  --cert-identity-regex '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/heads/main$' \
   --cert-oidc-issuer https://token.actions.githubusercontent.com
 tar -xzf workcell-vX.Y.Z.tar.gz
 cd workcell-vX.Y.Z
@@ -94,7 +94,7 @@ curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/SHA256SUMS
 curl -LO https://github.com/omkhar/workcell/releases/download/vX.Y.Z/SHA256SUMS.sigstore.json
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/tags/.+$' \
+  --certificate-identity-regexp '^https://github\.com/omkhar/workcell/\.github/workflows/release\.yml@refs/heads/main$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 shasum -a 256 --ignore-missing -c SHA256SUMS
 brew install --formula ./workcell.rb

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -117,7 +117,8 @@ The architecture build jobs and assembly job have only `contents: read` permissi
 They transfer bound artifacts with GitHub Actions artifact runtime credentials.
 The signer downloads those subjects by immutable artifact ID and requires exact byte matches.
 A release-approved signing job validates the handoff and publishes the OCI layout.
-The signing job uses fixed tools and does not check out repository code.
+The signing job uses fixed tools and checks out only the verified release commit,
+which it needs for the reviewed tag rechecks it runs before it signs and before it publishes.
 The final job publishes the 18 signed GitHub release assets.
 
 Release preflight does these checks:

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -97,12 +97,15 @@ The release install matrix runs the same ACL script before it uses release artif
 
 ## Release workflow
 
+The tag-policy job resolves the signed tag to one commit before any checkout.
+Every later job checks out that commit, so a moved tag cannot change the release source.
+
 The preflight job records the expected digest for its source archive.
-The release job independently creates and extracts its own archive from the checked-out release tag.
+The release job independently creates and extracts its own archive from the checked-out release commit.
 It then compares the archive digest with the expected digest.
 It creates source-dependent manifests from the extracted tree.
 It creates the formula from the verified archive digest.
-The native amd64 and arm64 image jobs build from the checked-out release tag.
+The native amd64 and arm64 image jobs build from the checked-out release commit.
 Each one binds its image digest to the matching preflight reproducibility digest.
 
 A separate read-only job creates the nine non-image signing subjects.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -258,10 +258,9 @@ gh attestation verify "${asset}" \
 The verified installer runs the Cosign and digest checks before extraction.
 Add `--attestation` to require the GitHub check.
 
-The shipped installer pins one exact identity, not any release tag. A release
-published after `v1.0.2` carries only the `refs/heads/main` identity. For the
-closed set of earlier tag-signed releases, the installer accepts that one exact
-tag identity as well, and no other.
+The shipped installer pins one exact identity, not any release tag: `refs/heads/main`
+for a release published after `v1.0.2`, or that release's own exact tag identity for
+the closed set of earlier tag-signed releases.
 
 ## SLSA v1.0 Build-track gap analysis
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -142,6 +142,13 @@ The `v1.0.2` GHCR package denied anonymous access during the 2026-08-05 check.
 Authenticate to GHCR with `read:packages` access before you verify that image.
 See [GitHub container registry authentication](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
+The release workflow now starts from a `repository_dispatch` event.
+GitHub always loads that workflow from the default branch.
+For each release after `v1.0.2`, set `identity` to
+`https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/heads/main`
+and set `--source-ref` to `refs/heads/main`.
+The `v1.0.2` values below stay as the historical example.
+
 Run the complete procedure in one Bash subshell.
 The subshell does not replace the current Docker configuration or exit trap.
 When the prompt appears, enter a token that has package access.
@@ -200,6 +207,11 @@ Download the asset and these two files from that release:
 
 - `SHA256SUMS`
 - `SHA256SUMS.sigstore.json`
+
+For each release after `v1.0.2`, set `identity` to
+`https://github.com/omkhar/workcell/.github/workflows/release.yml@refs/heads/main`
+and set `--source-ref` to `refs/heads/main`.
+The dispatched release workflow always runs from the default branch.
 
 Verify the checksum signature first:
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -258,8 +258,10 @@ gh attestation verify "${asset}" \
 The verified installer runs the Cosign and digest checks before extraction.
 Add `--attestation` to require the GitHub check.
 
-The shipped installer pins the repository workflow but accepts any release tag identity.
-Use the manual procedure above when you require exact-tag certificate binding.
+The shipped installer pins one exact identity, not any release tag. A release
+published after `v1.0.2` carries only the `refs/heads/main` identity. For the
+closed set of earlier tag-signed releases, the installer accepts that one exact
+tag identity as well, and no other.
 
 ## SLSA v1.0 Build-track gap analysis
 

--- a/docs/release-posture.md
+++ b/docs/release-posture.md
@@ -17,13 +17,16 @@ It does these checks:
 - It verifies the pinned Codex, Claude, Copilot, and Gemini releases against upstream metadata.
 - It keeps Antigravity unsupported until that provider passes the same gate.
 
+The tag-policy job resolves the signed tag to one commit before any checkout.
+Every later job checks out that commit, so a moved tag cannot change the release source.
+
 The preflight job records the expected digest for its source archive.
-The release job creates and extracts an independent archive from the checked-out release tag.
+The release job creates and extracts an independent archive from the checked-out release commit.
 It compares that archive digest with the expected digest.
 It creates source-dependent manifests from the extracted tree.
 It creates the Homebrew formula from the verified archive digest.
 
-The native amd64 and arm64 image jobs build from the checked-out release tag.
+The native amd64 and arm64 image jobs build from the checked-out release commit.
 Each one has only `contents: read` permission and emits an OCI archive.
 The workflow compares the bound platform digests with the preflight data.
 

--- a/internal/host/release/publisher_input_test.go
+++ b/internal/host/release/publisher_input_test.go
@@ -270,8 +270,9 @@ func TestReleaseWorkflowUsesSingleAuthoritativeTagPolicyGate(t *testing.T) {
 	if strings.Count(workflow, "release classify-tag") != 1 {
 		t.Fatalf("release workflow classify-tag invocation count = %d, want 1", strings.Count(workflow, "release classify-tag"))
 	}
-	if strings.Contains(workflow, "=~") || strings.Contains(workflow, `^v[0-9]`) {
-		t.Fatal("release workflow contains a competing release-tag regex")
+	envelopeCheck := `if [[ ! "${RELEASE_TAG}" =~ ^v[0-9A-Za-z.-]{1,63}$ ]]; then`
+	if count := strings.Count(workflow, envelopeCheck); count != 1 {
+		t.Fatalf("release workflow bounded tag envelope count = %d, want 1", count)
 	}
 
 	var document struct {
@@ -287,8 +288,8 @@ func TestReleaseWorkflowUsesSingleAuthoritativeTagPolicyGate(t *testing.T) {
 	if !ok {
 		t.Fatal("release workflow is missing tag-policy job")
 	}
-	if len(tagPolicy.Permissions) != 1 || tagPolicy.Permissions["contents"] != "read" {
-		t.Fatalf("tag-policy permissions = %#v, want only contents: read", tagPolicy.Permissions)
+	if len(tagPolicy.Permissions) != 2 || tagPolicy.Permissions["contents"] != "read" || tagPolicy.Permissions["actions"] != "read" {
+		t.Fatalf("tag-policy permissions = %#v, want contents and actions read", tagPolicy.Permissions)
 	}
 	for jobID, job := range document.Jobs {
 		if jobID == "tag-policy" {
@@ -311,10 +312,17 @@ func TestReleaseWorkflowUsesSingleAuthoritativeTagPolicyGate(t *testing.T) {
 	if strings.Contains(publisher, "curl ") || strings.Contains(publisher, "api GET") {
 		t.Fatal("publisher shell must delegate GitHub release API policy to the Go publisher")
 	}
-	for _, binding := range []string{`"${TAG_REF}^{tag}"`, `"${TAG_REF}^{commit}"`} {
+	for _, binding := range []string{
+		`"${TAG_REF}^{tag}"`,
+		`cat-file tag "${TAG_OBJECT_SHA}"`,
+		`object_type != "commit"`,
+	} {
 		if strings.Count(publisher, binding) != 1 {
 			t.Fatalf("publisher tag binding %q count = %d, want 1", binding, strings.Count(publisher, binding))
 		}
+	}
+	if strings.Contains(publisher, `"${TAG_REF}^{commit}"`) || strings.Contains(publisher, `"${TAG_OBJECT_SHA}^{commit}"`) {
+		t.Fatal("publisher must read the commit only from the captured annotated tag object headers")
 	}
 }
 
@@ -344,7 +352,7 @@ func TestWorkflowInventoryParserAcceptsBothBundlePlaceholderForms(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			marker := "- name: Upload workflow artifacts"
 			if tc.name == "expression placeholder in publisher" {
-				marker = `./scripts/publish-github-release.sh "${GITHUB_REF_NAME}"`
+				marker = `./scripts/publish-github-release.sh "${RELEASE_TAG}"`
 			}
 			mutated := replaceWorkflowSection(workflow, marker, tc.old, tc.new)
 			if mutated == workflow {
@@ -400,7 +408,7 @@ func TestWorkflowInventoryParserRejectsMutations(t *testing.T) {
 		{
 			name: "unresolved placeholder",
 			mutate: func(value string) string {
-				return replaceWorkflowSection(value, `./scripts/publish-github-release.sh "${GITHUB_REF_NAME}"`, "            \"dist/${BUNDLE_NAME}\" \\\n", "            \"dist/${UNRESOLVED_BUNDLE}\" \\\n")
+				return replaceWorkflowSection(value, `./scripts/publish-github-release.sh "${RELEASE_TAG}"`, "            \"dist/${BUNDLE_NAME}\" \\\n", "            \"dist/${UNRESOLVED_BUNDLE}\" \\\n")
 			},
 			want: "unresolved placeholder",
 		},
@@ -414,7 +422,7 @@ func TestWorkflowInventoryParserRejectsMutations(t *testing.T) {
 		{
 			name: "duplicate publisher invocation",
 			mutate: func(value string) string {
-				return value + "\n          ./scripts/publish-github-release.sh \"${GITHUB_REF_NAME}\" \\\n            dist/workcell.rb\n"
+				return value + "\n          ./scripts/publish-github-release.sh \"${RELEASE_TAG}\" \\\n            dist/workcell.rb\n"
 			},
 			want: "exactly one publisher inventory",
 		},
@@ -633,7 +641,7 @@ func parseWorkflowAssetInventories(workflow, tag string) (map[string][]string, e
 			}
 		case section == "artifact" && strings.HasPrefix(trimmed, "retention-days:"):
 			section = ""
-		case strings.HasPrefix(trimmed, `./scripts/publish-github-release.sh "${GITHUB_REF_NAME}"`):
+		case strings.HasPrefix(trimmed, `./scripts/publish-github-release.sh "${RELEASE_TAG}"`):
 			publisherInventories++
 			section = "publisher"
 		case section == "publisher":

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -487,8 +487,10 @@ func validateReleaseTagRechecks(workflowText string) error {
 		if mutationAt < 0 {
 			return fmt.Errorf("%s: job %s must keep its %q step", requirement, name, phase.before)
 		}
-		if lastAt > mutationAt {
-			return fmt.Errorf("%s: job %s runs a check after its %q step", requirement, name, phase.before)
+		// The check must run in an earlier step, not merely no later: a check
+		// moved inside the mutation step can sit after the mutation itself.
+		if lastAt >= mutationAt {
+			return fmt.Errorf("%s: job %s does not run a check before its %q step", requirement, name, phase.before)
 		}
 	}
 	for name := range releaseTagRecheckPhases {

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -425,35 +426,59 @@ func (check *pinnedInputsCheck) validateReleaseLegacyReferences() error {
 	); err != nil {
 		return err
 	}
-	count, err := countReleaseTagRechecks(check.releaseWorkflow)
-	if err != nil {
-		return err
-	}
-	if count != 5 {
-		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures before every release mutation phase, found %d checks", count)
-	}
-	return nil
+	return validateReleaseTagRechecks(check.releaseWorkflow)
 }
 
-// countReleaseTagRechecks counts the tag-signature rechecks that execute. It
-// reads parsed run statements, so a check converted into a comment no longer
-// counts towards the required set.
-func countReleaseTagRechecks(workflowText string) (int, error) {
+// releaseTagRecheckPhases names each job that mutates release state and the
+// number of bound rechecks it must run before doing so. Counting per job, not
+// across the file, keeps a recheck deleted from one phase from being covered by
+// a duplicate added to an unrelated job.
+var releaseTagRecheckPhases = map[string]int{
+	"preflight":              1,
+	"release":                1,
+	"sign-release":           2,
+	"publish-github-release": 1,
+}
+
+// releaseTagRecheckArguments is the complete reviewed argument list. A recheck
+// missing the commit or tag-object binding proves less than its name suggests,
+// so a partial invocation does not count towards a phase.
+var releaseTagRecheckArguments = []string{
+	"--github-repo", `"${GITHUB_REPOSITORY}"`,
+	"--repo-root", `"${GITHUB_WORKSPACE}"`,
+	"--tag", `"${RELEASE_TAG}"`,
+	"--expected-commit", `"${RELEASE_COMMIT}"`,
+	"--expected-tag-object", `"${RELEASE_TAG_OBJECT}"`,
+}
+
+// validateReleaseTagRechecks requires each mutation phase to run its own fully
+// bound tag recheck, and no other job to run one. It reads parsed run
+// statements, so a check converted into a comment does not count.
+func validateReleaseTagRechecks(workflowText string) error {
 	var document workflowDocument
 	if err := yaml.Unmarshal([]byte(workflowText), &document); err != nil {
-		return 0, fmt.Errorf("parse release tag rechecks: %w", err)
+		return fmt.Errorf("parse release tag rechecks: %w", err)
 	}
-	count := 0
-	for _, job := range document.Jobs {
+	const requirement = ".github/workflows/release.yml must verify release tag signatures before every release mutation phase"
+	for name, job := range document.Jobs {
+		found := 0
 		for _, step := range job.Steps {
 			for _, arguments := range commandArgs(step.Run, "./scripts/check-release-tag-signature.sh") {
-				if len(arguments) > 0 && arguments[0] == "--github-repo" {
-					count++
+				if slices.Equal(arguments, releaseTagRecheckArguments) {
+					found++
 				}
 			}
 		}
+		if want := releaseTagRecheckPhases[name]; found != want {
+			return fmt.Errorf("%s: job %s runs %d bound checks, want %d", requirement, name, found, want)
+		}
 	}
-	return count, nil
+	for name := range releaseTagRecheckPhases {
+		if _, ok := document.Jobs[name]; !ok {
+			return fmt.Errorf("%s: mutation phase %s is missing", requirement, name)
+		}
+	}
+	return nil
 }
 
 func (check *pinnedInputsCheck) validateReleaseHostedControls() error {

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -423,8 +423,8 @@ func (check *pinnedInputsCheck) validateReleaseLegacyReferences() error {
 	); err != nil {
 		return err
 	}
-	if count := strings.Count(check.releaseWorkflow, "./scripts/check-release-tag-signature.sh --github-repo"); count != 2 {
-		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures in preflight and publish jobs, found %d checks", count)
+	if count := strings.Count(check.releaseWorkflow, "./scripts/check-release-tag-signature.sh --github-repo"); count != 5 {
+		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures before every release mutation phase, found %d checks", count)
 	}
 	return nil
 }

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -429,15 +429,21 @@ func (check *pinnedInputsCheck) validateReleaseLegacyReferences() error {
 	return validateReleaseTagRechecks(check.releaseWorkflow)
 }
 
-// releaseTagRecheckPhases names each job that mutates release state and the
-// number of bound rechecks it must run before doing so. Counting per job, not
-// across the file, keeps a recheck deleted from one phase from being covered by
-// a duplicate added to an unrelated job.
-var releaseTagRecheckPhases = map[string]int{
-	"preflight":              1,
-	"release":                1,
-	"sign-release":           2,
-	"publish-github-release": 1,
+// releaseTagRecheckPhases names each job that mutates release state, the number
+// of bound rechecks it must run, and the step every one of them must precede.
+// Counting per job, not across the file, keeps a recheck deleted from one phase
+// from being covered by a duplicate added to an unrelated job. Requiring the
+// step order keeps a recheck moved below its mutation from counting either: a
+// check that runs after the mutation proves nothing about the tag the mutation
+// used.
+var releaseTagRecheckPhases = map[string]struct {
+	count  int
+	before string
+}{
+	"preflight":              {1, "Build preflight release install artifacts"},
+	"release":                {1, "Assemble deterministic multi-arch OCI layout"},
+	"sign-release":           {2, "Publish bound OCI layout"},
+	"publish-github-release": {1, "Recheck hosted controls and publish GitHub release assets"},
 }
 
 // releaseTagRecheckArguments is the complete reviewed argument list. A recheck
@@ -461,16 +467,28 @@ func validateReleaseTagRechecks(workflowText string) error {
 	}
 	const requirement = ".github/workflows/release.yml must verify release tag signatures before every release mutation phase"
 	for name, job := range document.Jobs {
-		found := 0
-		for _, step := range job.Steps {
+		phase := releaseTagRecheckPhases[name]
+		found, lastAt := 0, -1
+		for at, step := range job.Steps {
 			for _, arguments := range commandArgs(step.Run, "./scripts/check-release-tag-signature.sh") {
 				if slices.Equal(arguments, releaseTagRecheckArguments) {
 					found++
+					lastAt = at
 				}
 			}
 		}
-		if want := releaseTagRecheckPhases[name]; found != want {
-			return fmt.Errorf("%s: job %s runs %d bound checks, want %d", requirement, name, found, want)
+		if found != phase.count {
+			return fmt.Errorf("%s: job %s runs %d bound checks, want %d", requirement, name, found, phase.count)
+		}
+		if phase.count == 0 {
+			continue
+		}
+		mutationAt := slices.IndexFunc(job.Steps, func(step workflowStep) bool { return step.Name == phase.before })
+		if mutationAt < 0 {
+			return fmt.Errorf("%s: job %s must keep its %q step", requirement, name, phase.before)
+		}
+		if lastAt > mutationAt {
+			return fmt.Errorf("%s: job %s runs a check after its %q step", requirement, name, phase.before)
 		}
 	}
 	for name := range releaseTagRecheckPhases {

--- a/internal/metadatautil/pinnedinputs_check_workflows.go
+++ b/internal/metadatautil/pinnedinputs_check_workflows.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type workflowText struct{ text, path string }
@@ -423,10 +425,35 @@ func (check *pinnedInputsCheck) validateReleaseLegacyReferences() error {
 	); err != nil {
 		return err
 	}
-	if count := strings.Count(check.releaseWorkflow, "./scripts/check-release-tag-signature.sh --github-repo"); count != 5 {
+	count, err := countReleaseTagRechecks(check.releaseWorkflow)
+	if err != nil {
+		return err
+	}
+	if count != 5 {
 		return fmt.Errorf(".github/workflows/release.yml must verify release tag signatures before every release mutation phase, found %d checks", count)
 	}
 	return nil
+}
+
+// countReleaseTagRechecks counts the tag-signature rechecks that execute. It
+// reads parsed run statements, so a check converted into a comment no longer
+// counts towards the required set.
+func countReleaseTagRechecks(workflowText string) (int, error) {
+	var document workflowDocument
+	if err := yaml.Unmarshal([]byte(workflowText), &document); err != nil {
+		return 0, fmt.Errorf("parse release tag rechecks: %w", err)
+	}
+	count := 0
+	for _, job := range document.Jobs {
+		for _, step := range job.Steps {
+			for _, arguments := range commandArgs(step.Run, "./scripts/check-release-tag-signature.sh") {
+				if len(arguments) > 0 && arguments[0] == "--github-repo" {
+					count++
+				}
+			}
+		}
+	}
+	return count, nil
 }
 
 func (check *pinnedInputsCheck) validateReleaseHostedControls() error {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -341,7 +341,42 @@ func TestCheckPinnedInputsRejectsCommentedReleaseTagRecheck(t *testing.T) {
 		return strings.Replace(content, recheck,
 			"        run: |\n          #"+strings.TrimPrefix(recheck, "        run:")+"\n          true", 1)
 	})
-	requirePinnedInputsErrorContains(t, cfg, "found 4 checks")
+	requirePinnedInputsErrorContains(t, cfg, "before every release mutation phase")
+}
+
+// Each mutation phase must run its own fully bound recheck: a check moved to
+// another job, or one missing part of its binding, does not cover the phase it
+// left behind.
+func TestCheckPinnedInputsRejectsUnboundReleaseTagRechecks(t *testing.T) {
+	const recheck = `        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"`
+	for name, rewrite := range map[string]func(string) string{
+		"recheck relocated to another job": func(content string) string {
+			// Add a duplicate to the assembly job and drop the first phase's
+			// own check, so the file-wide count is still five while one
+			// mutation phase now runs none.
+			const assemblyStep = "      - name: Recheck release tag before release assembly\n" +
+				"        env:\n          GITHUB_TOKEN: ${{ github.token }}\n" + recheck + "\n"
+			duplicated := strings.Replace(content, assemblyStep, assemblyStep+"\n"+assemblyStep, 1)
+			return strings.Replace(duplicated, recheck+"\n", "        run: 'true'\n", 1)
+		},
+		"recheck missing its tag-object binding": func(content string) string {
+			return strings.Replace(content, ` --expected-tag-object "${RELEASE_TAG_OBJECT}"`, "", 1)
+		},
+		"recheck missing its commit binding": func(content string) string {
+			return strings.Replace(content, ` --expected-commit "${RELEASE_COMMIT}"`, "", 1)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, ".github/workflows/release.yml", func(content string) string {
+				mutated := rewrite(content)
+				if mutated == content {
+					t.Fatalf("mutation %q did not change the workflow", name)
+				}
+				return mutated
+			})
+			requirePinnedInputsErrorContains(t, cfg, "before every release mutation phase")
+		})
+	}
 }
 
 func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, directCollaborators []map[string]any) (string, string) {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -365,6 +365,28 @@ func TestCheckPinnedInputsRejectsUnboundReleaseTagRechecks(t *testing.T) {
 		"recheck missing its commit binding": func(content string) string {
 			return strings.Replace(content, ` --expected-commit "${RELEASE_COMMIT}"`, "", 1)
 		},
+		"publication recheck moved inside the publication step": func(content string) string {
+			// Same step as the mutation, and after its publisher command, so a
+			// no-later comparison would accept it.
+			const check = "      - name: Verify release tag signature\n" +
+				"        env:\n          GITHUB_TOKEN: ${{ github.token }}\n" + recheck + "\n\n"
+			const publisher = "          ./scripts/publish-github-release.sh \"${RELEASE_TAG}\" \\"
+			const lastAsset = "            dist/workcell-image.spdx.sigstore.json\n"
+			at := strings.Index(content, publisher)
+			if at < 0 {
+				return content
+			}
+			// The publishing job's own check step is the last one before the
+			// publisher; the earlier phases keep theirs.
+			head, tail := content[:at], content[at:]
+			last := strings.LastIndex(head, check)
+			if last < 0 {
+				return content
+			}
+			head = head[:last] + head[last+len(check):]
+			return head + strings.Replace(tail, lastAsset,
+				lastAsset+"          "+strings.TrimPrefix(recheck, "        run: ")+"\n", 1)
+		},
 		"publication recheck moved below the publication step": func(content string) string {
 			// Swap the two steps so the check still exists, and still runs in
 			// the publishing job, but no longer runs before the mutation.

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -362,6 +362,9 @@ func TestCheckPinnedInputsRejectsUnboundReleaseTagRechecks(t *testing.T) {
 		"recheck missing its tag-object binding": func(content string) string {
 			return strings.Replace(content, ` --expected-tag-object "${RELEASE_TAG_OBJECT}"`, "", 1)
 		},
+		"recheck failure ignored with a fallback": func(content string) string {
+			return strings.Replace(content, recheck+"\n", recheck+" || true\n", 1)
+		},
 		"recheck missing its commit binding": func(content string) string {
 			return strings.Replace(content, ` --expected-commit "${RELEASE_COMMIT}"`, "", 1)
 		},

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -365,6 +365,15 @@ func TestCheckPinnedInputsRejectsUnboundReleaseTagRechecks(t *testing.T) {
 		"recheck missing its commit binding": func(content string) string {
 			return strings.Replace(content, ` --expected-commit "${RELEASE_COMMIT}"`, "", 1)
 		},
+		"publication recheck moved below the publication step": func(content string) string {
+			// Swap the two steps so the check still exists, and still runs in
+			// the publishing job, but no longer runs before the mutation.
+			const check = "      - name: Verify release tag signature\n" +
+				"        env:\n          GITHUB_TOKEN: ${{ github.token }}\n" + recheck + "\n\n"
+			const mutation = "      - name: Recheck hosted controls and publish GitHub release assets\n"
+			return strings.Replace(content, check+mutation, mutation, 1) +
+				"\n" + strings.TrimSuffix(check, "\n")
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := rewritePinnedInputsFixtureFile(t, ".github/workflows/release.yml", func(content string) string {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -334,6 +334,16 @@ func TestCheckPinnedInputsRejectsCommentedDebianBootstrapGuard(t *testing.T) {
 	requirePinnedInputsErrorContains(t, cfg, "must use reviewed Debian bootstrap pin")
 }
 
+func TestCheckPinnedInputsRejectsCommentedReleaseTagRecheck(t *testing.T) {
+	const recheck = `        run: ./scripts/check-release-tag-signature.sh --github-repo "${GITHUB_REPOSITORY}" --repo-root "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" --expected-commit "${RELEASE_COMMIT}" --expected-tag-object "${RELEASE_TAG_OBJECT}"`
+	cfg := rewritePinnedInputsFixtureFile(t, ".github/workflows/release.yml", func(content string) string {
+		// Keep the check text in the run block, but as a comment that never runs.
+		return strings.Replace(content, recheck,
+			"        run: |\n          #"+strings.TrimPrefix(recheck, "        run:")+"\n          true", 1)
+	})
+	requirePinnedInputsErrorContains(t, cfg, "found 4 checks")
+}
+
 func writeHostedControlsFixture(tb testing.TB, branchMode, releaseMode string, directCollaborators []map[string]any) (string, string) {
 	tb.Helper()
 

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -161,6 +161,8 @@ func TestValidateReleaseWorkflowPublicationGateRejectsPolicyPathOverrides(t *tes
 		"single-quoted assignment": `          env 'WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml' ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
 		"double-quoted assignment": `          env "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml" ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
 		"quoted assignment prefix": `          'WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml' ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"declare -x export":        "          declare -x WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml\n" + auditCall,
+		"readonly export":          "          readonly WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml\n" + auditCall,
 	} {
 		t.Run(name, func(t *testing.T) {
 			mutated := strings.Replace(workflow, auditCall, override, 1)

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -100,14 +100,42 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 		{name: "publisher bound to the verified tag object", old: `--expected-tag-object "${RELEASE_TAG_OBJECT}"`, replacement: `--expected-tag-object "${GITHUB_REF_NAME}"`, want: "explicit preverified publisher"},
 		{name: "publisher bound to the verified tag", old: `publish-github-release.sh "${RELEASE_TAG}"`, replacement: `publish-github-release.sh "${GITHUB_REF_NAME}"`, want: "explicit preverified publisher"},
 		{name: "reviewed hosted-controls policy path", old: "WORKCELL_HOSTED_CONTROLS_REQUIRED", replacement: "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH", want: "reviewed GitHub hosted-controls policy path"},
+		{
+			name: "tag-object binding moved from the publisher command into a comment",
+			old: "            --expected-tag-object \"${RELEASE_TAG_OBJECT}\" \\\n" +
+				"            --immutable-releases-preverified-by-hosted-controls \\\n" +
+				"            dist/workcell.tar.gz\n",
+			replacement: "            --immutable-releases-preverified-by-hosted-controls \\\n" +
+				"            dist/workcell.tar.gz # --expected-tag-object \"${RELEASE_TAG_OBJECT}\"\n",
+			want: "explicit preverified publisher",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mutated := strings.Replace(workflow, tc.old, tc.replacement, 1)
+			if mutated == workflow {
+				t.Fatalf("mutation %q did not change the workflow", tc.name)
+			}
 			err := metadatautil.ValidateReleaseWorkflowPublicationGate(mutated)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("ValidateReleaseWorkflowPublicationGate() error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+// A comment that names the reviewed policy path overrides nothing, so the gate
+// must not reject the workflow for mentioning it.
+func TestValidateReleaseWorkflowPublicationGateAcceptsPolicyPathMention(t *testing.T) {
+	workflow := string(readReleaseWorkflow(t))
+	const auditCall = `          ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`
+	mutated := strings.Replace(workflow,
+		auditCall,
+		"          # WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH must stay unset in this job.\n"+auditCall, 1)
+	if mutated == workflow {
+		t.Fatal("policy path mention did not change the workflow")
+	}
+	if err := metadatautil.ValidateReleaseWorkflowPublicationGate(mutated); err != nil {
+		t.Fatalf("ValidateReleaseWorkflowPublicationGate() error = %v, want nil", err)
 	}
 }
 
@@ -118,7 +146,11 @@ func TestValidateReleaseWorkflowAuthoritySplit(t *testing.T) {
 	}
 	mutated := strings.Replace(string(content), "    permissions:\n      contents: read\n    outputs:\n      digest: ${{ steps.build_amd64.outputs.digest }}", "    permissions:\n      contents: read\n      packages: write\n    outputs:\n      digest: ${{ steps.build_amd64.outputs.digest }}", 1)
 	requireReleaseAuthorityError(t, mutated, "build-amd64-image")
-	mutated = strings.Replace(string(content), "    steps:\n      - name: Recheck release tag before signing and image mutation", "    steps:\n      - uses: actions/checkout@bad\n      - name: Recheck release tag before signing and image mutation", 1)
+	const signerRecheck = "      - name: Recheck release tag before signing and image mutation"
+	mutated = strings.Replace(string(content), signerRecheck, "      - uses: actions/checkout@bad\n"+signerRecheck, 1)
+	if mutated == string(content) {
+		t.Fatal("signer contract mutation did not change the workflow")
+	}
 	requireReleaseAuthorityError(t, mutated, "exact privileged step contract")
 }
 

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -145,10 +145,13 @@ func TestValidateReleaseWorkflowPublicationGateRejectsPolicyPathOverrides(t *tes
 	workflow := string(readReleaseWorkflow(t))
 	const auditCall = `          ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`
 	for name, override := range map[string]string{
-		"env command prefix":      `          env WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
-		"env with an option":      `          env -i WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
-		"plain assignment prefix": `          WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
-		"export statement":        "          export WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml\n" + auditCall,
+		"env command prefix":       `          env WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"env with an option":       `          env -i WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"plain assignment prefix":  `          WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"export statement":         "          export WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml\n" + auditCall,
+		"single-quoted assignment": `          env 'WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml' ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"double-quoted assignment": `          env "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml" ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"quoted assignment prefix": `          'WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml' ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			mutated := strings.Replace(workflow, auditCall, override, 1)

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -109,6 +109,15 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 				"            dist/workcell.tar.gz # --expected-tag-object \"${RELEASE_TAG_OBJECT}\"\n",
 			want: "explicit preverified publisher",
 		},
+		{
+			name: "tag-object binding moved past a shell separator",
+			old: "            --expected-tag-object \"${RELEASE_TAG_OBJECT}\" \\\n" +
+				"            --immutable-releases-preverified-by-hosted-controls \\\n" +
+				"            dist/workcell.tar.gz\n",
+			replacement: "            --immutable-releases-preverified-by-hosted-controls \\\n" +
+				"            dist/workcell.tar.gz ; : --expected-tag-object \"${RELEASE_TAG_OBJECT}\"\n",
+			want: "explicit preverified publisher",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mutated := strings.Replace(workflow, tc.old, tc.replacement, 1)

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -139,6 +139,30 @@ func TestValidateReleaseWorkflowPublicationGateAcceptsPolicyPathMention(t *testi
 	}
 }
 
+// An override reaches the audit through any executable assignment, including an
+// env or export command prefix, so each of those forms must fail the gate.
+func TestValidateReleaseWorkflowPublicationGateRejectsPolicyPathOverrides(t *testing.T) {
+	workflow := string(readReleaseWorkflow(t))
+	const auditCall = `          ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`
+	for name, override := range map[string]string{
+		"env command prefix":      `          env WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"env with an option":      `          env -i WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"plain assignment prefix": `          WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`,
+		"export statement":        "          export WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH=/tmp/policy.toml\n" + auditCall,
+	} {
+		t.Run(name, func(t *testing.T) {
+			mutated := strings.Replace(workflow, auditCall, override, 1)
+			if mutated == workflow {
+				t.Fatalf("override %q did not change the workflow", name)
+			}
+			err := metadatautil.ValidateReleaseWorkflowPublicationGate(mutated)
+			if err == nil || !strings.Contains(err.Error(), "reviewed GitHub hosted-controls policy path") {
+				t.Fatalf("ValidateReleaseWorkflowPublicationGate() error = %v, want a policy path override", err)
+			}
+		})
+	}
+}
+
 func TestValidateReleaseWorkflowAuthoritySplit(t *testing.T) {
 	content := readReleaseWorkflow(t)
 	if err := metadatautil.ValidateReleaseWorkflowAuthoritySplit(string(content)); err != nil {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -74,7 +74,8 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
         run: |
           ./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"
           unset WORKCELL_HOSTED_CONTROLS_TOKEN
-          ./scripts/publish-github-release.sh "${GITHUB_REF_NAME}" \
+          ./scripts/publish-github-release.sh "${RELEASE_TAG}" \
+            --expected-tag-object "${RELEASE_TAG_OBJECT}" \
             --immutable-releases-preverified-by-hosted-controls \
             dist/workcell.tar.gz
 `
@@ -96,6 +97,9 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 		{name: "minimal verifier permissions", old: "contents: read\n      packages: read", replacement: "contents: read\n      packages: write", want: "grant only read permissions"},
 		{name: "unsets audit token", old: "unset WORKCELL_HOSTED_CONTROLS_TOKEN", replacement: "true", want: "unset its credential"},
 		{name: "explicit handoff", old: "--immutable-releases-preverified-by-hosted-controls", replacement: "--other", want: "explicit preverified publisher"},
+		{name: "publisher bound to the verified tag object", old: `--expected-tag-object "${RELEASE_TAG_OBJECT}"`, replacement: `--expected-tag-object "${GITHUB_REF_NAME}"`, want: "explicit preverified publisher"},
+		{name: "publisher bound to the verified tag", old: `publish-github-release.sh "${RELEASE_TAG}"`, replacement: `publish-github-release.sh "${GITHUB_REF_NAME}"`, want: "explicit preverified publisher"},
+		{name: "reviewed hosted-controls policy path", old: "WORKCELL_HOSTED_CONTROLS_REQUIRED", replacement: "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH", want: "reviewed GitHub hosted-controls policy path"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mutated := strings.Replace(workflow, tc.old, tc.replacement, 1)
@@ -114,7 +118,7 @@ func TestValidateReleaseWorkflowAuthoritySplit(t *testing.T) {
 	}
 	mutated := strings.Replace(string(content), "    permissions:\n      contents: read\n    outputs:\n      digest: ${{ steps.build_amd64.outputs.digest }}", "    permissions:\n      contents: read\n      packages: write\n    outputs:\n      digest: ${{ steps.build_amd64.outputs.digest }}", 1)
 	requireReleaseAuthorityError(t, mutated, "build-amd64-image")
-	mutated = strings.Replace(string(content), "    steps:\n      - name: Download bound unsigned release artifact", "    steps:\n      - uses: actions/checkout@bad\n      - name: Download bound unsigned release artifact", 1)
+	mutated = strings.Replace(string(content), "    steps:\n      - name: Recheck release tag before signing and image mutation", "    steps:\n      - uses: actions/checkout@bad\n      - name: Recheck release tag before signing and image mutation", 1)
 	requireReleaseAuthorityError(t, mutated, "exact privileged step contract")
 }
 
@@ -125,7 +129,7 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 	}{
 		{
 			name:  "assembly command in a comment",
-			old:   "          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			old:   "          oras manifest index create --oci-layout \\\n            \"dist/release-image:${RELEASE_TAG}\" \\\n            amd64 arm64 >/dev/null",
 			decoy: "          # oras manifest index create --oci-layout dist/release-image amd64 arm64",
 			want:  "assemble the multi-arch index",
 		},
@@ -143,7 +147,7 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 		},
 		{
 			name:  "assembly command quoted inside another command",
-			old:   "          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			old:   "          oras manifest index create --oci-layout \\\n            \"dist/release-image:${RELEASE_TAG}\" \\\n            amd64 arm64 >/dev/null",
 			decoy: "          echo \"oras manifest index create --oci-layout dist/release-image amd64 arm64\"",
 			want:  "assemble the multi-arch index",
 		},
@@ -170,7 +174,7 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			name: "real commands replaced by a heredoc body naming them",
 			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
 				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
-				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${RELEASE_TAG}\" \\\n            amd64 arm64 >/dev/null",
 			decoy: "          cat <<'PLAN' >/dev/null\n" +
 				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
 				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
@@ -211,7 +215,7 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsSignerDrift(t *testing.T) {
 		strings.Replace(workflow, "  WORKCELL_ORAS_VERSION: 1.3.3", "  WORKCELL_ORAS_VERSION: 1.3.4", 1),
 		strings.Replace(workflow, "  WORKCELL_ORAS_LINUX_AMD64_SHA256: 9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59", "  WORKCELL_ORAS_LINUX_AMD64_SHA256: 0000000000000000000000000000000000000000000000000000000000000000", 1),
 		strings.Replace(workflow, "(cd dist && sha256sum -c SHA256SUMS)", "sha256sum -c dist/SHA256SUMS", 1),
-		strings.Replace(workflow, "    env:\n      BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz", "    env:\n      BUNDLE_NAME: workcell-${{ github.ref_name }}.tar.gz\n      EXTRA: forbidden", 1),
+		strings.Replace(workflow, "      BUNDLE_NAME: workcell-${{ needs.tag-policy.outputs.release_tag }}.tar.gz", "      BUNDLE_NAME: workcell-${{ needs.tag-policy.outputs.release_tag }}.tar.gz\n      EXTRA: forbidden", 1),
 		strings.Replace(workflow, "      - name: Sign release image", "      - name: Unexpected command\n        run: eval dist/payload\n\n      - name: Sign release image", 1),
 		strings.Replace(workflow, "    shell: bash --noprofile --norc -euo pipefail {0}", "    shell: bash {0}", 1),
 	}

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -326,10 +326,30 @@ func commandArgs(script, command string) [][]string {
 			heredoc = cmp.Or(match[1], match[2], match[3])
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
-			invocations = append(invocations, strings.Fields(rest))
+			invocations = append(invocations, commandWords(rest))
 		}
 	}
 	return invocations
+}
+
+// commandWords returns the words bash passes to one command: the fields of rest
+// up to the first shell separator. A word carrying a separator ends the command
+// there, so text after a ; or a && belongs to the next command and must not be
+// read as this one's argument.
+func commandWords(rest string) []string {
+	fields := strings.Fields(rest)
+	if at := slices.IndexFunc(fields, endsCommand); at >= 0 {
+		return fields[:at]
+	}
+	return fields
+}
+
+// endsCommand reports whether a word carries a shell separator and therefore
+// ends the command it belongs to. A separator inside a quoted word does not
+// separate, but stopping early only shortens an argument list, which can make a
+// requirement fail and never makes one pass.
+func endsCommand(word string) bool {
+	return strings.ContainsAny(word, ";&|")
 }
 
 func validateUnprivilegedReleaseJobs(document workflowDocument) error {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -22,6 +22,7 @@ import (
 )
 
 type workflowDocument struct {
+	Env  map[string]string      `yaml:"env"`
 	Jobs map[string]workflowJob `yaml:"jobs"`
 }
 
@@ -36,8 +37,9 @@ type workflowNodeDocument struct {
 }
 
 type workflowJob struct {
-	Name        string    `yaml:"name"`
-	Needs       yaml.Node `yaml:"needs"`
+	Name        string            `yaml:"name"`
+	Env         map[string]string `yaml:"env"`
+	Needs       yaml.Node         `yaml:"needs"`
 	Environment struct {
 		Name string `yaml:"name"`
 	} `yaml:"environment"`
@@ -56,7 +58,7 @@ type workflowStep struct {
 // ORAS pins, the registry it publishes to, and the shell its run steps inherit. It
 // rejects unknown fields, reordered steps, changed commands, changed action inputs,
 // a swapped publisher, a redirected registry, and a weakened shell default.
-const releaseSignerContractSHA256 = "47fadd56a99c49ce4eec3f291fd94dc507369c7efc2bf00d730c4526c77b9960"
+const releaseSignerContractSHA256 = "9427544fdcb574fd8ac5d906d425979822778230190a837bbf94fbc3d40cc575"
 
 func CollectWorkflowJobNames(content []byte) ([]string, error) {
 	var document workflowDocument
@@ -83,12 +85,12 @@ const verifyReleaseOutputsScript = "./scripts/verify-release-outputs.sh"
 // credential in a minimal final job and requires its fresh check to complete
 // immediately before the default-token publisher runs.
 func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
-	if strings.Contains(workflowText, "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH") {
-		return errors.New("release workflow must not override the reviewed GitHub hosted-controls policy path")
-	}
 	var document workflowDocument
 	if err := yaml.Unmarshal([]byte(workflowText), &document); err != nil {
 		return fmt.Errorf("parse release publication gate: %w", err)
+	}
+	if overridesHostedControlsPolicyPath(document) {
+		return errors.New("release workflow must not override the reviewed GitHub hosted-controls policy path")
 	}
 	releaseJob, ok := document.Jobs["release"]
 	if !ok {
@@ -158,14 +160,75 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		auditIndex := strings.Index(step.Run, `./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`)
 		unsetIndex := strings.Index(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
 		publishIndex := strings.Index(step.Run, `./scripts/publish-github-release.sh "${RELEASE_TAG}"`)
+		// The binding flags are read from the parsed publisher statement rather
+		// than the text after it, so the same flag inside a comment or an echoed
+		// string later in the block cannot stand in for the real argument.
+		invocations := commandArgs(step.Run, "./scripts/publish-github-release.sh")
 		if auditIndex < 0 || unsetIndex <= auditIndex || publishIndex <= unsetIndex ||
-			!strings.Contains(step.Run[publishIndex:], `--expected-tag-object "${RELEASE_TAG_OBJECT}"`) ||
-			!strings.Contains(step.Run[publishIndex:], "--immutable-releases-preverified-by-hosted-controls") {
+			len(invocations) != 1 || !publisherBindsVerifiedTag(invocations[0]) {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
 		}
 		return nil
 	}
 	return errors.New("release workflow must combine the fresh hosted-controls check and GitHub release publication in one reviewed step")
+}
+
+// publisherBindsVerifiedTag reports whether the parsed publisher arguments name
+// the verified tag, bind the annotated tag object it resolved to, and assert the
+// preverified publication path.
+func publisherBindsVerifiedTag(arguments []string) bool {
+	boundObject := slices.Index(arguments, "--expected-tag-object")
+	return len(arguments) > 0 && arguments[0] == `"${RELEASE_TAG}"` &&
+		boundObject >= 0 && boundObject+1 < len(arguments) &&
+		arguments[boundObject+1] == `"${RELEASE_TAG_OBJECT}"` &&
+		slices.Contains(arguments, "--immutable-releases-preverified-by-hosted-controls")
+}
+
+// hostedControlsPolicyPathVariable names the reviewed hosted-controls policy
+// path. The release workflow must never redirect it.
+const hostedControlsPolicyPathVariable = "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH"
+
+// overridesHostedControlsPolicyPath reports whether the parsed workflow sets the
+// policy path where it would take effect: a workflow, job, or step environment,
+// or an executable assignment in a run block. A mention in a comment changes
+// nothing and must not fail the gate.
+func overridesHostedControlsPolicyPath(document workflowDocument) bool {
+	if _, ok := document.Env[hostedControlsPolicyPathVariable]; ok {
+		return true
+	}
+	for _, job := range document.Jobs {
+		if _, ok := job.Env[hostedControlsPolicyPathVariable]; ok {
+			return true
+		}
+		for _, step := range job.Steps {
+			if _, ok := step.Env[hostedControlsPolicyPathVariable]; ok {
+				return true
+			}
+			if assignsInRun(step.Run, hostedControlsPolicyPathVariable) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// assignsInRun reports whether a run block assigns name in an executable
+// statement, directly, after export, or as a command prefix. Comments are
+// removed first, so a mention in one does not count.
+func assignsInRun(script, name string) bool {
+	for line := range strings.Lines(script) {
+		statement := strings.TrimSpace(inlineComment.ReplaceAllString(strings.TrimSpace(line), ""))
+		for _, word := range strings.Fields(strings.TrimPrefix(statement, "export ")) {
+			if strings.HasPrefix(word, name+"=") {
+				return true
+			}
+			// Assignment prefixes precede the command word, which has no "=".
+			if !strings.Contains(word, "=") {
+				break
+			}
+		}
+	}
+	return false
 }
 
 func ValidateReleaseWorkflowAuthoritySplit(workflowText string) error {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -226,8 +226,7 @@ func assignsInRun(script, name string) bool {
 		// they apply, so neither the leading word nor an option ends the run.
 		// Every word of such a statement is examined rather than only the
 		// leading assignments.
-		// Every builtin that can carry an assignment, so none of them ends the
-		// scan at its own name.
+		// Every builtin that can carry an assignment past its own name.
 		if slices.Contains([]string{"export", "env", "declare", "typeset", "readonly", "local"}, words[0]) {
 			if slices.ContainsFunc(words[1:], func(word string) bool { return assignsWord(word, name) }) {
 				return true
@@ -336,11 +335,9 @@ func commandArgs(script, command string) [][]string {
 	return invocations
 }
 
-// commandWords returns the words bash passes to one command, the fields of rest
-// up to the first shell separator, and whether the command's result is acted on.
-// Text after a ; or a && belongs to the next command and is not this one's
-// argument, and a command whose failure is swallowed by || proves nothing, so it
-// does not count as an invocation at all.
+// commandWords returns the words bash passes to one command, up to the first
+// shell separator, and whether its result is acted on. Text after a ; or a &&
+// is the next command's, and a failure swallowed by || proves nothing.
 func commandWords(rest string) ([]string, bool) {
 	fields := strings.Fields(rest)
 	at := slices.IndexFunc(fields, endsCommand)

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -226,7 +226,9 @@ func assignsInRun(script, name string) bool {
 		// they apply, so neither the leading word nor an option ends the run.
 		// Every word of such a statement is examined rather than only the
 		// leading assignments.
-		if words[0] == "export" || words[0] == "env" {
+		// Every builtin that can carry an assignment, so none of them ends the
+		// scan at its own name.
+		if slices.Contains([]string{"export", "env", "declare", "typeset", "readonly", "local"}, words[0]) {
 			if slices.ContainsFunc(words[1:], func(word string) bool { return assignsWord(word, name) }) {
 				return true
 			}
@@ -326,22 +328,26 @@ func commandArgs(script, command string) [][]string {
 			heredoc = cmp.Or(match[1], match[2], match[3])
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
-			invocations = append(invocations, commandWords(rest))
+			if words, runs := commandWords(rest); runs {
+				invocations = append(invocations, words)
+			}
 		}
 	}
 	return invocations
 }
 
-// commandWords returns the words bash passes to one command: the fields of rest
-// up to the first shell separator. A word carrying a separator ends the command
-// there, so text after a ; or a && belongs to the next command and must not be
-// read as this one's argument.
-func commandWords(rest string) []string {
+// commandWords returns the words bash passes to one command, the fields of rest
+// up to the first shell separator, and whether the command's result is acted on.
+// Text after a ; or a && belongs to the next command and is not this one's
+// argument, and a command whose failure is swallowed by || proves nothing, so it
+// does not count as an invocation at all.
+func commandWords(rest string) ([]string, bool) {
 	fields := strings.Fields(rest)
-	if at := slices.IndexFunc(fields, endsCommand); at >= 0 {
-		return fields[:at]
+	at := slices.IndexFunc(fields, endsCommand)
+	if at < 0 {
+		return fields, true
 	}
-	return fields
+	return fields[:at], !strings.HasPrefix(fields[at], "||")
 }
 
 // endsCommand reports whether a word carries a shell separator and therefore

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -227,13 +227,13 @@ func assignsInRun(script, name string) bool {
 		// Every word of such a statement is examined rather than only the
 		// leading assignments.
 		if words[0] == "export" || words[0] == "env" {
-			if slices.ContainsFunc(words[1:], func(word string) bool { return strings.HasPrefix(word, name+"=") }) {
+			if slices.ContainsFunc(words[1:], func(word string) bool { return assignsWord(word, name) }) {
 				return true
 			}
 			continue
 		}
 		for _, word := range words {
-			if strings.HasPrefix(word, name+"=") {
+			if assignsWord(word, name) {
 				return true
 			}
 			// A plain assignment prefix precedes the command word, which has no "=".
@@ -243,6 +243,12 @@ func assignsInRun(script, name string) bool {
 		}
 	}
 	return false
+}
+
+// assignsWord reports whether one shell word assigns name. Bash strips the
+// quotes before it reads the assignment, so a leading quote must not hide it.
+func assignsWord(word, name string) bool {
+	return strings.HasPrefix(strings.TrimLeft(word, `'"`), name+"=")
 }
 
 func ValidateReleaseWorkflowAuthoritySplit(workflowText string) error {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -56,7 +56,7 @@ type workflowStep struct {
 // ORAS pins, the registry it publishes to, and the shell its run steps inherit. It
 // rejects unknown fields, reordered steps, changed commands, changed action inputs,
 // a swapped publisher, a redirected registry, and a weakened shell default.
-const releaseSignerContractSHA256 = "59d426ff05378de33e64dc11f715e25f21727eb07e9f33d7cead528856e84982"
+const releaseSignerContractSHA256 = "47fadd56a99c49ce4eec3f291fd94dc507369c7efc2bf00d730c4526c77b9960"
 
 func CollectWorkflowJobNames(content []byte) ([]string, error) {
 	var document workflowDocument
@@ -83,6 +83,9 @@ const verifyReleaseOutputsScript = "./scripts/verify-release-outputs.sh"
 // credential in a minimal final job and requires its fresh check to complete
 // immediately before the default-token publisher runs.
 func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
+	if strings.Contains(workflowText, "WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH") {
+		return errors.New("release workflow must not override the reviewed GitHub hosted-controls policy path")
+	}
 	var document workflowDocument
 	if err := yaml.Unmarshal([]byte(workflowText), &document); err != nil {
 		return fmt.Errorf("parse release publication gate: %w", err)
@@ -154,8 +157,9 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		}
 		auditIndex := strings.Index(step.Run, `./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`)
 		unsetIndex := strings.Index(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
-		publishIndex := strings.Index(step.Run, `./scripts/publish-github-release.sh "${GITHUB_REF_NAME}"`)
+		publishIndex := strings.Index(step.Run, `./scripts/publish-github-release.sh "${RELEASE_TAG}"`)
 		if auditIndex < 0 || unsetIndex <= auditIndex || publishIndex <= unsetIndex ||
+			!strings.Contains(step.Run[publishIndex:], `--expected-tag-object "${RELEASE_TAG_OBJECT}"`) ||
 			!strings.Contains(step.Run[publishIndex:], "--immutable-releases-preverified-by-hosted-controls") {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
 		}

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -213,16 +213,30 @@ func overridesHostedControlsPolicyPath(document workflowDocument) bool {
 }
 
 // assignsInRun reports whether a run block assigns name in an executable
-// statement, directly, after export, or as a command prefix. Comments are
-// removed first, so a mention in one does not count.
+// statement, directly, as a command prefix, or through export or env. Comments
+// are removed first, so a mention in one does not count.
 func assignsInRun(script, name string) bool {
 	for line := range strings.Lines(script) {
 		statement := strings.TrimSpace(inlineComment.ReplaceAllString(strings.TrimSpace(line), ""))
-		for _, word := range strings.Fields(strings.TrimPrefix(statement, "export ")) {
+		words := strings.Fields(statement)
+		if len(words) == 0 {
+			continue
+		}
+		// export and env both carry their own options before the assignments
+		// they apply, so neither the leading word nor an option ends the run.
+		// Every word of such a statement is examined rather than only the
+		// leading assignments.
+		if words[0] == "export" || words[0] == "env" {
+			if slices.ContainsFunc(words[1:], func(word string) bool { return strings.HasPrefix(word, name+"=") }) {
+				return true
+			}
+			continue
+		}
+		for _, word := range words {
 			if strings.HasPrefix(word, name+"=") {
 				return true
 			}
-			// Assignment prefixes precede the command word, which has no "=".
+			// A plain assignment prefix precedes the command word, which has no "=".
 			if !strings.Contains(word, "=") {
 				break
 			}

--- a/internal/testkit/release_verify_test.go
+++ b/internal/testkit/release_verify_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -235,4 +237,73 @@ func TestVerifyReleaseArtifactSkipVerifyNeutralizationLetsTamperedArtifactPass(t
 	if strings.Contains(out, "OK: "+artifact+" verified") {
 		t.Fatalf("skip path must NOT report the artifact as verified, got:\n%s", out)
 	}
+}
+
+// The verifier pins the dispatch identity exactly, and when the caller names the
+// tag it is verifying it also accepts that one exact historical tag identity —
+// releases published before the dispatch trigger were signed from the pushed
+// tag. Neither alternative may become a wildcard, and neither may match a
+// different release.
+func TestVerifyReleaseArtifactPinsRequestedIdentities(t *testing.T) {
+	const prefix = "https://github.com/omkhar/workcell/.github/workflows/release.yml@"
+	for name, testCase := range map[string]struct {
+		extraArgs []string
+		accepts   []string
+		rejects   []string
+	}{
+		"dispatch only": {
+			accepts: []string{prefix + "refs/heads/main"},
+			rejects: []string{prefix + "refs/tags/v1.0.2", prefix + "refs/heads/mainx"},
+		},
+		"dispatch and requested tag": {
+			extraArgs: []string{"--tag", "v1.0.2"},
+			accepts:   []string{prefix + "refs/heads/main", prefix + "refs/tags/v1.0.2"},
+			rejects:   []string{prefix + "refs/tags/v1.0.3", prefix + "refs/tags/v1a0b2"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			binDir := stubBinDir(t, -1)
+			record := filepath.Join(t.TempDir(), "cosign-args")
+			cosign := "#!/bin/bash\nprintf '%s\\n' \"$@\" > " + record + "\nexit 0\n"
+			if err := os.WriteFile(filepath.Join(binDir, "cosign"), []byte(cosign), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			assets := writeAssets(t, "workcell-v1.0.2.tar.gz", []byte("bundle"), true)
+			args := append([]string{"--artifact", "workcell-v1.0.2.tar.gz"}, testCase.extraArgs...)
+			if code, out := runVerify(t, binDir, assets, args...); code != 0 {
+				t.Fatalf("verify exited %d: %s", code, out)
+			}
+			pattern := recordedIdentityRegexp(t, record)
+			for _, identity := range testCase.accepts {
+				if !pattern.MatchString(identity) {
+					t.Errorf("identity expression %q rejects %q", pattern, identity)
+				}
+			}
+			for _, identity := range testCase.rejects {
+				if pattern.MatchString(identity) {
+					t.Errorf("identity expression %q accepts %q", pattern, identity)
+				}
+			}
+		})
+	}
+}
+
+// recordedIdentityRegexp returns the compiled --certificate-identity-regexp the
+// script handed to cosign, one argument per recorded line.
+func recordedIdentityRegexp(t *testing.T, recordPath string) *regexp.Regexp {
+	t.Helper()
+	recorded, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(recorded), "\n"), "\n")
+	index := slices.Index(lines, "--certificate-identity-regexp")
+	if index < 0 || index+1 >= len(lines) {
+		t.Fatalf("cosign received no --certificate-identity-regexp: %q", lines)
+	}
+	pattern, err := regexp.Compile(lines[index+1])
+	if err != nil {
+		t.Fatalf("identity expression does not compile: %v", err)
+	}
+	return pattern
 }

--- a/internal/testkit/release_verify_test.go
+++ b/internal/testkit/release_verify_test.go
@@ -255,10 +255,17 @@ func TestVerifyReleaseArtifactPinsRequestedIdentities(t *testing.T) {
 			accepts: []string{prefix + "refs/heads/main"},
 			rejects: []string{prefix + "refs/tags/v1.0.2", prefix + "refs/heads/mainx"},
 		},
-		"dispatch and requested tag": {
+		"historical tag-signed release": {
 			extraArgs: []string{"--tag", "v1.0.2"},
 			accepts:   []string{prefix + "refs/heads/main", prefix + "refs/tags/v1.0.2"},
 			rejects:   []string{prefix + "refs/tags/v1.0.3", prefix + "refs/tags/v1a0b2"},
+		},
+		// A tag published after the cutover must not reintroduce tag-push
+		// signing authority, so its own tag identity is not accepted either.
+		"release after the cutover": {
+			extraArgs: []string{"--tag", "v1.0.3"},
+			accepts:   []string{prefix + "refs/heads/main"},
+			rejects:   []string{prefix + "refs/tags/v1.0.3", prefix + "refs/tags/v1.0.2"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -241,7 +241,7 @@
       "profiles": ["release-preflight"],
       "authority": "release-only",
       "local_mode": "none",
-      "github_only_reason": "the exact pushed-tag event binding exists only in GitHub Actions; the shared tag classifier and negative controls run in local Go tests"
+      "github_only_reason": "the exact repository_dispatch event binding exists only in GitHub Actions; the shared tag classifier and negative controls run in local Go tests"
     },
     "scorecard.yml/analysis": {
       "profiles": ["release-preflight"],

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -514,7 +514,7 @@
       "job_id": "bind-release-subjects",
       "job_name": "Bind independent release subjects",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -530,7 +530,7 @@
       "job_id": "build-amd64-image",
       "job_name": "Build native amd64 release image artifact",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -546,7 +546,7 @@
       "job_id": "build-arm64-image",
       "job_name": "Build native arm64 release image artifact",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -566,7 +566,7 @@
         "language": "go"
       },
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -586,7 +586,7 @@
         "language": "javascript-typescript"
       },
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -606,7 +606,7 @@
         "language": "rust"
       },
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -626,7 +626,7 @@
         "runner_label": "macos-15"
       },
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -646,7 +646,7 @@
         "runner_label": "macos-26"
       },
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -662,7 +662,7 @@
       "job_id": "preflight",
       "job_name": "Release preflight",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -678,7 +678,7 @@
       "job_id": "preflight-amd64-repro",
       "job_name": "Release reproducible image (amd64)",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -694,7 +694,7 @@
       "job_id": "preflight-arm64-copilot-runtime",
       "job_name": "Release Copilot runtime image probe (arm64)",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -710,7 +710,7 @@
       "job_id": "preflight-arm64-repro",
       "job_name": "Release reproducible image (arm64)",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -726,7 +726,7 @@
       "job_id": "preflight-container-smoke",
       "job_name": "Release container smoke",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -742,7 +742,7 @@
       "job_id": "publish-github-release",
       "job_name": "Publish GitHub release",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -758,7 +758,7 @@
       "job_id": "release",
       "job_name": "Assemble release artifacts",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -774,7 +774,7 @@
       "job_id": "sign-release",
       "job_name": "Publish and sign bound release artifacts",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
@@ -790,14 +790,14 @@
       "job_id": "tag-policy",
       "job_name": "Release tag policy",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"
       ],
       "authority": "release-only",
       "local_mode": "none",
-      "github_only_reason": "the exact pushed-tag event binding exists only in GitHub Actions; the shared tag classifier and negative controls run in local Go tests"
+      "github_only_reason": "the exact repository_dispatch event binding exists only in GitHub Actions; the shared tag classifier and negative controls run in local Go tests"
     },
     {
       "id": "release.yml/verify-release-outputs",
@@ -806,7 +806,7 @@
       "job_id": "verify-release-outputs",
       "job_name": "Verify release signatures and attestations",
       "workflow_events": [
-        "push"
+        "repository_dispatch"
       ],
       "profiles": [
         "release-preflight"

--- a/scripts/check-release-tag-signature.sh
+++ b/scripts/check-release-tag-signature.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 REPO_ROOT=""
 TAG_REF=""
+EXPECTED_COMMIT=""
+EXPECTED_TAG_OBJECT=""
 TRUSTED_HOST_PATH=""
 HOST_GIT_BIN=""
 REAL_HOME="${HOME:-/}"
@@ -83,10 +85,39 @@ Usage: check-release-tag-signature.sh --repo-root PATH --tag TAG
 Options:
   --repo-root PATH   Repository whose release tag should be verified
   --tag TAG          Tag name or ref to verify
+  --expected-commit SHA      Require the tag to target this commit
+  --expected-tag-object SHA  Require the tag ref to resolve to this tag object
   --git-bin PATH     Trusted Git executable to use
   --github-repo REPO Verify the tag through GitHub's tag-object verification API
   -h, --help         Show this help text
 EOF
+}
+
+# require_expected_binding fails closed when the tag no longer resolves to the
+# object and commit the caller already verified, so a tag moved between release
+# phases cannot pass a later recheck.
+require_expected_binding() {
+  local tag_object="$1"
+  local target_commit="$2"
+
+  if [[ -n "${EXPECTED_TAG_OBJECT}" && "${tag_object}" != "${EXPECTED_TAG_OBJECT}" ]]; then
+    echo "Release tag ${TAG_REF} resolves to object ${tag_object}, not the expected ${EXPECTED_TAG_OBJECT}." >&2
+    exit 2
+  fi
+  if [[ -n "${EXPECTED_COMMIT}" && "${target_commit}" != "${EXPECTED_COMMIT}" ]]; then
+    echo "Release tag ${TAG_REF} targets ${target_commit}, not the expected commit ${EXPECTED_COMMIT}." >&2
+    exit 2
+  fi
+}
+
+require_object_id() {
+  local flag="$1"
+  local value="$2"
+
+  if [[ ! "${value}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "${flag} requires a 40-character lowercase object ID." >&2
+    exit 2
+  fi
 }
 
 option_value_or_die() {
@@ -109,6 +140,8 @@ verify_github_tag_signature() {
   local object_sha=""
   local verified=""
   local reason=""
+  local target_type=""
+  local target_sha=""
 
   command -v gh >/dev/null 2>&1 || {
     echo "Missing trusted host tool: gh" >&2
@@ -132,6 +165,14 @@ verify_github_tag_signature() {
     exit 2
   fi
 
+  target_type="$(jq -r '.object.type // empty' <<<"${tag_json}")"
+  target_sha="$(jq -r '.object.sha // empty' <<<"${tag_json}")"
+  if [[ "${target_type}" != "commit" ]]; then
+    echo "Release tag ${tag_ref} on ${repo} must directly target a commit." >&2
+    exit 2
+  fi
+  require_expected_binding "${object_sha}" "${target_sha}"
+
   printf 'Release tag signature check passed: tag=%s verifier=github\n' "${tag_ref}"
 }
 
@@ -143,6 +184,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tag)
       TAG_REF="$(option_value_or_die "$1" "${2-}")"
+      shift 2
+      ;;
+    --expected-commit)
+      EXPECTED_COMMIT="$(option_value_or_die "$1" "${2-}")"
+      require_object_id "$1" "${EXPECTED_COMMIT}"
+      shift 2
+      ;;
+    --expected-tag-object)
+      EXPECTED_TAG_OBJECT="$(option_value_or_die "$1" "${2-}")"
+      require_object_id "$1" "${EXPECTED_TAG_OBJECT}"
       shift 2
       ;;
     --git-bin)
@@ -210,6 +261,21 @@ cleanup() {
   rm -f "${verify_log}"
 }
 trap cleanup EXIT
+
+tag_target="$(run_clean_host_command_in_dir "${REPO_ROOT}" "${HOST_GIT_BIN}" --no-replace-objects cat-file tag "${tag_object}" |
+  /usr/bin/awk '
+    $0 == "" { exit }
+    index($0, "object ") == 1 { object_count++; object = substr($0, 8) }
+    index($0, "type ") == 1 { type_count++; object_type = substr($0, 6) }
+    END {
+      if (object_count != 1 || type_count != 1 || object_type != "commit") exit 2
+      print object
+    }
+  ')" || {
+  echo "Release tag ${TAG_REF} must directly target one commit with canonical annotated tag headers." >&2
+  exit 2
+}
+require_expected_binding "${tag_object}" "${tag_target}"
 
 if ! run_clean_host_command_in_dir "${REPO_ROOT}" "${HOST_GIT_BIN}" --no-replace-objects verify-tag "${tag_object}" >/dev/null 2>"${verify_log}"; then
   echo "release workflow requires a verifiable signed tag; unable to verify ${TAG_REF}." >&2

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -170,7 +170,7 @@ if [[ "${SKIP_VERIFY}" -eq 0 ]]; then
   download "SHA256SUMS.sigstore.json"
 fi
 
-verify_args=(--assets-dir "${WORK_DIR}" --artifact "${BUNDLE_NAME}" --repo "${REPO}")
+verify_args=(--assets-dir "${WORK_DIR}" --artifact "${BUNDLE_NAME}" --repo "${REPO}" --tag "${VERSION}")
 if [[ "${REQUIRE_ATTESTATION}" -eq 1 ]]; then
   verify_args+=(--attestation)
 fi

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -1,6 +1,20 @@
 #!/bin/bash -p
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
-if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
+entrypoint_environment_is_sanitized() {
+  local name=""
+  local expected_path="${TRUSTED_HOST_PATH}"
+
+  [[ "${PATH:-}" == "${expected_path}" ]] || return 1
+
+  while IFS= read -r name; do
+    case "${name}" in
+      GITHUB_REPOSITORY | GITHUB_TOKEN | HOME | PATH | PWD | SHLVL | TMPDIR | WORKCELL_SANITIZED_ENTRYPOINT) ;;
+      *) return 1 ;;
+    esac
+  done < <(compgen -e)
+}
+
+if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]] || ! entrypoint_environment_is_sanitized; then
   exec /usr/bin/env -i \
     GITHUB_REPOSITORY="${GITHUB_REPOSITORY-}" \
     GITHUB_TOKEN="${GITHUB_TOKEN-}" \
@@ -12,9 +26,50 @@ if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
 fi
 set -euo pipefail
 export PATH="${TRUSTED_HOST_PATH}"
+unset WORKCELL_SANITIZED_ENTRYPOINT
+export CGO_ENABLED=0 GOENV=off GOTOOLCHAIN=local GOWORK=off
+PUBLISH_TOKEN="${GITHUB_TOKEN:-}"
+export -n PUBLISH_TOKEN 2>/dev/null || true
+unset GITHUB_TOKEN
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=/dev/null
 source "${ROOT_DIR}/scripts/lib/go-run-env.sh"
+
+resolve_trusted_go_bin() {
+  local expected_toolchain=""
+  local toolchain_version=""
+  local toolcache_arch=""
+  local candidate=""
+
+  expected_toolchain="$(awk '$1 == "toolchain" { print $2; exit }' "${ROOT_DIR}/go.mod")"
+  if [[ ! "${expected_toolchain}" =~ ^go[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "go.mod must declare one exact Go toolchain." >&2
+    return 2
+  fi
+  toolchain_version="${expected_toolchain#go}"
+  case "$(uname -m)" in
+    arm64 | aarch64) toolcache_arch="arm64" ;;
+    x86_64 | amd64) toolcache_arch="x64" ;;
+    *)
+      echo "GitHub release publication does not support this Go toolchain architecture." >&2
+      return 2
+      ;;
+  esac
+  for candidate in \
+    "/opt/hostedtoolcache/go/${toolchain_version}/${toolcache_arch}/bin/go" \
+    /opt/homebrew/bin/go \
+    /usr/local/go/bin/go \
+    /usr/local/bin/go \
+    /usr/bin/go; do
+    [[ -x "${candidate}" ]] || continue
+    if GOTOOLCHAIN=local GOENV=off "${candidate}" env GOVERSION 2>/dev/null | grep -Fx "${expected_toolchain}" >/dev/null; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  echo "Go toolchain ${expected_toolchain} is unavailable at a trusted absolute path." >&2
+  return 1
+}
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
   head -n 1 "$0" >/dev/null
@@ -24,7 +79,7 @@ fi
 
 usage() {
   cat <<'EOF' >&2
-Usage: publish-github-release.sh TAG [--immutable-releases-preverified-by-hosted-controls] FILE...
+Usage: publish-github-release.sh TAG [--expected-tag-object SHA] [--immutable-releases-preverified-by-hosted-controls] FILE...
 EOF
   exit 2
 }
@@ -34,12 +89,27 @@ EOF
 TAG_NAME="$1"
 shift
 
+EXPECTED_TAG_OBJECT=""
+if [[ "${1:-}" == "--expected-tag-object" ]]; then
+  [[ "${2:-}" =~ ^[0-9a-f]{40}$ ]] || usage
+  EXPECTED_TAG_OBJECT="$2"
+  shift 2
+fi
+
 IMMUTABLE_RELEASES_PREVERIFIED="false"
 if [[ "${1:-}" == "--immutable-releases-preverified-by-hosted-controls" ]]; then
   IMMUTABLE_RELEASES_PREVERIFIED="true"
   shift
 fi
 [[ $# -ge 1 ]] || usage
+if [[ -z "${PUBLISH_TOKEN}" || "${#PUBLISH_TOKEN}" -gt 4096 || "${PUBLISH_TOKEN}" =~ [[:space:][:cntrl:]] ]]; then
+  echo "GITHUB_TOKEN must be a bounded credential without whitespace or control characters." >&2
+  exit 2
+fi
+
+WORKCELL_GO_BIN="$(resolve_trusted_go_bin)"
+readonly WORKCELL_GO_BIN
+export -n WORKCELL_GO_BIN 2>/dev/null || true
 
 HOSTUTIL_BIN="$(mktemp "${TMPDIR:-/tmp}/workcell-hostutil.XXXXXX")"
 
@@ -49,15 +119,44 @@ cleanup() {
 
 trap cleanup EXIT
 build_go_tool_in_repo "${ROOT_DIR}" "${HOSTUTIL_BIN}" ./cmd/workcell-hostutil
+"${HOSTUTIL_BIN}" release classify-tag "${TAG_NAME}" >/dev/null
 
 TAG_REF="refs/tags/${TAG_NAME}"
 TAG_OBJECT_SHA="$(git -C "${ROOT_DIR}" --no-replace-objects rev-parse --verify "${TAG_REF}^{tag}")" || {
   echo "Release tag ${TAG_NAME} must resolve locally to an annotated tag object." >&2
   exit 2
 }
-PEELED_COMMIT_SHA="$(git -C "${ROOT_DIR}" --no-replace-objects rev-parse --verify "${TAG_REF}^{commit}")" || {
-  echo "Release tag ${TAG_NAME} must peel locally to exactly one commit." >&2
+if [[ -n "${EXPECTED_TAG_OBJECT}" && "${TAG_OBJECT_SHA}" != "${EXPECTED_TAG_OBJECT}" ]]; then
+  echo "Release tag ${TAG_NAME} changed from expected object ${EXPECTED_TAG_OBJECT}." >&2
+  exit 2
+fi
+TAG_HEADERS="$(
+  git -C "${ROOT_DIR}" --no-replace-objects cat-file tag "${TAG_OBJECT_SHA}" |
+    /usr/bin/awk '
+      $0 == "" { exit }
+      index($0, "object ") == 1 { object_count++; object = substr($0, 8) }
+      index($0, "type ") == 1 { type_count++; object_type = substr($0, 6) }
+      index($0, "tag ") == 1 { tag_count++; name = substr($0, 5) }
+      END {
+        if (object_count != 1 || type_count != 1 || tag_count != 1 || object_type != "commit") exit 2
+        print object
+        print name
+      }
+    '
+)" || {
+  echo "Release tag ${TAG_NAME} must directly target one commit and contain canonical annotated tag headers." >&2
   exit 2
 }
+PEELED_COMMIT_SHA="${TAG_HEADERS%%$'\n'*}"
+EMBEDDED_TAG_NAME="${TAG_HEADERS#*$'\n'}"
+if [[ "${#PEELED_COMMIT_SHA}" -ne 40 || "${PEELED_COMMIT_SHA}" == *[!0-9a-f]* ]]; then
+  echo "Release tag ${TAG_NAME} must directly target one lowercase 40-character commit ID." >&2
+  exit 2
+fi
+if [[ "${EMBEDDED_TAG_NAME}" != "${TAG_NAME}" ]]; then
+  echo "Release tag ${TAG_NAME} does not match embedded tag name ${EMBEDDED_TAG_NAME}." >&2
+  exit 2
+fi
 
-"${HOSTUTIL_BIN}" release publish "${TAG_NAME}" "${TAG_OBJECT_SHA}" "${PEELED_COMMIT_SHA}" "--immutable-releases-preverified-by-hosted-controls=${IMMUTABLE_RELEASES_PREVERIFIED}" "$@"
+GITHUB_TOKEN="${PUBLISH_TOKEN}" \
+  "${HOSTUTIL_BIN}" release publish "${TAG_NAME}" "${TAG_OBJECT_SHA}" "${PEELED_COMMIT_SHA}" "--immutable-releases-preverified-by-hosted-controls=${IMMUTABLE_RELEASES_PREVERIFIED}" "$@"

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -214,12 +214,12 @@ artifact_path="${ASSETS_DIR}/${ARTIFACT}"
 [[ -f "${sums_path}" ]] || fail "verification material missing: ${sums_path}"
 [[ -f "${bundle_path}" ]] || fail "verification material missing: ${bundle_path} (the release publishes it alongside SHA256SUMS)"
 
-# Anchor (^…$) and escape every fixed segment so only the release tag is a
-# wildcard. release.yml is triggered solely by tag pushes ("on: push: tags:
-# v*"), so the keyless Fulcio identity is always the workflow file at the tag
-# ref: https://github.com/OWNER/REPO/.github/workflows/release.yml@refs/tags/TAG.
+# Anchor (^…$) and escape every fixed segment, leaving no wildcard at all.
+# release.yml is triggered solely by repository_dispatch, which always loads the
+# workflow from the default branch, so the keyless Fulcio identity is exactly
+# https://github.com/OWNER/REPO/.github/workflows/release.yml@refs/heads/main.
 repo_escaped="$(regex_escape "${REPO}")"
-identity_regexp="^https://github\.com/${repo_escaped}/\.github/workflows/release\.yml@refs/tags/.+\$"
+identity_regexp="^https://github\.com/${repo_escaped}/\.github/workflows/release\.yml@refs/heads/main\$"
 
 echo "Verifying ${ARTIFACT} against ${REPO} release signing identity..." >&2
 
@@ -250,7 +250,7 @@ if [[ "${REQUIRE_ATTESTATION}" -eq 1 ]]; then
   # exact match (cli/cli#9507), so an unescaped '.' in it would over-match. Pin
   # the signer with the SAME anchored, escaped regex used for the cosign
   # signature above — the attestation SAN is the same keyless
-  # release.yml@refs/tags identity — via --cert-identity-regex, and pin the OIDC
+  # release.yml@refs/heads/main identity — via --cert-identity-regex, and pin the OIDC
   # issuer explicitly. --repo is an exact owner/repo match for attestation
   # lookup. This keeps the attestation identity pin exactly as tight as the
   # cosign one, with no over-match.

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -73,6 +73,9 @@ Required:
 Options:
   --repo OWNER/REPO  Release repository to pin the signer identity against
                      (default: omkhar/workcell, or $GITHUB_REPOSITORY).
+  --tag vX.Y.Z       Release tag being verified. Releases published before the
+                     dispatch trigger were signed from that tag, so naming it
+                     also accepts that one exact historical identity.
   --attestation      Additionally require `gh attestation verify` to pass.
   --skip-verify      Do NOT verify. Requires --i-understand-unverified-install
                      and prints a loud warning. For documented air-gapped use.
@@ -121,6 +124,7 @@ regex_escape() {
 
 ASSETS_DIR=""
 ARTIFACT=""
+TAG=""
 REPO="${GITHUB_REPOSITORY:-${DEFAULT_REPO}}"
 REQUIRE_ATTESTATION=0
 SKIP_VERIFY=0
@@ -138,6 +142,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --repo)
       REPO="${2:?--repo requires OWNER/REPO}"
+      shift 2
+      ;;
+    --tag)
+      TAG="${2:?--tag requires a release tag}"
       shift 2
       ;;
     --attestation)
@@ -171,6 +179,12 @@ done
 }
 if [[ "${ARTIFACT}" == */* ]]; then
   echo "--artifact must be a basename, not a path: ${ARTIFACT}" >&2
+  exit 2
+fi
+# Same tag shape the release workflow accepts, so a malformed value cannot reach
+# the identity expression.
+if [[ -n "${TAG}" ]] && [[ ! "${TAG}" =~ ^v[0-9A-Za-z.-]{1,63}$ ]]; then
+  echo "--tag must be a release tag of the form vX.Y.Z: ${TAG}" >&2
   exit 2
 fi
 
@@ -216,10 +230,22 @@ artifact_path="${ASSETS_DIR}/${ARTIFACT}"
 
 # Anchor (^…$) and escape every fixed segment, leaving no wildcard at all.
 # release.yml is triggered solely by repository_dispatch, which always loads the
-# workflow from the default branch, so the keyless Fulcio identity is exactly
+# workflow from the default branch, so the keyless Fulcio identity of a release
+# published under that trigger is exactly
 # https://github.com/OWNER/REPO/.github/workflows/release.yml@refs/heads/main.
+#
+# Releases published before that change were signed from the pushed tag. When
+# the caller names the tag it is verifying, that one exact tag identity is
+# accepted as well. Both alternatives stay exact: the tag branch is pinned to
+# the requested tag, so it is no looser than the branch one and cannot match a
+# different release.
 repo_escaped="$(regex_escape "${REPO}")"
-identity_regexp="^https://github\.com/${repo_escaped}/\.github/workflows/release\.yml@refs/heads/main\$"
+identity_prefix="https://github\.com/${repo_escaped}/\.github/workflows/release\.yml@"
+identity_refs="refs/heads/main"
+if [[ -n "${TAG}" ]]; then
+  identity_refs="${identity_refs}|refs/tags/$(regex_escape "${TAG}")"
+fi
+identity_regexp="^${identity_prefix}(${identity_refs})\$"
 
 echo "Verifying ${ARTIFACT} against ${REPO} release signing identity..." >&2
 

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -52,6 +52,12 @@ export PATH="${WORKCELL_INSTALL_TRUSTED_PATH:-/usr/bin:/bin:/usr/sbin:/sbin:/usr
 
 DEFAULT_REPO="omkhar/workcell"
 OIDC_ISSUER="https://token.actions.githubusercontent.com"
+# The closed set of releases published before the release workflow moved to the
+# repository_dispatch trigger, and therefore the only releases whose signing
+# identity is the pushed tag rather than the default branch. Every later release
+# must present the default-branch identity. Extend this list only for a release
+# that was genuinely published under the old tag-push trigger.
+TAG_SIGNED_RELEASES="v1.0.2"
 # Distinct from 0 (verified) and from failure codes: an acknowledged skip is an
 # unverified install, not a verified one.
 EXIT_SKIPPED_UNVERIFIED=10
@@ -73,9 +79,10 @@ Required:
 Options:
   --repo OWNER/REPO  Release repository to pin the signer identity against
                      (default: omkhar/workcell, or $GITHUB_REPOSITORY).
-  --tag vX.Y.Z       Release tag being verified. Releases published before the
-                     dispatch trigger were signed from that tag, so naming it
-                     also accepts that one exact historical identity.
+  --tag vX.Y.Z       Release tag being verified. Naming a release that was
+                     published before the dispatch trigger also accepts that
+                     one exact historical tag identity; every later release
+                     must present the default-branch identity.
   --attestation      Additionally require `gh attestation verify` to pass.
   --skip-verify      Do NOT verify. Requires --i-understand-unverified-install
                      and prints a loud warning. For documented air-gapped use.
@@ -234,15 +241,16 @@ artifact_path="${ASSETS_DIR}/${ARTIFACT}"
 # published under that trigger is exactly
 # https://github.com/OWNER/REPO/.github/workflows/release.yml@refs/heads/main.
 #
-# Releases published before that change were signed from the pushed tag. When
-# the caller names the tag it is verifying, that one exact tag identity is
-# accepted as well. Both alternatives stay exact: the tag branch is pinned to
-# the requested tag, so it is no looser than the branch one and cannot match a
-# different release.
+# Releases published before that change were signed from the pushed tag. That
+# identity is accepted only for the closed set of releases below, and only when
+# the caller names one of them. Accepting it for any requested tag would let a
+# credential that can create a tag, but not change the default branch, sign a
+# release from an arbitrary commit and defeat the branch binding entirely.
+# Both alternatives stay exact, so neither can match a different release.
 repo_escaped="$(regex_escape "${REPO}")"
 identity_prefix="https://github\.com/${repo_escaped}/\.github/workflows/release\.yml@"
 identity_refs="refs/heads/main"
-if [[ -n "${TAG}" ]]; then
+if [[ -n "${TAG}" ]] && [[ " ${TAG_SIGNED_RELEASES} " == *" ${TAG} "* ]]; then
   identity_refs="${identity_refs}|refs/tags/$(regex_escape "${TAG}")"
 fi
 identity_regexp="^${identity_prefix}(${identity_refs})\$"

--- a/tests/scenarios/shared/test-publish-github-release.sh
+++ b/tests/scenarios/shared/test-publish-github-release.sh
@@ -81,6 +81,35 @@ HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scrip
   --repo-root "${FIXTURE}" \
   --tag v9.9.9 >/dev/null
 
+# The expected binding must accept the verified pair and reject a moved tag.
+HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \
+  --repo-root "${FIXTURE}" \
+  --tag v9.9.9 \
+  --expected-commit "${commit_sha}" \
+  --expected-tag-object "${tag_sha}" >/dev/null
+
+other_sha="$(printf '%040d' 0)"
+for binding in "--expected-commit ${other_sha}" "--expected-tag-object ${other_sha}"; do
+  set +e
+  # shellcheck disable=SC2086 # Each binding is a fixed flag/value pair.
+  binding_output="$(HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \
+    --repo-root "${FIXTURE}" \
+    --tag v9.9.9 ${binding} 2>&1)"
+  binding_rc=$?
+  set -e
+  test "${binding_rc}" -eq 2
+  grep -F 'not the expected' <<<"${binding_output}" >/dev/null
+done
+
+set +e
+malformed_output="$(HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \
+  --repo-root "${FIXTURE}" \
+  --tag v9.9.9 --expected-commit "${commit_sha^^}" 2>&1)"
+malformed_rc=$?
+set -e
+test "${malformed_rc}" -eq 2
+grep -F 'requires a 40-character lowercase object ID' <<<"${malformed_output}" >/dev/null
+
 git_cmd -C "${FIXTURE}" -c tag.gpgSign=false tag v9.9.10
 set +e
 unsigned_tag_output="$(HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \


### PR DESCRIPTION
Unit 3 of the #650 series (superseded by #669). Splits out the release
trigger change and the signed-tag binding.

## Why

Release ran on `push: tags`, so the workflow file, every checkout, and the
keyless Fulcio identity all came from the tag ref. A tag pushed to any commit
therefore selected the release logic that judged it, and each job re-resolved
the movable tag on its own. The `Require tag commit on main` and
`Require main checks green` steps ran only after checkout and proved less than
their names suggest.

## What changes

**Dispatch trigger.** `repository_dispatch: [release]` replaces `push: tags`,
and the concurrency group keys on `client_payload.tag`. GitHub always loads a
`repository_dispatch` workflow from the default branch, so the reviewed release
logic on `main` is the logic that runs.

**Signed-tag binding.** A new `Verify signed tag binding before checkout` step
in `tag-policy` runs before any repository content is fetched, using only fixed
runner tools. It requires:

- `GITHUB_REF` is `refs/heads/main` and `GITHUB_WORKFLOW_REF`/`GITHUB_WORKFLOW_SHA`
  match this repository's `release.yml` at the current main commit,
- exactly the payload fields `tag` and `commit`, with the tag matching
  `^v[0-9A-Za-z.-]{1,63}$` and the commit 40 lowercase hex characters,
- the tag ref resolves to an annotated tag object with a well-formed object ID,
- that object is GitHub-verified (`verified == true`, `reason == valid`),
- the object's embedded name matches, its target type is `commit`, and its
  target is the requested commit,
- the target commit is the current main workflow commit,
- the exact required main workflow set (ci, codeql, docs, hosted-controls,
  scorecard, security) has completed successfully for it, with a bounded
  run inventory.

It publishes `release_commit`, `release_tag` and `tag_object`. Every checkout is
`ref:`-pinned to `release_commit`, and every `GITHUB_SHA` / `GITHUB_REF_NAME` /
`github.sha` / `github.ref_name` use becomes `RELEASE_COMMIT` / `RELEASE_TAG`
sourced from those outputs. The two superseded preflight steps are removed.

**Consumer identity repin.** The signing workflow now runs from
`refs/heads/main`, so `scripts/verify-release-artifact.sh` pins the exact
`release.yml@refs/heads/main` identity with no wildcard segment — tighter than
the previous `@refs/tags/.+`, and matching the verifier `#669` added.
`docs/getting-started.md` carries the same expression.

**Bound rechecks.** `check-release-tag-signature.sh` gains `--expected-commit`
and `--expected-tag-object` (both 40-hex validated) and fails closed in both the
GitHub API path and the local git path when the tag no longer resolves to that
object and commit. The local path also parses canonical annotated tag headers
and requires a direct `commit` target. The workflow rechecks before every
mutation phase: preflight, release assembly, signing, named image publication,
and GitHub release publication — five, up from two.

**Publisher hardening** (`scripts/publish-github-release.sh`, verbatim from the
#650 branch): assert the sanitized entrypoint rather than trusting a single
flag; resolve the Go toolchain to a trusted absolute path whose `GOVERSION`
matches `go.mod` exactly, with `GOTOOLCHAIN=local` so no toolchain is fetched
mid-publish; keep the publication token out of the build environment and hand it
only to the publisher process; accept `--expected-tag-object`; and read the
release commit from canonical annotated tag headers instead of peeling
`^{commit}`, which a nested tag could redirect.

## Validators

`ValidateReleaseWorkflowPublicationGate` now requires the publisher to be
invoked as `"${RELEASE_TAG}"` with `--expected-tag-object "${RELEASE_TAG_OBJECT}"`,
and rejects any `WORKCELL_GITHUB_HOSTED_CONTROLS_POLICY_PATH` override.
`pinnedInputsCheck` requires 5 tag-signature checks, not 2. The merged
binder-authoritative digest, job-scoped parsed validators, and authority split
are unchanged.

The `sign-release` contract digest is recomputed because this change touches the
signer job. Derivation verified empirically: the pre-change workflow reproduces
the merged `59d426ff…` through the validator's own marshalling, and the contract
byte diff against the new `47fadd56…` contains only the intended signer edits
(job env, the two rechecks, and the `RELEASE_TAG`/`RELEASE_COMMIT` rebinds) —
nothing else drifted into the covered surface.

## Operational note

The publisher's toolchain resolution is fail-closed: the publish job needs Go
matching `go.mod` (`go1.27.1`) at one of the trusted absolute paths
(`/opt/hostedtoolcache/go/1.27.1/<arch>/bin/go`, `/usr/local/go/bin/go`, …).
If a runner image drifts off that version the publish step stops with
`Go toolchain go1.27.1 is unavailable at a trusted absolute path.` rather than
downloading one over the network mid-publish.

Do not dispatch a release until the whole series lands.

## Verification

- `go build ./...`; `gofmt -l internal/ cmd/` clean; `go vet` clean
- `go test ./... -count=1` — 48 packages ok
- `go test ./internal/metadatautil/ ./internal/host/release/ ./internal/testkit/ -run 'Release|Workflow|Output|Publish' -count=1` ok
- `./scripts/check-workflows.sh` (actionlint + zizmor), `./scripts/verify-workflow-lanes.sh`,
  `./scripts/check-pinned-inputs.sh`, `./scripts/check-dead-code.sh`,
  `./scripts/verify-control-plane-manifest.sh`, `./scripts/check-doc-links.sh`,
  `./scripts/check-public-contract.sh`, `./scripts/check-doc-support-matrix-fields.sh` — all exit 0
- `bash -n` + `shellcheck` + `shfmt -d` clean on every touched script
- `tests/scenarios/shared/test-publish-github-release.sh` passes, extended with
  negative controls: the correct expected pair is accepted, a wrong
  `--expected-commit` and a wrong `--expected-tag-object` each exit 2, and a
  non-lowercase-hex value is rejected as malformed.

Shape: 12 files, +500/-198 = 698 changed lines.

Series remaining: unit 4 (unconditional attestation, ~490 lines), unit 5
(docs, ~145 lines).
