### PR TITLE
Build the Go apt broker binaries into the runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,14 @@
 *
+!go.mod
+!go.sum
+!internal/
+!internal/aptbroker/
+!internal/aptbroker/**
+!cmd/
+!cmd/workcell-apt-broker-client/
+!cmd/workcell-apt-broker-client/**
+!cmd/workcell-apt-broker-server/
+!cmd/workcell-apt-broker-server/**
 !adapters/
 !adapters/**
 !runtime/

--- a/docs/outbound-endpoints.md
+++ b/docs/outbound-endpoints.md
@@ -113,6 +113,8 @@ The image build path uses a larger fixed set.
 | Docker content | `production.cloudflare.docker.com:443`, `production.cloudfront.docker.com:443`, `docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443` |
 | GitHub content | `github.com:443`, `objects.githubusercontent.com:443`, `release-assets.githubusercontent.com:443` |
 | npm registry | `registry.npmjs.org:443` |
+| Go toolchain | `dl.google.com:443` |
+| Go modules | `proxy.golang.org:443`, `sum.golang.org:443` |
 | Google storage | `storage.googleapis.com:443` |
 | Debian snapshot | `snapshot-cloudflare.debian.org:443`, `snapshot.debian.org:443` |
 

--- a/internal/aptbroker/server_linux_test.go
+++ b/internal/aptbroker/server_linux_test.go
@@ -73,19 +73,14 @@ const (
 	testBrokerExchangeTimeout = 30 * time.Second
 )
 
-// The returned context is the broker lifetime, cancelled only by cleanup. A
-// caller that dials must derive its own per-exchange deadline from it, so that
-// a slow exchange cannot close the listener out from under itself.
-//
-// Readiness comes from ServerConfig.Ready, which Serve calls once the socket is
-// bound, listening and secured. Polling for the socket file instead would
-// observe the pathname in the window between bind(2) and listen(2), where a
-// dial is refused: on a loaded machine that window is wide enough to fail.
+// The returned context is the broker lifetime, so a dialing caller derives its
+// own per-exchange deadline and a slow exchange cannot close the listener under
+// itself. Readiness comes from ServerConfig.Ready: polling for the socket file
+// would see the pathname between bind(2) and listen(2), where a dial is refused.
 func startTestBroker(t *testing.T) (context.Context, string) {
 	t.Helper()
-	// ServerConfig rejects peer uid 0, so a root process is never an
-	// admissible peer for its own broker and this round trip has no uid to
-	// dial from. The unprivileged lanes cover it.
+	// ServerConfig rejects peer uid 0, so root is never an admissible peer for
+	// its own broker and this round trip has no uid to dial from.
 	if os.Getuid() == 0 {
 		t.Skip("round trip requires a non-root client: peer uid 0 is not admissible")
 	}

--- a/internal/aptbroker/server_linux_test.go
+++ b/internal/aptbroker/server_linux_test.go
@@ -17,8 +17,10 @@ import (
 
 func TestServeRoundTripPreservesHelperResult(t *testing.T) {
 	ctx, socket := startTestBroker(t)
+	exchange, cancelExchange := context.WithTimeout(ctx, testBrokerExchangeTimeout)
+	defer cancelExchange()
 	lookup := func(string) (string, bool) { return "noninteractive", true }
-	response, status, err := RunClient(ctx, socket, []string{"apt-get"}, []string{"DEBIAN_FRONTEND"}, lookup)
+	response, status, err := RunClient(exchange, socket, []string{"apt-get"}, []string{"DEBIAN_FRONTEND"}, lookup)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,41 +68,50 @@ func TestValidateSocketAncestryRejectsMutableAncestors(t *testing.T) {
 	}
 }
 
+const (
+	testBrokerReadyTimeout    = 10 * time.Second
+	testBrokerExchangeTimeout = 30 * time.Second
+)
+
+// The returned context is the broker lifetime, cancelled only by cleanup. A
+// caller that dials must derive its own per-exchange deadline from it, so that
+// a slow exchange cannot close the listener out from under itself.
+//
+// Readiness comes from ServerConfig.Ready, which Serve calls once the socket is
+// bound, listening and secured. Polling for the socket file instead would
+// observe the pathname in the window between bind(2) and listen(2), where a
+// dial is refused: on a loaded machine that window is wide enough to fail.
 func startTestBroker(t *testing.T) (context.Context, string) {
 	t.Helper()
+	// ServerConfig rejects peer uid 0, so a root process is never an
+	// admissible peer for its own broker and this round trip has no uid to
+	// dial from. The unprivileged lanes cover it.
 	if os.Getuid() == 0 {
-		t.Skip("round trip requires a non-root client")
+		t.Skip("round trip requires a non-root client: peer uid 0 is not admissible")
 	}
 	socket := filepath.Join(shortSocketDir(t), "broker.sock")
 	helper := writeHelper(t, "printf '%s' \"$DEBIAN_FRONTEND\"\nprintf fixture-stderr >&2\nexit 37\n")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
 	finished := make(chan error, 1)
 	go func() {
-		finished <- Serve(ctx, ServerConfig{SocketPath: socket, HelperPath: helper, ExpectedPeerUID: uint32(os.Getuid())})
+		finished <- Serve(ctx, ServerConfig{
+			SocketPath:      socket,
+			HelperPath:      helper,
+			ExpectedPeerUID: uint32(os.Getuid()),
+			Ready:           func() error { close(ready); return nil },
+		})
 	}()
 	t.Cleanup(func() {
 		cancel()
 		awaitTestBrokerShutdown(t, finished)
 	})
-	waitForTestBrokerSocket(t, ctx, socket)
-	return ctx, socket
-}
-
-func waitForTestBrokerSocket(t *testing.T, ctx context.Context, socket string) {
-	t.Helper()
-	ticker := time.NewTicker(time.Millisecond)
-	defer ticker.Stop()
-	for {
-		info, err := os.Lstat(socket)
-		if isSocketFile(info, err) {
-			return
-		}
-		select {
-		case <-ctx.Done():
-			t.Fatalf("broker socket did not become ready: %v", ctx.Err())
-		case <-ticker.C:
-		}
+	select {
+	case <-ready:
+	case <-time.After(testBrokerReadyTimeout):
+		t.Fatal("broker did not report readiness")
 	}
+	return ctx, socket
 }
 
 func awaitTestBrokerShutdown(t *testing.T, finished <-chan error) {

--- a/internal/metadatautil/apt_broker_build_test.go
+++ b/internal/metadatautil/apt_broker_build_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckPinnedInputsAcceptsAptBrokerBuildContract(t *testing.T) {
+	cfg := writePinnedInputsFixture(t)
+	if err := metadatautil.CheckPinnedInputs(cfg); err != nil {
+		t.Fatalf("metadatautil.CheckPinnedInputs() error = %v", err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsAptBrokerGoPinDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{
+			name: "version",
+			old:  "ARG GO_VERSION=",
+			new:  "ARG GO_VERSION=0.0.0 # replaced ",
+			want: "apt broker Go version",
+		},
+		{
+			name: "amd64-digest",
+			old:  "ARG GO_LINUX_X86_64_SHA256=",
+			new:  "ARG GO_LINUX_X86_64_SHA256=deadbeef",
+			want: "apt broker amd64 Go digest",
+		},
+		{
+			name: "arm64-digest",
+			old:  "ARG GO_LINUX_ARM64_SHA256=",
+			new:  "ARG GO_LINUX_ARM64_SHA256=deadbeef",
+			want: "apt broker arm64 Go digest",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := rewriteAptBrokerDockerfile(t, tc.old, tc.new)
+			requirePinnedInputsErrorContains(t, cfg, tc.want)
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsDuplicateAptBrokerGoPins(t *testing.T) {
+	for _, name := range []string{"GO_VERSION", "GO_LINUX_X86_64_SHA256", "GO_LINUX_ARM64_SHA256"} {
+		t.Run(name, func(t *testing.T) {
+			cfg := rewriteAptBrokerDockerfileWith(t, func(content string) string {
+				prefix := "ARG " + name + "="
+				start := strings.Index(content, prefix)
+				if start < 0 {
+					t.Fatalf("runtime Dockerfile does not contain %q", prefix)
+				}
+				end := strings.IndexByte(content[start:], '\n')
+				if end < 0 {
+					t.Fatalf("runtime Dockerfile %q declaration has no line ending", name)
+				}
+				end += start + 1
+				return content[:end] + "arg " + name + "=attacker-value\n" + content[end:]
+			})
+			requirePinnedInputsErrorContains(t, cfg, "must match the reviewed canonical stage")
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsAptBrokerBuildContractDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{
+			name: "duplicate-stage",
+			old:  "FROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder\n",
+			new:  "FROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder\nFROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder\n",
+			want: "Docker stage alias apt-broker-builder",
+		},
+		{
+			name: "target-platform-builder",
+			old:  "FROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder",
+			new:  "FROM --platform=$TARGETPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder",
+			want: "apt broker builder stage",
+		},
+		{
+			name: "duplicate-builder-alias",
+			old:  "FROM runtime-base AS provider-builder\n",
+			new:  "FROM runtime-base AS provider-builder\nFROM attacker.invalid/image AS apt-broker-builder\n",
+			want: "Docker stage alias apt-broker-builder",
+		},
+		{
+			name: "architecture-digest",
+			old:  `arm64) GO_SHA256="${GO_LINUX_ARM64_SHA256}" ;;`,
+			new:  `arm64) GO_SHA256="${GO_LINUX_X86_64_SHA256}" ;;`,
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "download-origin",
+			old:  "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz",
+			new:  "https://example.invalid/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "target-architecture-download",
+			old:  "linux-${BUILDARCH}.tar.gz",
+			new:  "linux-${TARGETARCH}.tar.gz",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "checksum",
+			old:  `echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c -`,
+			new:  `echo "downloaded /tmp/go.tar.gz"`,
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "overwrite-after-checksum",
+			old:  `&& echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \`,
+			new:  "&& echo \"${GO_SHA256}  /tmp/go.tar.gz\" | sha256sum -c - \\\n  && curl --ipv4 -fsSL https://example.invalid/go.tar.gz -o /tmp/go.tar.gz \\",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "module-copy-mode",
+			old:  "COPY --chmod=0444 go.mod go.sum ./",
+			new:  "COPY go.mod go.sum ./",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "trusted-ca-copy",
+			old:  "COPY --from=runtime-base --chmod=0444 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt",
+			new:  "COPY /tmp/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "broker-source-copy",
+			old:  "COPY --chmod=0555 internal/aptbroker ./internal/aptbroker",
+			new:  "COPY internal/aptbroker ./internal/aptbroker",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "client-source-copy",
+			old:  "COPY --chmod=0555 cmd/workcell-apt-broker-client ./cmd/workcell-apt-broker-client",
+			new:  "COPY cmd/workcell-apt-broker-client ./cmd/workcell-apt-broker-client",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "server-source-copy",
+			old:  "COPY --chmod=0555 cmd/workcell-apt-broker-server ./cmd/workcell-apt-broker-server",
+			new:  "COPY cmd/workcell-apt-broker-server ./cmd/workcell-apt-broker-server",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "network-toolchain",
+			old:  "ENV GOTOOLCHAIN=local",
+			new:  "ENV GOTOOLCHAIN=auto",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "static-build",
+			old:  "ENV CGO_ENABLED=0",
+			new:  "ENV CGO_ENABLED=1",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "reproducible-build-flags",
+			old:  "-mod=readonly -trimpath -buildvcs=false -ldflags='-buildid='",
+			new:  "-mod=readonly -buildvcs=false",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "command-local-build-override",
+			old:  `RUN GOOS=linux GOARCH="${TARGETARCH}" /usr/local/go/bin/go build`,
+			new:  `RUN GOTOOLCHAIN=auto CGO_ENABLED=1 GOOS=linux GOARCH="${TARGETARCH}" /usr/local/go/bin/go build`,
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "host-operating-system-build",
+			old:  "RUN GOOS=linux",
+			new:  "RUN GOOS=darwin",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "build-architecture-target",
+			old:  `GOARCH="${TARGETARCH}"`,
+			new:  `GOARCH="${BUILDARCH}"`,
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "missing-source-date-epoch-argument",
+			old:  "ARG TARGETARCH\nARG SOURCE_DATE_EPOCH\n\nSHELL",
+			new:  "ARG TARGETARCH\n\nSHELL",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "normalized-output-time",
+			old:  `touch -d "@${SOURCE_DATE_EPOCH}" /out/workcell-apt-broker-client /out/workcell-apt-broker-server`,
+			new:  "true",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "preload",
+			old:  "ENV CGO_ENABLED=0",
+			new:  "ENV CGO_ENABLED=0\nENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "environment-override",
+			old:  "ENV GOTOOLCHAIN=local",
+			new:  "ENV GOTOOLCHAIN=local\nenv GOTOOLCHAIN auto",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "multi-assignment-environment-override",
+			old:  "ENV GOTOOLCHAIN=local",
+			new:  "ENV GOTOOLCHAIN=local\nENV ATTACKER_MARKER=x GOTOOLCHAIN=auto",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "toolchain-replacement-instruction",
+			old:  "ENV GOTOOLCHAIN=local",
+			new:  "RUN rm -rf /usr/local/go && mkdir -p /usr/local/go\n\nENV GOTOOLCHAIN=local",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "post-build-output-mutation",
+			old:  `touch -d "@${SOURCE_DATE_EPOCH}" /out/workcell-apt-broker-client /out/workcell-apt-broker-server`,
+			new:  "touch -d \"@${SOURCE_DATE_EPOCH}\" /out/workcell-apt-broker-client /out/workcell-apt-broker-server\nRUN printf replaced > /out/workcell-apt-broker-client",
+			want: "must match the reviewed canonical stage",
+		},
+		{
+			name: "runtime-install-mode",
+			old:  "COPY --from=apt-broker-builder --chown=0:0 --chmod=0555",
+			new:  "COPY --from=apt-broker-builder --chown=65532:65532 --chmod=0755",
+			want: "apt broker runtime install boundary",
+		},
+		{
+			name: "runtime-install-override",
+			old:  "COPY --from=apt-broker-builder --chown=0:0 --chmod=0555 /out/workcell-apt-broker-client /out/workcell-apt-broker-server /usr/local/libexec/workcell/",
+			new:  "COPY --from=apt-broker-builder --chown=0:0 --chmod=0555 /out/workcell-apt-broker-client /out/workcell-apt-broker-server /usr/local/libexec/workcell/\nRUN chmod 0777 /usr/local/libexec/workcell/workcell-apt-broker-client",
+			want: "apt broker runtime install boundary",
+		},
+		{
+			name: "post-install-directory-mutation",
+			old:  "WORKDIR /workspace\n\nENV HOME",
+			new:  "WORKDIR /workspace\nRUN chmod -R 0777 /usr/local/libexec/workcell\n\nENV HOME",
+			want: "must not mutate the filesystem after the apt broker runtime install",
+		},
+		{
+			name: "appended-final-stage",
+			old:  `ENTRYPOINT ["/usr/local/bin/workcell-entrypoint"]`,
+			new:  "ENTRYPOINT [\"/usr/local/bin/workcell-entrypoint\"]\n\n  FROM runtime-base AS alternate-final",
+			want: "final runtime stage must be the last Docker stage",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := rewriteAptBrokerDockerfile(t, tc.old, tc.new)
+			requirePinnedInputsErrorContains(t, cfg, tc.want)
+		})
+	}
+}
+
+func rewriteAptBrokerDockerfile(t testing.TB, old, replacement string) metadatautil.PinnedInputsConfig {
+	t.Helper()
+	return rewriteAptBrokerDockerfileWith(t, func(content string) string {
+		if !strings.Contains(content, old) {
+			t.Fatalf("runtime Dockerfile does not contain %q", old)
+		}
+		return strings.Replace(content, old, replacement, 1)
+	})
+}
+
+func rewriteAptBrokerDockerfileWith(t testing.TB, rewrite func(string) string) metadatautil.PinnedInputsConfig {
+	t.Helper()
+	return rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", rewrite)
+}

--- a/internal/metadatautil/apt_broker_build_test.go
+++ b/internal/metadatautil/apt_broker_build_test.go
@@ -281,8 +281,7 @@ func rewriteAptBrokerDockerfileWith(t testing.TB, rewrite func(string) string) m
 	return rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", rewrite)
 }
 
-// A Dockerfile comment naming a broker binary changes nothing in the image, so
-// the runtime-binary count must not read it as a second reference.
+// A comment naming a broker binary is not a second runtime-binary reference.
 func TestCheckPinnedInputsAcceptsCommentedAptBrokerBinaryMention(t *testing.T) {
 	cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
 		return body + "\n# workcell-apt-broker-client and workcell-apt-broker-server are installed above.\n"

--- a/internal/metadatautil/apt_broker_build_test.go
+++ b/internal/metadatautil/apt_broker_build_test.go
@@ -280,3 +280,14 @@ func rewriteAptBrokerDockerfileWith(t testing.TB, rewrite func(string) string) m
 	t.Helper()
 	return rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", rewrite)
 }
+
+// A Dockerfile comment naming a broker binary changes nothing in the image, so
+// the runtime-binary count must not read it as a second reference.
+func TestCheckPinnedInputsAcceptsCommentedAptBrokerBinaryMention(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
+		return body + "\n# workcell-apt-broker-client and workcell-apt-broker-server are installed above.\n"
+	})
+	if err := metadatautil.CheckPinnedInputs(cfg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/metadatautil/apt_broker_context_test.go
+++ b/internal/metadatautil/apt_broker_context_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckPinnedInputsRejectsMissingAptBrokerContextInput(t *testing.T) {
+	for _, line := range []string{
+		"!go.mod", "!go.sum", "!internal/", "!internal/aptbroker/", "!internal/aptbroker/**",
+		"!cmd/", "!cmd/workcell-apt-broker-client/", "!cmd/workcell-apt-broker-client/**",
+		"!cmd/workcell-apt-broker-server/", "!cmd/workcell-apt-broker-server/**",
+	} {
+		t.Run(line, func(t *testing.T) {
+			cfg := writePinnedInputsFixture(t)
+			root := filepath.Join(filepath.Dir(cfg.RuntimeDockerfilePath), "..", "..")
+			rewriteFile(t, filepath.Join(root, ".dockerignore"), func(content string) string {
+				if !strings.Contains(content, line+"\n") {
+					t.Fatalf("fixture missing context rule %q", line)
+				}
+				return strings.Replace(content, line+"\n", "", 1)
+			})
+			requirePinnedInputsErrorContains(t, cfg, ".dockerignore must match the reviewed runtime build context")
+		})
+	}
+}
+
+func TestCheckPinnedInputsRejectsAppendedContextRules(t *testing.T) {
+	for _, line := range []string{"go.mod", "internal/aptbroker/**", "cmd/**", "*", "!**"} {
+		t.Run(line, func(t *testing.T) {
+			cfg := writePinnedInputsFixture(t)
+			root := filepath.Join(filepath.Dir(cfg.RuntimeDockerfilePath), "..", "..")
+			rewriteFile(t, filepath.Join(root, ".dockerignore"), func(content string) string {
+				return content + line + "\n"
+			})
+			requirePinnedInputsErrorContains(t, cfg, ".dockerignore must match the reviewed runtime build context")
+		})
+	}
+}

--- a/internal/metadatautil/build_inputs_test.go
+++ b/internal/metadatautil/build_inputs_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeBuildInputFixture(t *testing.T, root, relative string, data []byte) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func buildInputFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, relative := range []string{
+		"runtime/container/Dockerfile",
+		DebianBootstrapManifestRelPath,
+		"runtime/container/providers/package.json",
+		"runtime/container/providers/package-lock.json",
+	} {
+		data, err := os.ReadFile(filepath.Join("..", "..", filepath.FromSlash(relative)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeBuildInputFixture(t, root, relative, data)
+	}
+	for _, relative := range []string{
+		".dockerignore", "adapters/example/config.json", "go.mod", "go.sum",
+		"internal/aptbroker/protocol.go", "internal/aptbroker/peer_linux.go",
+		"cmd/workcell-apt-broker-client/main.go", "cmd/workcell-apt-broker-server/main.go",
+		"internal/unrelated/example.go",
+	} {
+		writeBuildInputFixture(t, root, relative, []byte("initial fixture\n"))
+	}
+	return root
+}
+
+type buildInputTestManifest struct {
+	Runtime struct {
+		Inputs map[string]string `json:"context_inputs"`
+	} `json:"runtime"`
+	Verification struct {
+		Inputs map[string]string `json:"inputs"`
+	} `json:"verification"`
+}
+
+func generateBuildInputFixture(t *testing.T, root string) buildInputTestManifest {
+	t.Helper()
+	output := filepath.Join(t.TempDir(), "manifest.json")
+	err := GenerateBuildInputManifest(
+		filepath.Join(root, "runtime/container/Dockerfile"),
+		filepath.Join(root, "runtime/container/providers/package.json"),
+		filepath.Join(root, "runtime/container/providers/package-lock.json"),
+		output, "fixture", 0, false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest buildInputTestManifest
+	if err := readJSONFile(output, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func TestBuildInputManifestBindsBrokerSources(t *testing.T) {
+	root := buildInputFixture(t)
+	before := generateBuildInputFixture(t, root)
+	for _, relative := range []string{
+		"go.mod", "go.sum", "internal/aptbroker/protocol.go", "internal/aptbroker/peer_linux.go",
+		"cmd/workcell-apt-broker-client/main.go", "cmd/workcell-apt-broker-server/main.go",
+	} {
+		t.Run(relative, func(t *testing.T) {
+			if before.Runtime.Inputs[relative] != sha256HexString("initial fixture\n") {
+				t.Fatalf("runtime input missing or incorrect: %s", relative)
+			}
+			if _, exists := before.Verification.Inputs[relative]; exists {
+				t.Fatalf("runtime input also classified as verification: %s", relative)
+			}
+			writeBuildInputFixture(t, root, relative, []byte("changed fixture\n"))
+			after := generateBuildInputFixture(t, root)
+			if after.Runtime.Inputs[relative] != sha256HexString("changed fixture\n") {
+				t.Fatalf("runtime input digest did not follow source: %s", relative)
+			}
+		})
+	}
+	const unrelated = "internal/unrelated/example.go"
+	if _, exists := before.Runtime.Inputs[unrelated]; exists {
+		t.Fatal("unrelated Go source entered runtime context")
+	}
+	if before.Verification.Inputs[unrelated] != sha256HexString("initial fixture\n") {
+		t.Fatal("unrelated Go source lost verification binding")
+	}
+}

--- a/internal/metadatautil/core.go
+++ b/internal/metadatautil/core.go
@@ -903,15 +903,7 @@ func GenerateBuildInputManifest(
 		}
 	}
 
-	adapterContextPaths, err := walkFiles(rootDir, "adapters", "node_modules", "target")
-	if err != nil {
-		return err
-	}
-	runtimeContainerContextPaths, err := walkFiles(rootDir, filepath.Join("runtime", "container"), "node_modules", "target")
-	if err != nil {
-		return err
-	}
-	runtimeContextPaths, err := gitTrackedSubset(rootDir, append(append([]string{".dockerignore"}, adapterContextPaths...), runtimeContainerContextPaths...), requireTracked)
+	runtimeContextPaths, err := runtimeBuildContextPaths(rootDir, requireTracked)
 	if err != nil {
 		return err
 	}
@@ -993,6 +985,21 @@ func GenerateBuildInputManifest(
 		},
 	}
 	return writeJSONFile(outputPath, manifest)
+}
+
+func runtimeBuildContextPaths(rootDir string, requireTracked bool) ([]string, error) {
+	paths := []string{".dockerignore", "go.mod", "go.sum"}
+	for _, directory := range []string{
+		"adapters", "runtime/container", "internal/aptbroker",
+		"cmd/workcell-apt-broker-client", "cmd/workcell-apt-broker-server",
+	} {
+		files, err := walkFiles(rootDir, filepath.FromSlash(directory), "node_modules", "target")
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, files...)
+	}
+	return gitTrackedSubset(rootDir, paths, requireTracked)
 }
 
 func sha256HexString(text string) string {

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -544,8 +544,7 @@ func (validator *dockerPinnedInputValidator) aptBrokerRuntimeStage() (string, er
 }
 
 func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeBinaries(runtimeStage string) error {
-	// Count instructions, not text: a Dockerfile comment that names a binary
-	// changes nothing in the image and must not fail a valid build file.
+	// Count instructions, not text: a comment naming a binary changes nothing.
 	instructions := dockerfileInstructions(runtimeStage)
 	for _, binary := range []string{"workcell-apt-broker-client", "workcell-apt-broker-server"} {
 		if err := requireTextCount(instructions, binary, 1, "apt broker runtime binary", validator.cfg.RuntimeDockerfilePath); err != nil {
@@ -555,8 +554,7 @@ func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeBinaries(ru
 	return nil
 }
 
-// dockerfileInstructions returns text with its comment lines removed. A # is
-// only a comment when it opens a line; elsewhere it is part of the instruction.
+// dockerfileInstructions drops comment lines; a # opens one only at line start.
 func dockerfileInstructions(text string) string {
 	var instructions strings.Builder
 	for line := range strings.Lines(text) {

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -555,11 +555,8 @@ func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeBinaries(ru
 	return nil
 }
 
-// dockerfileInstructions returns text as logical instructions: comment lines
-// removed, then continuations joined. A # is only a comment when it opens a
-// line; elsewhere it is part of the instruction, so nothing else is stripped.
-// Docker drops a comment line before it joins a continuation, so the two run in
-// that order, and a key split across physical lines reads as one assignment.
+// dockerfileInstructions returns text with its comment lines removed. A # is
+// only a comment when it opens a line; elsewhere it is part of the instruction.
 func dockerfileInstructions(text string) string {
 	var instructions strings.Builder
 	for line := range strings.Lines(text) {
@@ -568,7 +565,7 @@ func dockerfileInstructions(text string) string {
 		}
 		instructions.WriteString(line)
 	}
-	return strings.ReplaceAll(instructions.String(), "\\\n", " ")
+	return instructions.String()
 }
 
 func requireTextCount(text, needle string, want int, label, path string) error {

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -555,9 +555,11 @@ func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeBinaries(ru
 	return nil
 }
 
-// dockerfileInstructions returns text with its Dockerfile comment lines
-// removed. A # is only a comment when it opens a line; elsewhere it is part of
-// the instruction, so nothing else is stripped.
+// dockerfileInstructions returns text as logical instructions: comment lines
+// removed, then continuations joined. A # is only a comment when it opens a
+// line; elsewhere it is part of the instruction, so nothing else is stripped.
+// Docker drops a comment line before it joins a continuation, so the two run in
+// that order, and a key split across physical lines reads as one assignment.
 func dockerfileInstructions(text string) string {
 	var instructions strings.Builder
 	for line := range strings.Lines(text) {
@@ -566,7 +568,7 @@ func dockerfileInstructions(text string) string {
 		}
 		instructions.WriteString(line)
 	}
-	return instructions.String()
+	return strings.ReplaceAll(instructions.String(), "\\\n", " ")
 }
 
 func requireTextCount(text, needle string, want int, label, path string) error {

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -544,12 +544,29 @@ func (validator *dockerPinnedInputValidator) aptBrokerRuntimeStage() (string, er
 }
 
 func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeBinaries(runtimeStage string) error {
+	// Count instructions, not text: a Dockerfile comment that names a binary
+	// changes nothing in the image and must not fail a valid build file.
+	instructions := dockerfileInstructions(runtimeStage)
 	for _, binary := range []string{"workcell-apt-broker-client", "workcell-apt-broker-server"} {
-		if err := requireTextCount(runtimeStage, binary, 1, "apt broker runtime binary", validator.cfg.RuntimeDockerfilePath); err != nil {
+		if err := requireTextCount(instructions, binary, 1, "apt broker runtime binary", validator.cfg.RuntimeDockerfilePath); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// dockerfileInstructions returns text with its Dockerfile comment lines
+// removed. A # is only a comment when it opens a line; elsewhere it is part of
+// the instruction, so nothing else is stripped.
+func dockerfileInstructions(text string) string {
+	var instructions strings.Builder
+	for line := range strings.Lines(text) {
+		if strings.HasPrefix(strings.TrimLeft(line, " \t"), "#") {
+			continue
+		}
+		instructions.WriteString(line)
+	}
+	return instructions.String()
 }
 
 func requireTextCount(text, needle string, want int, label, path string) error {

--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -38,7 +38,13 @@ func validateDockerPinnedInputs(cfg PinnedInputsConfig, repoRoot, runtimeDockerf
 	if err := validator.validateDockerPackageSets(); err != nil {
 		return err
 	}
-	return validator.validateValidatorToolInputs()
+	if err := validator.validateValidatorToolInputs(); err != nil {
+		return err
+	}
+	if err := validator.validateAptBrokerBuildInputs(); err != nil {
+		return err
+	}
+	return validateRuntimeBuildPreload(runtimeDockerfile, cfg.RuntimeDockerfilePath)
 }
 
 type dockerPinnedInputValidator struct {
@@ -360,6 +366,204 @@ func (validator *dockerPinnedInputValidator) validateValidatorDeadcode() error {
 	}
 	if !pinnedReleaseTagPattern.MatchString(version) {
 		return fmt.Errorf("DEADCODE_VERSION must be an exact pinned release, found %q", version)
+	}
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) validateAptBrokerBuildInputs() error {
+	stage, err := validator.aptBrokerBuilderStage()
+	if err != nil {
+		return err
+	}
+	pins, err := validator.validateAptBrokerGoPins(stage)
+	if err != nil {
+		return err
+	}
+	expected := fmt.Sprintf(aptBrokerBuilderStageTemplate, pins.version, pins.amd64Digest, pins.arm64Digest)
+	if stage != expected {
+		return errors.New("runtime/container/Dockerfile apt broker builder stage must match the reviewed canonical stage")
+	}
+	return firstPinnedInputError(validator.validateAptBrokerRuntimeInstall, validator.validateAptBrokerContext)
+}
+
+// Keep the complete context canonical: later ignore rules can undo inclusions.
+func (validator *dockerPinnedInputValidator) validateAptBrokerContext() error {
+	const expected = `*
+!go.mod
+!go.sum
+!internal/
+!internal/aptbroker/
+!internal/aptbroker/**
+!cmd/
+!cmd/workcell-apt-broker-client/
+!cmd/workcell-apt-broker-client/**
+!cmd/workcell-apt-broker-server/
+!cmd/workcell-apt-broker-server/**
+!adapters/
+!adapters/**
+!runtime/
+!runtime/container/
+!runtime/container/**
+!tools/markdownlint/
+!tools/markdownlint/**
+tools/markdownlint/node_modules/
+runtime/container/providers/node_modules/
+runtime/container/rust/target/
+runtime/container/rust/fuzz/target/
+runtime/container/rust/fuzz/artifacts/
+runtime/container/rust/fuzz/coverage/
+`
+	content, err := readText(filepath.Join(filepath.Dir(validator.goModPath), ".dockerignore"))
+	if err != nil {
+		return err
+	}
+	if content != expected {
+		return errors.New(".dockerignore must match the reviewed runtime build context")
+	}
+	return nil
+}
+
+func (validator *dockerPinnedInputValidator) aptBrokerBuilderStage() (string, error) {
+	const (
+		stageStart = "FROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder\n"
+		stageEnd   = "FROM runtime-base AS provider-builder\n"
+	)
+	if err := requireDockerStageAliasCount(validator.runtimeDockerfile, "apt-broker-builder", 1, validator.cfg.RuntimeDockerfilePath); err != nil {
+		return "", err
+	}
+	if strings.Count(validator.runtimeDockerfile, stageStart) != 1 {
+		return "", errors.New("runtime/container/Dockerfile must contain exactly one apt broker builder stage")
+	}
+	stage, err := requireDelimitedText(validator.runtimeDockerfile, stageStart, stageEnd, "apt broker builder stage", validator.cfg.RuntimeDockerfilePath)
+	return stage, err
+}
+
+type aptBrokerGoPins struct {
+	version     string
+	amd64Digest string
+	arm64Digest string
+}
+
+func (validator *dockerPinnedInputValidator) validateAptBrokerGoPins(stage string) (aptBrokerGoPins, error) {
+	var pins aptBrokerGoPins
+	var err error
+	pins.version, err = validator.validateAptBrokerGoPin(stage, "GO_VERSION", "apt broker Go version")
+	if err != nil {
+		return aptBrokerGoPins{}, err
+	}
+	pins.amd64Digest, err = validator.validateAptBrokerGoPin(stage, "GO_LINUX_X86_64_SHA256", "apt broker amd64 Go digest")
+	if err != nil {
+		return aptBrokerGoPins{}, err
+	}
+	pins.arm64Digest, err = validator.validateAptBrokerGoPin(stage, "GO_LINUX_ARM64_SHA256", "apt broker arm64 Go digest")
+	return pins, err
+}
+
+func (validator *dockerPinnedInputValidator) validateAptBrokerGoPin(stage, name, label string) (string, error) {
+	runtimeValue, err := requireArg(stage, name, validator.cfg.RuntimeDockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	validatorValue, err := requireArg(validator.validatorDockerfile, name, validator.cfg.ValidatorDockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	if err := requireEqual(label, runtimeValue, validator.cfg.RuntimeDockerfilePath, validatorValue, validator.cfg.ValidatorDockerfilePath); err != nil {
+		return "", err
+	}
+	return runtimeValue, nil
+}
+
+const aptBrokerBuilderStageTemplate = `
+ARG GO_VERSION=%s
+ARG GO_LINUX_X86_64_SHA256=%s
+ARG GO_LINUX_ARM64_SHA256=%s
+ARG BUILDARCH
+ARG TARGETARCH
+ARG SOURCE_DATE_EPOCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Node supplies TLS before the pinned Go toolchain is available.
+RUN case "${BUILDARCH}" in \
+      amd64) GO_SHA256="${GO_LINUX_X86_64_SHA256}" ;; \
+      arm64) GO_SHA256="${GO_LINUX_ARM64_SHA256}" ;; \
+      *) echo "Unsupported Go build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
+    esac \
+  && case "${TARGETARCH}" in amd64|arm64) ;; *) echo "Unsupported Go target architecture: ${TARGETARCH}" >&2; exit 1 ;; esac \
+  && node --dns-result-order=ipv4first -e 'const { createWriteStream } = require("node:fs"); const { Readable } = require("node:stream"); const { pipeline } = require("node:stream/promises"); (async () => { const response = await fetch(process.argv[1]); if (!response.ok) throw new Error("Go download HTTP status " + response.status); await pipeline(Readable.fromWeb(response.body), createWriteStream("/tmp/go.tar.gz")); })().catch((error) => { console.error(error.message); process.exit(1); });' "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz" \
+  && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/go.tar.gz -C /usr/local \
+  && rm -f /tmp/go.tar.gz
+
+COPY --from=runtime-base --chmod=0444 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENV GOTOOLCHAIN=local
+ENV GOPROXY=https://proxy.golang.org
+ENV GOSUMDB=sum.golang.org
+ENV CGO_ENABLED=0
+
+WORKDIR /workcell-go
+COPY --chmod=0444 go.mod go.sum ./
+COPY --chmod=0555 internal/aptbroker ./internal/aptbroker
+COPY --chmod=0555 cmd/workcell-apt-broker-client ./cmd/workcell-apt-broker-client
+COPY --chmod=0555 cmd/workcell-apt-broker-server ./cmd/workcell-apt-broker-server
+
+RUN GOOS=linux GOARCH="${TARGETARCH}" /usr/local/go/bin/go build -mod=readonly -trimpath -buildvcs=false -ldflags='-buildid=' -o /out/ ./cmd/workcell-apt-broker-client ./cmd/workcell-apt-broker-server \
+  && touch -d "@${SOURCE_DATE_EPOCH}" /out/workcell-apt-broker-client /out/workcell-apt-broker-server
+
+`
+
+func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeInstall() error {
+	runtimeStage, err := validator.aptBrokerRuntimeStage()
+	if err != nil {
+		return err
+	}
+	const install = "COPY --from=apt-broker-builder --chown=0:0 --chmod=0555 /out/workcell-apt-broker-client /out/workcell-apt-broker-server /usr/local/libexec/workcell/"
+	const installBoundary = install + "\n\nWORKDIR /workspace\n"
+	if err := requireTextCount(runtimeStage, installBoundary, 1, "apt broker runtime install boundary", validator.cfg.RuntimeDockerfilePath); err != nil {
+		return err
+	}
+	parts := strings.SplitN(runtimeStage, installBoundary, 2)
+	if regexp.MustCompile(`(?mi)^[\t ]*(?:RUN|COPY|ADD|WORKDIR)[\t ]`).MatchString(parts[1]) {
+		return errors.New("runtime/container/Dockerfile must not mutate the filesystem after the apt broker runtime install")
+	}
+	return validator.validateAptBrokerRuntimeBinaries(runtimeStage)
+}
+
+func (validator *dockerPinnedInputValidator) aptBrokerRuntimeStage() (string, error) {
+	const stageStart = "FROM runtime-base AS runtime\n"
+	if strings.Count(validator.runtimeDockerfile, stageStart) != 1 {
+		return "", errors.New("runtime/container/Dockerfile must contain exactly one final runtime stage")
+	}
+	stage := strings.SplitN(validator.runtimeDockerfile, stageStart, 2)[1]
+	if regexp.MustCompile(`(?mi)^[\t ]*FROM[\t ]`).MatchString(stage) {
+		return "", errors.New("runtime/container/Dockerfile final runtime stage must be the last Docker stage")
+	}
+	return stage, nil
+}
+
+func (validator *dockerPinnedInputValidator) validateAptBrokerRuntimeBinaries(runtimeStage string) error {
+	for _, binary := range []string{"workcell-apt-broker-client", "workcell-apt-broker-server"} {
+		if err := requireTextCount(runtimeStage, binary, 1, "apt broker runtime binary", validator.cfg.RuntimeDockerfilePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireTextCount(text, needle string, want int, label, path string) error {
+	if count := strings.Count(text, needle); count != want {
+		return fmt.Errorf("%s in %s must occur exactly %d time(s), found %d", label, path, want, count)
+	}
+	return nil
+}
+
+func requireDockerStageAliasCount(text, alias string, want int, path string) error {
+	pattern := `(?mi)^[\t ]*FROM[^\r\n]*[\t ]+AS[\t ]+` + regexp.QuoteMeta(alias) + `[\t ]*$`
+	count := len(regexp.MustCompile(pattern).FindAllStringIndex(text, -1))
+	if count != want {
+		return fmt.Errorf("Docker stage alias %s in %s must occur exactly %d time(s), found %d", alias, path, want, count)
 	}
 	return nil
 }

--- a/internal/metadatautil/runtime_build_preload.go
+++ b/internal/metadatautil/runtime_build_preload.go
@@ -36,5 +36,8 @@ func validateRuntimeBuildPreload(dockerfile, path string) error {
 // preloadAssignment matches an assignment of the guard variable that takes
 // effect: a Dockerfile ENV instruction or a shell export inside a RUN. It is
 // anchored to the start of a line, so a comment or prose that names the
-// variable assigns nothing and does not count.
-var preloadAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:ENV|(?:&&[ \t]+)?export)[ \t]+LD_PRELOAD=`)
+// variable assigns nothing and does not count. The variable may appear in any
+// position of the instruction, because ENV and export both persist every key
+// they list, and it is matched by name alone so that the legacy space-separated
+// ENV form cannot smuggle in a fourth assignment either.
+var preloadAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:ENV|(?:&&[ \t]+)?export)[ \t]+(?:[^\n]*[ \t])?LD_PRELOAD\b`)

--- a/internal/metadatautil/runtime_build_preload.go
+++ b/internal/metadatautil/runtime_build_preload.go
@@ -6,7 +6,6 @@ package metadatautil
 import (
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 const runtimeGuardPreload = "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
@@ -28,8 +27,14 @@ func validateRuntimeBuildPreload(dockerfile, path string) error {
 			return err
 		}
 	}
-	if strings.Count(dockerfile, "LD_PRELOAD") != 3 {
-		return fmt.Errorf("%s must keep exactly the three canonical early runtime build preload assignments", path)
+	if count := len(preloadAssignment.FindAllString(dockerfile, -1)); count != 3 {
+		return fmt.Errorf("%s must keep exactly the three canonical early runtime build preload assignments, found %d", path, count)
 	}
 	return nil
 }
+
+// preloadAssignment matches an assignment of the guard variable that takes
+// effect: a Dockerfile ENV instruction or a shell export inside a RUN. It is
+// anchored to the start of a line, so a comment or prose that names the
+// variable assigns nothing and does not count.
+var preloadAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:ENV|(?:&&[ \t]+)?export)[ \t]+LD_PRELOAD=`)

--- a/internal/metadatautil/runtime_build_preload.go
+++ b/internal/metadatautil/runtime_build_preload.go
@@ -13,8 +13,7 @@ const runtimeGuardPreload = "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
 
 // Validate the canonical build fragments, not arbitrary Dockerfile semantics.
 // Keep activation and the next child command together in the builder RUN.
-// Fragments are matched against instructions only: a comment beside a
-// declaration changes nothing Docker does and must not break the pin.
+// Fragments match instructions only: a comment beside one changes nothing.
 func validateRuntimeBuildPreload(dockerfile, path string) error {
 	instructions := dockerfileInstructions(dockerfile)
 	blocks := []string{
@@ -37,11 +36,9 @@ func validateRuntimeBuildPreload(dockerfile, path string) error {
 	return nil
 }
 
-// preloadAssignments counts the guard assignments that take effect. Continuations
-// are joined first, so a split line counts. An ENV persists every key it lists,
-// including the legacy space-separated form; inside a RUN only an assignment
-// that follows an export word counts, so the two words merely appearing in a
-// command's output do not.
+// preloadAssignments counts the guard assignments that take effect, joining
+// continuations first. An ENV persists every key it lists, including the legacy
+// space-separated form; inside a RUN only an export-anchored assignment counts.
 func preloadAssignments(instructions string) int {
 	const guard = "LD_PRELOAD"
 	count := 0

--- a/internal/metadatautil/runtime_build_preload.go
+++ b/internal/metadatautil/runtime_build_preload.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const runtimeGuardPreload = "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
+
+// Validate the canonical build fragments, not arbitrary Dockerfile semantics.
+// Keep activation and the next child command together in the builder RUN.
+func validateRuntimeBuildPreload(dockerfile, path string) error {
+	blocks := []string{
+		"  && printf '/usr/local/lib/libworkcell_exec_guard.so\\n' > /etc/ld.so.preload \\\n" +
+			"  && export " + runtimeGuardPreload + " \\\n" +
+			"  && rm -rf /tmp/workcell-rust-target /workcell-rust\n\n" +
+			"ENV " + runtimeGuardPreload + "\n",
+		"COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json\n\n" +
+			"ENV " + runtimeGuardPreload + "\n\n" +
+			"RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \\\n",
+	}
+	for _, block := range blocks {
+		if _, _, err := requireRegex(dockerfile, "(?m)^"+regexp.QuoteMeta(block), "early runtime build preload", path); err != nil {
+			return err
+		}
+	}
+	if strings.Count(dockerfile, "LD_PRELOAD") != 3 {
+		return fmt.Errorf("%s must keep exactly the three canonical early runtime build preload assignments", path)
+	}
+	return nil
+}

--- a/internal/metadatautil/runtime_build_preload.go
+++ b/internal/metadatautil/runtime_build_preload.go
@@ -6,67 +6,60 @@ package metadatautil
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 )
 
 const runtimeGuardPreload = "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
 
-// runtimeGuardPreloadNote is the reviewed comment that must stay attached to
-// each declaration, so the reason the declaration sits where it does cannot be
-// dropped without this check noticing.
-const runtimeGuardPreloadNote = "# /etc/ld.so.preload loads the exec guard into every process from here on, and\n" +
-	"# the guard refuses a child environment without its own preload. Declare it\n" +
-	"# before the next RUN, or the build's own commands are the first thing refused.\n"
-
 // Validate the canonical build fragments, not arbitrary Dockerfile semantics.
 // Keep activation and the next child command together in the builder RUN.
+// Fragments are matched against instructions only: a comment beside a
+// declaration changes nothing Docker does and must not break the pin.
 func validateRuntimeBuildPreload(dockerfile, path string) error {
+	instructions := dockerfileInstructions(dockerfile)
 	blocks := []string{
 		"  && printf '/usr/local/lib/libworkcell_exec_guard.so\\n' > /etc/ld.so.preload \\\n" +
 			"  && export " + runtimeGuardPreload + " \\\n" +
 			"  && rm -rf /tmp/workcell-rust-target /workcell-rust\n\n" +
-			runtimeGuardPreloadNote +
 			"ENV " + runtimeGuardPreload + "\n",
 		"COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json\n\n" +
-			runtimeGuardPreloadNote +
 			"ENV " + runtimeGuardPreload + "\n\n" +
 			"RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \\\n",
 	}
 	for _, block := range blocks {
-		if _, _, err := requireRegex(dockerfile, "(?m)^"+regexp.QuoteMeta(block), "early runtime build preload", path); err != nil {
+		if _, _, err := requireRegex(instructions, "(?m)^"+regexp.QuoteMeta(block), "early runtime build preload", path); err != nil {
 			return err
 		}
 	}
-	if count := preloadAssignments(dockerfile); count != 3 {
+	if count := preloadAssignments(instructions); count != 3 {
 		return fmt.Errorf("%s must keep exactly the three canonical early runtime build preload assignments, found %d", path, count)
 	}
 	return nil
 }
 
-// runtimeGuardVariable is the environment variable the guard is activated
-// through. Every assignment of it in the build file is reviewed.
-const runtimeGuardVariable = "LD_PRELOAD"
-
-// preloadAssignments counts the assignments of the guard variable that take
-// effect. It reads logical Dockerfile instructions, so a comment, a line split
-// across a continuation, a key in any position, and the legacy space-separated
-// ENV form are each read the way Docker reads them. ENV and export both persist
-// every key they list, so every word of such an instruction is examined.
-func preloadAssignments(dockerfile string) int {
+// preloadAssignments counts the guard assignments that take effect. Continuations
+// are joined first, so a split line counts. An ENV persists every key it lists,
+// including the legacy space-separated form; inside a RUN only an assignment
+// that follows an export word counts, so the two words merely appearing in a
+// command's output do not.
+func preloadAssignments(instructions string) int {
+	const guard = "LD_PRELOAD"
 	count := 0
-	for _, instruction := range strings.Split(dockerfileInstructions(dockerfile), "\n") {
+	for _, instruction := range strings.Split(strings.ReplaceAll(instructions, "\\\n", " "), "\n") {
 		fields := strings.Fields(instruction)
 		if len(fields) == 0 {
 			continue
 		}
-		if !strings.EqualFold(fields[0], "ENV") && !slices.Contains(fields, "export") {
-			continue
-		}
-		for _, field := range fields {
-			if field == runtimeGuardVariable || strings.HasPrefix(field, runtimeGuardVariable+"=") {
+		env := strings.EqualFold(fields[0], "ENV")
+		exported := false
+		for _, field := range fields[1:] {
+			switch {
+			case env && (field == guard || strings.HasPrefix(field, guard+"=")):
+				count++
+			case exported && strings.HasPrefix(field, guard+"="):
 				count++
 			}
+			exported = field == "export" || (exported && strings.Contains(field, "="))
 		}
 	}
 	return count

--- a/internal/metadatautil/runtime_build_preload.go
+++ b/internal/metadatautil/runtime_build_preload.go
@@ -6,9 +6,18 @@ package metadatautil
 import (
 	"fmt"
 	"regexp"
+	"slices"
+	"strings"
 )
 
 const runtimeGuardPreload = "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
+
+// runtimeGuardPreloadNote is the reviewed comment that must stay attached to
+// each declaration, so the reason the declaration sits where it does cannot be
+// dropped without this check noticing.
+const runtimeGuardPreloadNote = "# /etc/ld.so.preload loads the exec guard into every process from here on, and\n" +
+	"# the guard refuses a child environment without its own preload. Declare it\n" +
+	"# before the next RUN, or the build's own commands are the first thing refused.\n"
 
 // Validate the canonical build fragments, not arbitrary Dockerfile semantics.
 // Keep activation and the next child command together in the builder RUN.
@@ -17,8 +26,10 @@ func validateRuntimeBuildPreload(dockerfile, path string) error {
 		"  && printf '/usr/local/lib/libworkcell_exec_guard.so\\n' > /etc/ld.so.preload \\\n" +
 			"  && export " + runtimeGuardPreload + " \\\n" +
 			"  && rm -rf /tmp/workcell-rust-target /workcell-rust\n\n" +
+			runtimeGuardPreloadNote +
 			"ENV " + runtimeGuardPreload + "\n",
 		"COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json\n\n" +
+			runtimeGuardPreloadNote +
 			"ENV " + runtimeGuardPreload + "\n\n" +
 			"RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \\\n",
 	}
@@ -27,17 +38,36 @@ func validateRuntimeBuildPreload(dockerfile, path string) error {
 			return err
 		}
 	}
-	if count := len(preloadAssignment.FindAllString(dockerfile, -1)); count != 3 {
+	if count := preloadAssignments(dockerfile); count != 3 {
 		return fmt.Errorf("%s must keep exactly the three canonical early runtime build preload assignments, found %d", path, count)
 	}
 	return nil
 }
 
-// preloadAssignment matches an assignment of the guard variable that takes
-// effect: a Dockerfile ENV instruction or a shell export inside a RUN. It is
-// anchored to the start of a line, so a comment or prose that names the
-// variable assigns nothing and does not count. The variable may appear in any
-// position of the instruction, because ENV and export both persist every key
-// they list, and it is matched by name alone so that the legacy space-separated
-// ENV form cannot smuggle in a fourth assignment either.
-var preloadAssignment = regexp.MustCompile(`(?m)^[ \t]*(?:ENV|(?:&&[ \t]+)?export)[ \t]+(?:[^\n]*[ \t])?LD_PRELOAD\b`)
+// runtimeGuardVariable is the environment variable the guard is activated
+// through. Every assignment of it in the build file is reviewed.
+const runtimeGuardVariable = "LD_PRELOAD"
+
+// preloadAssignments counts the assignments of the guard variable that take
+// effect. It reads logical Dockerfile instructions, so a comment, a line split
+// across a continuation, a key in any position, and the legacy space-separated
+// ENV form are each read the way Docker reads them. ENV and export both persist
+// every key they list, so every word of such an instruction is examined.
+func preloadAssignments(dockerfile string) int {
+	count := 0
+	for _, instruction := range strings.Split(dockerfileInstructions(dockerfile), "\n") {
+		fields := strings.Fields(instruction)
+		if len(fields) == 0 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "ENV") && !slices.Contains(fields, "export") {
+			continue
+		}
+		for _, field := range fields {
+			if field == runtimeGuardVariable || strings.HasPrefix(field, runtimeGuardVariable+"=") {
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/internal/metadatautil/runtime_build_preload_test.go
+++ b/internal/metadatautil/runtime_build_preload_test.go
@@ -17,8 +17,7 @@ func TestCheckPinnedInputsRuntimeBuildPreload(t *testing.T) {
 	}
 }
 
-// A comment that names the guard variable assigns nothing, so it must not
-// change the canonical assignment count or fail a valid build file.
+// A comment naming the guard variable assigns nothing, so the count is unchanged.
 func TestCheckPinnedInputsAcceptsInertBuildPreloadMentions(t *testing.T) {
 	const laterStage = "FROM runtime-base AS provider-builder\n"
 	for name, rewrite := range map[string]func(string) string{
@@ -44,8 +43,7 @@ func TestCheckPinnedInputsAcceptsInertBuildPreloadMentions(t *testing.T) {
 	}
 }
 
-// ENV and export persist every key they list, so an override that hides the
-// guard variable behind another key is still an override.
+// ENV and export persist every key, so a key that hides the guard still overrides.
 func TestCheckPinnedInputsRejectsMultiKeyBuildPreloadOverride(t *testing.T) {
 	const canonicalExport = "  && export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so \\\n"
 	for name, rewrite := range map[string]func(string) string{

--- a/internal/metadatautil/runtime_build_preload_test.go
+++ b/internal/metadatautil/runtime_build_preload_test.go
@@ -39,6 +39,12 @@ func TestCheckPinnedInputsRejectsMultiKeyBuildPreloadOverride(t *testing.T) {
 		"legacy ENV syntax": func(body string) string {
 			return body + "\nENV LD_PRELOAD /workspace/evil.so\n"
 		},
+		"key split across a continuation": func(body string) string {
+			return body + "\nENV MARKER=x \\\n    LD_PRELOAD=/workspace/evil.so\n"
+		},
+		"key behind a comment inside a continuation": func(body string) string {
+			return body + "\nENV MARKER=x \\\n# Docker drops this line before it joins the continuation.\n    LD_PRELOAD=/workspace/evil.so\n"
+		},
 		"multi-key export in the builder RUN": func(body string) string {
 			return strings.Replace(body, canonicalExport,
 				canonicalExport+"  && export MARKER=x LD_PRELOAD=/workspace/evil.so \\\n", 1)

--- a/internal/metadatautil/runtime_build_preload_test.go
+++ b/internal/metadatautil/runtime_build_preload_test.go
@@ -19,12 +19,28 @@ func TestCheckPinnedInputsRuntimeBuildPreload(t *testing.T) {
 
 // A comment that names the guard variable assigns nothing, so it must not
 // change the canonical assignment count or fail a valid build file.
-func TestCheckPinnedInputsAcceptsCommentedBuildPreloadMention(t *testing.T) {
-	cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
-		return body + "\n# LD_PRELOAD activation is reviewed above; do not add another assignment.\n"
-	})
-	if err := metadatautil.CheckPinnedInputs(cfg); err != nil {
-		t.Fatal(err)
+func TestCheckPinnedInputsAcceptsInertBuildPreloadMentions(t *testing.T) {
+	const laterStage = "FROM runtime-base AS provider-builder\n"
+	for name, rewrite := range map[string]func(string) string{
+		"comment": func(body string) string {
+			return body + "\n# LD_PRELOAD activation is reviewed above; do not add another assignment.\n"
+		},
+		"words in a command": func(body string) string {
+			return strings.Replace(body, laterStage, laterStage+"\nRUN printf '%s\\n' export LD_PRELOAD\n", 1)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
+				mutated := rewrite(body)
+				if mutated == body {
+					t.Fatalf("mention %q did not change the build file", name)
+				}
+				return mutated
+			})
+			if err := metadatautil.CheckPinnedInputs(cfg); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/internal/metadatautil/runtime_build_preload_test.go
+++ b/internal/metadatautil/runtime_build_preload_test.go
@@ -28,6 +28,35 @@ func TestCheckPinnedInputsAcceptsCommentedBuildPreloadMention(t *testing.T) {
 	}
 }
 
+// ENV and export persist every key they list, so an override that hides the
+// guard variable behind another key is still an override.
+func TestCheckPinnedInputsRejectsMultiKeyBuildPreloadOverride(t *testing.T) {
+	const canonicalExport = "  && export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so \\\n"
+	for name, rewrite := range map[string]func(string) string{
+		"multi-key ENV": func(body string) string {
+			return body + "\nENV MARKER=x LD_PRELOAD=/workspace/evil.so\n"
+		},
+		"legacy ENV syntax": func(body string) string {
+			return body + "\nENV LD_PRELOAD /workspace/evil.so\n"
+		},
+		"multi-key export in the builder RUN": func(body string) string {
+			return strings.Replace(body, canonicalExport,
+				canonicalExport+"  && export MARKER=x LD_PRELOAD=/workspace/evil.so \\\n", 1)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
+				mutated := rewrite(body)
+				if mutated == body {
+					t.Fatalf("override %q did not change the build file", name)
+				}
+				return mutated
+			})
+			requirePinnedInputsErrorContains(t, cfg, "early runtime build preload")
+		})
+	}
+}
+
 func TestCheckPinnedInputsRejectsLateBuildPreload(t *testing.T) {
 	preload := "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
 	for _, index := range []int{0, 1} {

--- a/internal/metadatautil/runtime_build_preload_test.go
+++ b/internal/metadatautil/runtime_build_preload_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckPinnedInputsRuntimeBuildPreload(t *testing.T) {
+	if err := metadatautil.CheckPinnedInputs(writePinnedInputsFixture(t)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckPinnedInputsRejectsLateBuildPreload(t *testing.T) {
+	preload := "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
+	for _, index := range []int{0, 1} {
+		for _, replacement := range []string{"", "# ENV " + preload + "\n", "ENV LD_PRELOAD=/tmp/guard.so\n"} {
+			t.Run(fmt.Sprintf("%d/%s", index, replacement), func(t *testing.T) {
+				cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
+					parts := strings.Split(body, "ENV "+preload+"\n")
+					if len(parts) != 3 {
+						t.Fatal("expected exactly two stage preload declarations")
+					}
+					parts[index] += replacement + parts[index+1]
+					parts = append(parts[:index+1], parts[index+2:]...)
+					return strings.Join(parts, "ENV "+preload+"\n") + "\nENV " + preload + "\n"
+				})
+				requirePinnedInputsErrorContains(t, cfg, "early runtime build preload")
+			})
+		}
+	}
+}
+
+func TestCheckPinnedInputsRejectsBuildPreloadOverrides(t *testing.T) {
+	preload := "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
+	for name, rewrite := range map[string]func(string) string{
+		"missing inline export": func(body string) string {
+			return strings.Replace(body, "  && export "+preload+" \\\n", "", 1)
+		},
+		"wrong inline export": func(body string) string {
+			return strings.Replace(body, "export "+preload, "export LD_PRELOAD=/tmp/guard.so", 1)
+		},
+		"later override": func(body string) string {
+			return body + "\nENV LD_PRELOAD=/tmp/guard.so\n"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", rewrite)
+			requirePinnedInputsErrorContains(t, cfg, "early runtime build preload")
+		})
+	}
+}

--- a/internal/metadatautil/runtime_build_preload_test.go
+++ b/internal/metadatautil/runtime_build_preload_test.go
@@ -17,6 +17,17 @@ func TestCheckPinnedInputsRuntimeBuildPreload(t *testing.T) {
 	}
 }
 
+// A comment that names the guard variable assigns nothing, so it must not
+// change the canonical assignment count or fail a valid build file.
+func TestCheckPinnedInputsAcceptsCommentedBuildPreloadMention(t *testing.T) {
+	cfg := rewritePinnedInputsFixtureFile(t, "runtime/container/Dockerfile", func(body string) string {
+		return body + "\n# LD_PRELOAD activation is reviewed above; do not add another assignment.\n"
+	})
+	if err := metadatautil.CheckPinnedInputs(cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCheckPinnedInputsRejectsLateBuildPreload(t *testing.T) {
 	preload := "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
 	for _, index := range []int{0, 1} {

--- a/internal/metadatautil/validate_security_test.go
+++ b/internal/metadatautil/validate_security_test.go
@@ -58,6 +58,7 @@ func writePinnedInputsFixture(tb testing.TB) metadatautil.PinnedInputsConfig {
 	srcRoot := metadatautilRepoRoot(tb)
 	dstRoot := tb.TempDir()
 	for _, relativePath := range []string{
+		".dockerignore",
 		"go.mod",
 		".github/CODEOWNERS",
 		".github/workflows/ci.yml",

--- a/internal/testkit/runtime_go_pins_test.go
+++ b/internal/testkit/runtime_go_pins_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpstreamRefreshIncludesRuntimeGoPins(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts/update-upstream-pins.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pin := range []struct{ arg, current, target string }{
+		{"GO_VERSION", "current_runtime_go_version", "target_go_toolchain"},
+		{"GO_LINUX_X86_64_SHA256", "current_runtime_go_sha_amd64", "target_go_sha_amd64"},
+		{"GO_LINUX_ARM64_SHA256", "current_runtime_go_sha_arm64", "target_go_sha_arm64"},
+	} {
+		for _, want := range []string{
+			fmt.Sprintf(`%s="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" %s)"`, pin.current, pin.arg),
+			fmt.Sprintf(`"${%s}|${%s}"`, pin.current, pin.target),
+			fmt.Sprintf(`replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG %s=' "ARG %s=${%s}"`, pin.arg, pin.arg, pin.target),
+		} {
+			if !strings.Contains(string(data), want) {
+				t.Errorf("upstream refresh lacks runtime Go pin operation: %s", want)
+			}
+		}
+	}
+}

--- a/internal/testkit/update_upstream_pins_check_test.go
+++ b/internal/testkit/update_upstream_pins_check_test.go
@@ -29,6 +29,9 @@ type updaterFixturePins struct {
 	GoLanguage                   string
 	GoAMD64SHA                   string
 	GoARM64SHA                   string
+	RuntimeGoVersion             string
+	RuntimeGoAMD64SHA            string
+	RuntimeGoARM64SHA            string
 	DeadcodeVersion              string
 	RustVersion                  string
 	RuntimeRustImage             string
@@ -509,6 +512,7 @@ func writeUpdaterFixture(t *testing.T, manifest updaterFixtureManifest, manifest
 
 	root := t.TempDir()
 	for _, rel := range []string{
+		".dockerignore",
 		".github/CODEOWNERS",
 		"adapters/codex/mcp/config.toml",
 		"adapters/codex/requirements.toml",
@@ -982,6 +986,9 @@ func updaterFixtureSummary(pins updaterFixturePins, current, target updaterFixtu
 	writeUpdaterFixtureSummaryLine(&output, "debian-ca-certificates-sha256", current.CACertificatesSHA256, target.CACertificatesSHA256)
 	writeUpdaterFixtureSummaryLine(&output, "go-toolchain", pins.GoToolchain, pins.GoToolchain)
 	writeUpdaterFixtureSummaryLine(&output, "go-language", pins.GoLanguage, pins.GoLanguage)
+	writeUpdaterFixtureSummaryLine(&output, "runtime-go", pins.RuntimeGoVersion, pins.GoToolchain)
+	writeUpdaterFixtureSummaryLine(&output, "runtime-go-amd64-sha256", pins.RuntimeGoAMD64SHA, pins.GoAMD64SHA)
+	writeUpdaterFixtureSummaryLine(&output, "runtime-go-arm64-sha256", pins.RuntimeGoARM64SHA, pins.GoARM64SHA)
 	writeUpdaterFixtureSummaryLine(&output, "deadcode-validator", pins.DeadcodeVersion, pins.DeadcodeVersion)
 	writeUpdaterFixtureSummaryLine(&output, "deadcode-script", pins.DeadcodeVersion, pins.DeadcodeVersion)
 	writeUpdaterFixtureSummaryLine(&output, "rust-toolchain", pins.RustVersion, pins.RustVersion)
@@ -1025,21 +1032,24 @@ func readUpdaterFixturePins(t *testing.T) updaterFixturePins {
 	hadolintARM64SHA := updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_LINUX_ARM64_SHA256=")
 
 	return updaterFixturePins{
-		RuntimeBase:      updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG NODE_BASE_IMAGE="),
-		ValidatorBase:    updaterFixtureUniqueValue(t, validatorDockerfile, "ARG VALIDATOR_BASE_IMAGE="),
-		GoToolchain:      updaterFixtureUniqueValue(t, goMod, "toolchain go"),
-		GoLanguage:       updaterFixtureUniqueValue(t, goMod, "go "),
-		GoAMD64SHA:       updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_X86_64_SHA256="),
-		GoARM64SHA:       updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_ARM64_SHA256="),
-		DeadcodeVersion:  updaterFixtureUniqueValue(t, validatorDockerfile, "ARG DEADCODE_VERSION="),
-		RustVersion:      updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_VERSION="),
-		RuntimeRustImage: updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_TOOLCHAIN_IMAGE="),
-		RustupVersion:    updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_VERSION="),
-		RustupAMD64SHA:   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_X86_64_SHA256="),
-		RustupARM64SHA:   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_ARM64_SHA256="),
-		HadolintVersion:  updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_VERSION="),
-		HadolintAMD64SHA: hadolintAMD64SHA,
-		HadolintARM64SHA: hadolintARM64SHA,
+		RuntimeBase:       updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG NODE_BASE_IMAGE="),
+		ValidatorBase:     updaterFixtureUniqueValue(t, validatorDockerfile, "ARG VALIDATOR_BASE_IMAGE="),
+		GoToolchain:       updaterFixtureUniqueValue(t, goMod, "toolchain go"),
+		GoLanguage:        updaterFixtureUniqueValue(t, goMod, "go "),
+		GoAMD64SHA:        updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_X86_64_SHA256="),
+		GoARM64SHA:        updaterFixtureUniqueValue(t, validatorDockerfile, "ARG GO_LINUX_ARM64_SHA256="),
+		RuntimeGoVersion:  updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG GO_VERSION="),
+		RuntimeGoAMD64SHA: updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG GO_LINUX_X86_64_SHA256="),
+		RuntimeGoARM64SHA: updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG GO_LINUX_ARM64_SHA256="),
+		DeadcodeVersion:   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG DEADCODE_VERSION="),
+		RustVersion:       updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_VERSION="),
+		RuntimeRustImage:  updaterFixtureUniqueValue(t, runtimeDockerfile, "ARG RUST_TOOLCHAIN_IMAGE="),
+		RustupVersion:     updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_VERSION="),
+		RustupAMD64SHA:    updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_X86_64_SHA256="),
+		RustupARM64SHA:    updaterFixtureUniqueValue(t, validatorDockerfile, "ARG RUSTUP_INIT_LINUX_ARM64_SHA256="),
+		HadolintVersion:   updaterFixtureUniqueValue(t, validatorDockerfile, "ARG HADOLINT_VERSION="),
+		HadolintAMD64SHA:  hadolintAMD64SHA,
+		HadolintARM64SHA:  hadolintARM64SHA,
 		HadolintChecksums: fmt.Sprintf(
 			"%s  *hadolint-linux-x86_64\n%s  *hadolint-linux-arm64\n",
 			hadolintAMD64SHA,

--- a/internal/workcellhardening/runtime_path_test.go
+++ b/internal/workcellhardening/runtime_path_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package workcellhardening
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const runtimePathPin = "readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\nexport PATH\n"
+
+func TestRuntimePathPrologues(t *testing.T) {
+	executable := "#!/bin/bash -p\n" + runtimePathPin + "set -euo pipefail\n"
+	library := "#!/bin/bash -p\n" +
+		"if [[ \"${PATH}\" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then\n" +
+		"  PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\n" +
+		"fi\nreadonly PATH\nexport PATH\n"
+	for name, prefix := range map[string]string{
+		"entrypoint.sh":          executable,
+		"provider-wrapper.sh":    executable,
+		"development-wrapper.sh": executable,
+		"home-control-plane.sh":  library,
+		"runtime-user.sh":        library,
+	} {
+		t.Run(name, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join("..", "..", "runtime", "container", name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, ok := strings.CutPrefix(string(content), prefix)
+			if !ok {
+				t.Fatal("missing ordered trusted PATH prologue")
+			}
+			if runtimePathMutation(body) {
+				t.Fatal("shell PATH mutation follows the trusted prologue")
+			}
+		})
+	}
+}
+
+// runtimePathMutation reports direct shell mutations of PATH, not the meaning
+// of arbitrary shell programs: an assignment at the start of a command, after
+// a declaration builtin, or an unset naming PATH. Command arguments such as
+// env PATH=value do not assign the shell variable and are not mutations.
+// The scan is deliberately over-eager on anything that reads as an
+// assignment, so a missed mutation cannot pass as a parse subtlety.
+var runtimePathMutationPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?m)(^|[;&|(){}]|\b(then|else|elif|do|export|declare|local|typeset|readonly)\b)[ \t]*PATH=`),
+	regexp.MustCompile(`(?m)\bunset\b[^;&|\n]*\bPATH\b`),
+}
+
+func runtimePathMutation(body string) bool {
+	// Comments first, then continuations: joining a comment into the next
+	// physical line would hide the assignment that follows it.
+	var code strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimLeft(line, " \t"), "#") {
+			continue
+		}
+		code.WriteString(line)
+		code.WriteByte('\n')
+	}
+	joined := strings.ReplaceAll(code.String(), "\\\n", " ")
+	for _, pattern := range runtimePathMutationPatterns {
+		if pattern.MatchString(joined) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRuntimePathMutationSourceClassification(t *testing.T) {
+	for _, body := range []string{
+		"PATH=/tmp", "export PATH=/tmp", "declare PATH=/tmp", "unset PATH", "unset -v PATH",
+		"if true; then PATH=/tmp; fi", "readonly PATH=/tmp", "true && PATH=/tmp",
+	} {
+		if !runtimePathMutation(body) {
+			t.Errorf("direct mutation not detected: %s", body)
+		}
+	}
+	for _, body := range []string{
+		"env PATH=/bin tool", "printf '%s' \"$PATH\"", "# PATH=/tmp", "HOME=/tmp",
+		"MYPATH=/tmp", "  # unset PATH", "unset GIT_EXEC_PATH",
+		"/usr/bin/env -i \\\n  PATH=/bin LC_ALL=C \\\n  tool",
+	} {
+		if runtimePathMutation(body) {
+			t.Errorf("non-mutation rejected: %s", body)
+		}
+	}
+}

--- a/internal/workcellhardening/runtime_path_test.go
+++ b/internal/workcellhardening/runtime_path_test.go
@@ -13,9 +13,17 @@ import (
 
 const runtimePathPin = "readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\nexport PATH\n"
 
+// Privileged mode keeps the script's own shell from reading BASH_ENV and ENV,
+// but leaves them exported for the plain-bash children these scripts start.
+// The prologue must clear them, which is what the replaced shebang did.
+const runtimeStartupPin = "#!/bin/bash -p\n" +
+	"# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.\n" +
+	"# The plain-bash children below would still read them, so clear them here.\n" +
+	"unset BASH_ENV ENV\n"
+
 func TestRuntimePathPrologues(t *testing.T) {
-	executable := "#!/bin/bash -p\n" + runtimePathPin + "set -euo pipefail\n"
-	library := "#!/bin/bash -p\n" +
+	executable := runtimeStartupPin + runtimePathPin + "set -euo pipefail\n"
+	library := runtimeStartupPin +
 		"if [[ \"${PATH}\" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then\n" +
 		"  PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\n" +
 		"fi\nreadonly PATH\nexport PATH\n"

--- a/internal/workcellhardening/runtime_path_test.go
+++ b/internal/workcellhardening/runtime_path_test.go
@@ -13,23 +13,16 @@ import (
 
 const runtimePathPin = "readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\nexport PATH\n"
 
-// The BASH_ENV/ENV clearing prologue is checked in internal/testkit; it is
-// repeated here so the PATH pin is held to the line right after it.
-const runtimeStartupPin = "#!/usr/bin/env -S BASH_ENV= ENV= bash\n" +
-	"# The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts\n" +
-	"# also run as plain `/bin/bash <script>`, so clear them for every child bash.\n" +
-	"# A startup file that already ran can pin either one readonly, which makes the\n" +
-	"# unset fail while errexit is still off, so refuse to run while one survives.\n" +
-	"unset BASH_ENV ENV\n" +
+// internal/testkit holds this clearing prologue to the top of each script; the
+// PATH pin is required on the line where it ends.
+const runtimeStartupPin = "unset BASH_ENV ENV\n" +
 	"[[ -z \"${BASH_ENV+set}${ENV+set}\" ]] || {\n" +
 	"  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2\n" +
-	"  exit 2\n" +
-	"}\n"
+	"  exit 2\n}\n"
 
 func TestRuntimePathPrologues(t *testing.T) {
-	executable := runtimeStartupPin + runtimePathPin + "set -euo pipefail\n"
-	library := runtimeStartupPin +
-		"if [[ \"${PATH}\" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then\n" +
+	executable := runtimePathPin + "set -euo pipefail\n"
+	library := "if [[ \"${PATH}\" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then\n" +
 		"  PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\n" +
 		"fi\nreadonly PATH\nexport PATH\n"
 	for name, prefix := range map[string]string{
@@ -44,8 +37,9 @@ func TestRuntimePathPrologues(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			body, ok := strings.CutPrefix(string(content), prefix)
-			if !ok {
+			_, tail, found := strings.Cut(string(content), runtimeStartupPin)
+			body, ok := strings.CutPrefix(tail, prefix)
+			if !found || !ok {
 				t.Fatal("missing ordered trusted PATH prologue")
 			}
 			if runtimePathMutation(body) {
@@ -55,20 +49,17 @@ func TestRuntimePathPrologues(t *testing.T) {
 	}
 }
 
-// runtimePathMutation reports direct shell mutations of PATH, not the meaning
-// of arbitrary shell programs: an assignment at the start of a command, after
-// a declaration builtin, or an unset naming PATH. Command arguments such as
-// env PATH=value do not assign the shell variable and are not mutations.
-// The scan is deliberately over-eager on anything that reads as an
-// assignment, so a missed mutation cannot pass as a parse subtlety.
+// runtimePathMutation reports direct shell mutations of PATH: an assignment at
+// the start of a command, after a declaration builtin, or an unset naming PATH.
+// A command argument such as env PATH=value assigns no shell variable. The scan
+// is over-eager, so a missed mutation cannot pass as a parse subtlety.
 var runtimePathMutationPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?m)(^|[;&|(){}]|\b(then|else|elif|do|export|declare|local|typeset|readonly)\b)[ \t]*PATH=`),
 	regexp.MustCompile(`(?m)\bunset\b[^;&|\n]*\bPATH\b`),
 }
 
 func runtimePathMutation(body string) bool {
-	// Comments first, then continuations: joining a comment into the next
-	// physical line would hide the assignment that follows it.
+	// Comments first: joining one into the next line hides what follows it.
 	var code strings.Builder
 	for _, line := range strings.Split(body, "\n") {
 		if strings.HasPrefix(strings.TrimLeft(line, " \t"), "#") {
@@ -104,10 +95,9 @@ func TestRuntimePathMutationSourceClassification(t *testing.T) {
 			t.Errorf("non-mutation rejected: %s", body)
 		}
 	}
-	// Deliberately over-eager, recorded so it stays a reviewed property. A #
-	// inside a quoted word is not a comment, so a scan that stripped from the
-	// first # would delete the assignment behind it: a false report costs one
-	// edit, a missed mutation costs the runtime PATH.
+	// Over-eager by design, recorded so it stays a reviewed property: a # inside
+	// a quoted word is not a comment, and a scan that stripped from the first #
+	// would delete the assignment behind it.
 	for _, body := range []string{"true # export PATH=/tmp", "printf 'then PATH=/tmp'"} {
 		if !runtimePathMutation(body) {
 			t.Errorf("over-eager classification changed: %s", body)

--- a/internal/workcellhardening/runtime_path_test.go
+++ b/internal/workcellhardening/runtime_path_test.go
@@ -91,4 +91,17 @@ func TestRuntimePathMutationSourceClassification(t *testing.T) {
 			t.Errorf("non-mutation rejected: %s", body)
 		}
 	}
+	// Deliberate over-eagerness, recorded so it is a reviewed property rather
+	// than a surprise. An inline comment or a quoted payload that reads as an
+	// assignment is reported. Resolving either one needs the scan to decide
+	// where a # or a quote begins, and a # inside a quoted word is not a
+	// comment, so a scan that stripped from the first # would delete the
+	// assignment behind it. These five scripts are maintainer-owned, so the
+	// cost of a report is one edit, and the cost of a missed mutation is a
+	// hijacked runtime PATH.
+	for _, body := range []string{"true # export PATH=/tmp", "printf 'then PATH=/tmp'"} {
+		if !runtimePathMutation(body) {
+			t.Errorf("over-eager classification changed: %s", body)
+		}
+	}
 }

--- a/internal/workcellhardening/runtime_path_test.go
+++ b/internal/workcellhardening/runtime_path_test.go
@@ -13,12 +13,10 @@ import (
 
 const runtimePathPin = "readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\nexport PATH\n"
 
-// Privileged mode keeps the script's own shell from reading BASH_ENV and ENV,
-// but leaves them exported for the plain-bash children these scripts start.
-// The prologue must clear them, which is what the replaced shebang did.
+// -p stops only this shell from reading BASH_ENV and ENV, so the prologue must
+// clear them for the plain-bash children, as the replaced shebang did.
 const runtimeStartupPin = "#!/bin/bash -p\n" +
-	"# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.\n" +
-	"# The plain-bash children below would still read them, so clear them here.\n" +
+	"# -p hides these from this shell only; its plain-bash children still read them.\n" +
 	"unset BASH_ENV ENV\n"
 
 func TestRuntimePathPrologues(t *testing.T) {
@@ -99,14 +97,10 @@ func TestRuntimePathMutationSourceClassification(t *testing.T) {
 			t.Errorf("non-mutation rejected: %s", body)
 		}
 	}
-	// Deliberate over-eagerness, recorded so it is a reviewed property rather
-	// than a surprise. An inline comment or a quoted payload that reads as an
-	// assignment is reported. Resolving either one needs the scan to decide
-	// where a # or a quote begins, and a # inside a quoted word is not a
-	// comment, so a scan that stripped from the first # would delete the
-	// assignment behind it. These five scripts are maintainer-owned, so the
-	// cost of a report is one edit, and the cost of a missed mutation is a
-	// hijacked runtime PATH.
+	// Deliberately over-eager, recorded so it stays a reviewed property. A #
+	// inside a quoted word is not a comment, so a scan that stripped from the
+	// first # would delete the assignment behind it: a false report costs one
+	// edit, a missed mutation costs the runtime PATH.
 	for _, body := range []string{"true # export PATH=/tmp", "printf 'then PATH=/tmp'"} {
 		if !runtimePathMutation(body) {
 			t.Errorf("over-eager classification changed: %s", body)

--- a/policy/hardening-profile.toml
+++ b/policy/hardening-profile.toml
@@ -158,6 +158,7 @@ required = [
   "docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443",
   "github.com:443", "objects.githubusercontent.com:443",
   "release-assets.githubusercontent.com:443", "registry.npmjs.org:443",
+  "dl.google.com:443", "proxy.golang.org:443", "sum.golang.org:443",
   "storage.googleapis.com:443", "snapshot-cloudflare.debian.org:443",
   "snapshot.debian.org:443",
 ]

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -188,6 +188,45 @@ RUN mapfile -t debian_bootstrap_pins < /usr/local/share/workcell/debian-bootstra
       \( -path '/etc/hostname' -o -path '/etc/hosts' -o -path '/etc/resolv.conf' \) -prune -o \
       -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
 
+FROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS apt-broker-builder
+
+ARG GO_VERSION=1.27.1
+ARG GO_LINUX_X86_64_SHA256=63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445
+ARG GO_LINUX_ARM64_SHA256=3450b45a3f9ee8568792736a5c5e70a1f2e9b36c35a8f74958c03e51d7d92bec
+ARG BUILDARCH
+ARG TARGETARCH
+ARG SOURCE_DATE_EPOCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Node supplies TLS before the pinned Go toolchain is available.
+RUN case "${BUILDARCH}" in \
+      amd64) GO_SHA256="${GO_LINUX_X86_64_SHA256}" ;; \
+      arm64) GO_SHA256="${GO_LINUX_ARM64_SHA256}" ;; \
+      *) echo "Unsupported Go build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
+    esac \
+  && case "${TARGETARCH}" in amd64|arm64) ;; *) echo "Unsupported Go target architecture: ${TARGETARCH}" >&2; exit 1 ;; esac \
+  && node --dns-result-order=ipv4first -e 'const { createWriteStream } = require("node:fs"); const { Readable } = require("node:stream"); const { pipeline } = require("node:stream/promises"); (async () => { const response = await fetch(process.argv[1]); if (!response.ok) throw new Error("Go download HTTP status " + response.status); await pipeline(Readable.fromWeb(response.body), createWriteStream("/tmp/go.tar.gz")); })().catch((error) => { console.error(error.message); process.exit(1); });' "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz" \
+  && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/go.tar.gz -C /usr/local \
+  && rm -f /tmp/go.tar.gz
+
+COPY --from=runtime-base --chmod=0444 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENV GOTOOLCHAIN=local
+ENV GOPROXY=https://proxy.golang.org
+ENV GOSUMDB=sum.golang.org
+ENV CGO_ENABLED=0
+
+WORKDIR /workcell-go
+COPY --chmod=0444 go.mod go.sum ./
+COPY --chmod=0555 internal/aptbroker ./internal/aptbroker
+COPY --chmod=0555 cmd/workcell-apt-broker-client ./cmd/workcell-apt-broker-client
+COPY --chmod=0555 cmd/workcell-apt-broker-server ./cmd/workcell-apt-broker-server
+
+RUN GOOS=linux GOARCH="${TARGETARCH}" /usr/local/go/bin/go build -mod=readonly -trimpath -buildvcs=false -ldflags='-buildid=' -o /out/ ./cmd/workcell-apt-broker-client ./cmd/workcell-apt-broker-server \
+  && touch -d "@${SOURCE_DATE_EPOCH}" /out/workcell-apt-broker-client /out/workcell-apt-broker-server
+
 FROM runtime-base AS provider-builder
 
 ARG SOURCE_DATE_EPOCH
@@ -483,7 +522,10 @@ RUN export \
   # and survives the layer compression that a symlink would not.
   && ln /usr/local/libexec/workcell/core/launcher /usr/local/libexec/workcell/core/git \
   && printf '/usr/local/lib/libworkcell_exec_guard.so\n' > /etc/ld.so.preload \
+  && export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so \
   && rm -rf /tmp/workcell-rust-target /workcell-rust
+
+ENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
 
 # Copy adapters and control-plane scripts AFTER cargo build so that changes to
 # these frequently-modified files do not invalidate the Rust compilation cache.
@@ -560,6 +602,8 @@ COPY --from=runtime-builder /usr/local/lib/libworkcell_exec_guard.so /usr/local/
 COPY --from=runtime-builder /usr/local/libexec/workcell /usr/local/libexec/workcell
 COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json
 
+ENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
+
 RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
   && chmod 0644 /usr/local/libexec/workcell/real/git \
   && mv /usr/local/bin/node /usr/local/libexec/workcell/real/node \
@@ -613,11 +657,12 @@ RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
       /usr/bin/sudo \
       -print0 | LC_ALL=C sort -z | xargs -0 touch -h -d "@${SOURCE_DATE_EPOCH}"
 
+COPY --from=apt-broker-builder --chown=0:0 --chmod=0555 /out/workcell-apt-broker-client /out/workcell-apt-broker-server /usr/local/libexec/workcell/
+
 WORKDIR /workspace
 
 ENV HOME=/state/agent-home
 ENV CODEX_HOME=/state/agent-home/.codex
-ENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
 ENV PATH=/usr/local/bin:/usr/bin:/bin
 
 # Defense-in-depth: default to the fixed unprivileged workcell UID/GID so that

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -2,7 +2,7 @@
   "host_artifacts": [
     {
       "repo_path": "scripts/workcell",
-      "sha256": "0be4e87ae344ebdeade6d02e3c33139f75feb6e2b2167d743bdbb7cb4dbab1bc"
+      "sha256": "5ab7eb1df7d3e4249771fb2e3e30947a2d755b9f8f918f34cc15323929811a64"
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
@@ -218,13 +218,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/development-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/development-wrapper.sh",
-      "sha256": "2e6c4c65b86a166f7a963e390e85e3d43d963d90a0bf5a73d0f8456a36641a4a"
+      "sha256": "274d315151d1d690de7a53de9b68983a5d7972a5f69ffe4d46e991d7bd938b89"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/entrypoint.sh",
       "runtime_path": "/usr/local/libexec/workcell/entrypoint.sh",
-      "sha256": "49a33dc4b43c0d87090c2dcc0be78ffe8d9af14cd7832e7ad72c19c69dd386ef"
+      "sha256": "1960df04c34276d32b5b50549f63692c70d883570e193533bb82b69e0af86106"
     },
     {
       "kind": "runtime-control-plane",
@@ -236,7 +236,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "f699292966cf737b9700008c090750319b23ab7dac617a4e236e82f2952e2b35"
+      "sha256": "b0fedb560b519d65f38d04dac940277c606238cc4efd2c94b1b96ca9362efb38"
     },
     {
       "kind": "runtime-control-plane",
@@ -254,7 +254,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "fdf553db0f799ec09d9e4e02a359f5f97bada6e3b0d18a94e9d191ecc6a3392b"
+      "sha256": "29bdabf0859cb1fe5a31050905f6214497bf9d2d94a48a1d52c55231138c637e"
     },
     {
       "kind": "runtime-control-plane",
@@ -266,7 +266,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/runtime-user.sh",
       "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
-      "sha256": "b9a4bd99fd90f322f4f07dab9dae43b2f2787a27ad6dc65e11c2818e4c28193e"
+      "sha256": "36d2cd77ea2a6b51c044682dd51e86152ae7e8e1d8cc7312cc5de5cef7a093f3"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -p
-# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
-# The plain-bash children below would still read them, so clear them here.
+# -p hides these from this shell only; its plain-bash children still read them.
 unset BASH_ENV ENV
 readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
+# The plain-bash children below would still read them, so clear them here.
+unset BASH_ENV ENV
 readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH
 set -euo pipefail

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -1,8 +1,9 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
+readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-${WORKCELL_LAUNCH_TARGET:-}}"
-TRUSTED_PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 export WORKCELL_WRAPPER_CONTEXT=1
 export ADAPTER_ROOT="/opt/workcell/adapters"
 
@@ -89,7 +90,6 @@ sanitize_development_env() {
   unset OTEL_LOGS_EXPORTER
   workcell_sanitize_git_runtime_env
   export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
-  export PATH="${TRUSTED_PATH}"
 }
 
 # shellcheck source=runtime/container/assurance.sh

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
+readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-}"

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -p
-# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
-# The plain-bash children below would still read them, so clear them here.
+# -p hides these from this shell only; its plain-bash children still read them.
 unset BASH_ENV ENV
 readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
+# The plain-bash children below would still read them, so clear them here.
+unset BASH_ENV ENV
 readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH
 set -euo pipefail

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1,4 +1,9 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
+if [[ "${PATH}" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then
+  PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+fi
+readonly PATH
+export PATH
 
 # shellcheck source=runtime/container/assurance.sh
 source /usr/local/libexec/workcell/assurance.sh

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
+# The plain-bash children below would still read them, so clear them here.
+unset BASH_ENV ENV
 if [[ "${PATH}" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then
   PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 fi

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -p
-# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
-# The plain-bash children below would still read them, so clear them here.
+# -p hides these from this shell only; its plain-bash children still read them.
 unset BASH_ENV ENV
 if [[ "${PATH}" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then
   PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -1,8 +1,9 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
+readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
 set -euo pipefail
 
 AGENT_NAME="${WORKCELL_LAUNCH_TARGET:-${0##*/}}"
-TRUSTED_PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 WORKCELL_COPILOT_TOKEN_HANDOFF_CONTAINER_DIR="${WORKCELL_COPILOT_TOKEN_HANDOFF_CONTAINER_DIR:-/opt/workcell/copilot-token-handoff}"
 copilot_token_handoff_consumed_file="${WORKCELL_COPILOT_TOKEN_HANDOFF_CONTAINER_DIR}/copilot-token-consumed"
 WORKCELL_COPILOT_AUTH_REQUIRED=""
@@ -93,7 +94,6 @@ sanitize_provider_env() {
   workcell_sanitize_git_runtime_env
   export NODE_NO_WARNINGS=1
   export LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
-  export PATH="${TRUSTED_PATH}"
 }
 
 workcell_provider_parent_is_launcher() {

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -p
-# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
-# The plain-bash children below would still read them, so clear them here.
+# -p hides these from this shell only; its plain-bash children still read them.
 unset BASH_ENV ENV
 readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
+# The plain-bash children below would still read them, so clear them here.
+unset BASH_ENV ENV
 readonly PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 export PATH
 set -euo pipefail

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -1,4 +1,9 @@
-#!/usr/bin/env -S BASH_ENV= ENV= bash
+#!/bin/bash -p
+if [[ "${PATH}" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then
+  PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+fi
+readonly PATH
+export PATH
 
 # shellcheck source=runtime/container/assurance.sh
 source /usr/local/libexec/workcell/assurance.sh

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
+# The plain-bash children below would still read them, so clear them here.
+unset BASH_ENV ENV
 if [[ "${PATH}" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then
   PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 fi

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -p
-# -p keeps this shell from reading BASH_ENV/ENV, but leaves them exported.
-# The plain-bash children below would still read them, so clear them here.
+# -p hides these from this shell only; its plain-bash children still read them.
 unset BASH_ENV ENV
 if [[ "${PATH}" != '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' ]]; then
   PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -503,6 +503,9 @@ current_debian_ca_sha256="$(jq -er '.ca_certificates_sha256' <<<"${current_debia
 current_go_toolchain="$(awk '/^toolchain / { sub(/^toolchain go/, "", $0); print; exit }' "${GO_MOD_PATH}")"
 current_go_language="$(awk '/^go / { print $2; exit }' "${GO_MOD_PATH}")"
 current_validator_go_version="$(extract_dockerfile_arg "${VALIDATOR_DOCKERFILE_PATH}" GO_VERSION)"
+current_runtime_go_version="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" GO_VERSION)"
+current_runtime_go_sha_amd64="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" GO_LINUX_X86_64_SHA256)"
+current_runtime_go_sha_arm64="$(extract_dockerfile_arg "${RUNTIME_DOCKERFILE_PATH}" GO_LINUX_ARM64_SHA256)"
 current_go_sha_amd64="$(extract_dockerfile_arg "${VALIDATOR_DOCKERFILE_PATH}" GO_LINUX_X86_64_SHA256)"
 current_go_sha_arm64="$(extract_dockerfile_arg "${VALIDATOR_DOCKERFILE_PATH}" GO_LINUX_ARM64_SHA256)"
 current_deadcode_version="$(extract_dockerfile_arg "${VALIDATOR_DOCKERFILE_PATH}" DEADCODE_VERSION)"
@@ -627,6 +630,9 @@ for current_target_pair in \
   "${current_go_toolchain}|${target_go_toolchain}" \
   "${current_go_language}|${target_go_language}" \
   "${current_validator_go_version}|${target_go_toolchain}" \
+  "${current_runtime_go_version}|${target_go_toolchain}" \
+  "${current_runtime_go_sha_amd64}|${target_go_sha_amd64}" \
+  "${current_runtime_go_sha_arm64}|${target_go_sha_arm64}" \
   "${current_go_sha_amd64}|${target_go_sha_amd64}" \
   "${current_go_sha_arm64}|${target_go_sha_arm64}" \
   "${current_deadcode_version}|${target_deadcode_version}" \
@@ -695,6 +701,9 @@ print_summary() {
   print_summary_line "debian-ca-certificates-sha256" "${current_debian_ca_sha256}" "${target_debian_ca_sha256}"
   print_summary_line "go-toolchain" "${current_go_toolchain}" "${target_go_toolchain}"
   print_summary_line "go-language" "${current_go_language}" "${target_go_language}"
+  print_summary_line "runtime-go" "${current_runtime_go_version}" "${target_go_toolchain}"
+  print_summary_line "runtime-go-amd64-sha256" "${current_runtime_go_sha_amd64}" "${target_go_sha_amd64}"
+  print_summary_line "runtime-go-arm64-sha256" "${current_runtime_go_sha_arm64}" "${target_go_sha_arm64}"
   print_summary_line "deadcode-validator" "${current_deadcode_version}" "${target_deadcode_version}"
   print_summary_line "deadcode-script" "${current_deadcode_script_version}" "${target_deadcode_version}"
   print_summary_line "rust-toolchain" "${current_rust_version}" "${target_rust_version}"
@@ -743,6 +752,9 @@ if [[ "${debian_has_changes}" -eq 1 ]]; then
 fi
 
 replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG NODE_BASE_IMAGE=' "ARG NODE_BASE_IMAGE=${target_runtime_base}"
+replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG GO_VERSION=' "ARG GO_VERSION=${target_go_toolchain}"
+replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG GO_LINUX_X86_64_SHA256=' "ARG GO_LINUX_X86_64_SHA256=${target_go_sha_amd64}"
+replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG GO_LINUX_ARM64_SHA256=' "ARG GO_LINUX_ARM64_SHA256=${target_go_sha_arm64}"
 replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG RUST_VERSION=' "ARG RUST_VERSION=${target_rust_version}"
 replace_line_with_prefix "${RUNTIME_DOCKERFILE_PATH}" 'ARG RUST_TOOLCHAIN_IMAGE=' "ARG RUST_TOOLCHAIN_IMAGE=${target_runtime_rust_toolchain_image}"
 

--- a/scripts/workcell
+++ b/scripts/workcell
@@ -8147,7 +8147,7 @@ prepare_workspace_control_plane_shadow() {
 }
 
 bootstrap_endpoints() {
-  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 production.cloudfront.docker.com:443 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 storage.googleapis.com:443 snapshot-cloudflare.debian.org:443 snapshot.debian.org:443"
+  echo "auth.docker.io:443 docker.io:443 index.docker.io:443 registry-1.docker.io:443 production.cloudflare.docker.com:443 production.cloudfront.docker.com:443 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443 github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 registry.npmjs.org:443 dl.google.com:443 proxy.golang.org:443 sum.golang.org:443 storage.googleapis.com:443 snapshot-cloudflare.debian.org:443 snapshot.debian.org:443"
 }
 
 # ephemeral_extra_endpoints emits the Debian snapshot hosts appended to the


### PR DESCRIPTION
Unit 5 of the #651 apt broker series. It follows #668 (protocol and client
library), #674 (privileged helper runner), #677 (socket server and SO_PEERCRED
admission), and #679 (client and server command binaries).

This unit builds the two binaries into the runtime image. Nothing invokes them:
the shell broker at `runtime/container/apt-broker.sh` stays live, `sudo-wrapper.sh`
still talks to it, and the runtime wiring is unit 6's work. The binaries land in
the image inert so that the switch in unit 6 is a wiring change with no build risk
attached.

## Builder stage

`apt-broker-builder` is a cross-build stage on the pinned Node base image. Node
supplies TLS before a Go toolchain exists, so the toolchain tarball is fetched
with `node --dns-result-order=ipv4first` and checked against a per-architecture
`ARG` digest before it is unpacked. Both the build and target architectures are
rejected unless they are `amd64` or `arm64`. The build runs with `GOTOOLCHAIN=local`,
`CGO_ENABLED=0`, `-mod=readonly`, `-trimpath`, `-buildvcs=false` and `-ldflags='-buildid='`,
and the outputs are stamped to `SOURCE_DATE_EPOCH`.

The runtime install is one `COPY --from=apt-broker-builder --chown=0:0 --chmod=0555`
placed immediately before `WORKDIR /workspace`, so the binaries are the last thing
written into the image and nothing afterwards can alter them.

## Build context and inputs

`.dockerignore` opens exactly `go.mod`, `go.sum`, `internal/aptbroker/`, and the two
command directories, and `GenerateBuildInputManifest` walks the same set. Broker
source is now a build input of the runtime image, so a source change invalidates it
rather than silently reusing a stale layer.

## Pinned-input validation

`validateAptBrokerBuildInputs` treats the builder stage as a canonical fragment
rather than a set of loose greps: the stage is extracted between its own `FROM`
and the next one, the three Go `ARG` values are required to match the validator
image, and the stage is then compared against the reviewed template rendered with
those pins. The stage alias must appear exactly once. `.dockerignore` is compared
whole, because a later ignore rule can undo an earlier inclusion. The runtime install
is checked for its exact boundary and for the absence of any `RUN`/`COPY`/`ADD`/`WORKDIR`
after it.

`scripts/update-upstream-pins.sh` now reads and rewrites the runtime Go pins alongside
the validator ones, so the two cannot drift apart, and the fixture check covers the
three new summary lines.

## Exec guard preload

The guard was previously activated by writing `/etc/ld.so.preload` in the builder and
by an `ENV` on the final stage, which left the rest of each build running without it.
It is now exported inside the builder `RUN` and set as an `ENV` at the top of both
stages, so every later child command in the build inherits it. The check requires
exactly the three canonical assignments and their surrounding fragments.

## Runtime PATH prologues

`entrypoint.sh`, `provider-wrapper.sh`, `development-wrapper.sh`, `home-control-plane.sh`
and `runtime-user.sh` set a fixed trusted PATH in their prologue instead of assigning
one partway through, and `#!/bin/bash -p` keeps `BASH_ENV`/`ENV` unprocessed. The two
sourced libraries assign only when the value differs, so sourcing one twice does not
fail on the readonly. A check requires the ordered prologue and refuses any direct
PATH mutation after it. Its classifier is deliberately over-eager on anything that
reads as an assignment, and it is exercised against both mutations and lookalikes
(`env PATH=... tool`, `MYPATH=`, comments, line continuations) so a miss cannot pass
as a parse subtlety.

## Round-trip test flake

`TestServeRoundTripPreservesHelperResult` waited for the broker by polling for the
socket file. That is not a readiness signal: the pathname is visible in the window
between `bind(2)` and `listen(2)`, and a dial in that window is refused. The test
also gave one 5s context to both the broker lifetime and the client exchange.

Readiness now comes from `ServerConfig.Ready`, which `Serve` calls only after the
socket is bound, listening, chmodded and validated. The broker context is
cancel-only and the exchange carries its own deadline, so a slow exchange cannot
close the listener under itself.

Reproduced and verified in a CPU-starved Linux container (`--cpus=0.5`, 24 spinners,
uid 4242, `go test -run TestServeRoundTrip -count=30`):

- Before: `dial unix .../broker.sock: connect: connection refused` at 0.29s — well
  inside the old 5s budget, which confirms the deadline was not the cause.
- After: repeated clean runs under the same load.

The uid 0 skip is kept and now states its reason: `ServerConfig` rejects peer uid 0,
so a root process is never an admissible peer for its own broker and the round trip
has no uid to dial from.

## Validation

- `go build ./...`, `GOOS=linux go build ./...`, `go vet ./...` clean
- `go test ./internal/aptbroker/... ./internal/metadatautil/ ./internal/workcellhardening/ ./internal/testkit/ -count=1` passes
- `scripts/dev-quick-check.sh` passes (full Go suite, shellcheck, shfmt, Rust)
- `scripts/verify-control-plane-manifest.sh` and `scripts/verify-build-input-manifest.sh` pass; the manifest was regenerated for the prologue changes
- `scripts/lint-dockerfiles.sh` (hadolint) passes
- `scripts/check-pinned-inputs.sh`, `check-dead-code.sh`, `check-public-repo-hygiene.sh`, `check-public-contract.sh` all exit 0
- PR shape: files=23 lines=1092 areas=5 binary_files=0

## Next

Unit 6 retires the shell broker and moves the runtime onto these binaries.
