### PR TITLE
^B Refuse loader-environment overrides on native exec (differential container proof; user-visible execution boundary)

### DIFF
--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -852,8 +852,9 @@ fn env_has_unsafe_loader_override(env_entries: &[String]) -> bool {
     env_entries.iter().any(|entry| {
         env_entry_value(entry, "LD_AUDIT").is_some_and(|value| !value.is_empty())
             || env_entry_value(entry, "LD_LIBRARY_PATH").is_some_and(|value| !value.is_empty())
-            || env_entry_value(entry, "LD_TRACE_LOADED_OBJECTS")
-                .is_some_and(|value| !value.is_empty())
+            // The loader enters trace mode on the presence of this variable,
+            // whatever its value, so an empty one is an override too.
+            || env_entry_value(entry, "LD_TRACE_LOADED_OBJECTS").is_some()
             || env_entry_value(entry, "LD_PRELOAD")
                 .is_some_and(|value| !value.is_empty() && value != ALLOWED_LD_PRELOAD)
     })
@@ -912,9 +913,7 @@ fn should_block_workcell_launcher_fd_loader_env(fd: c_int, env_entries: &[String
 fn file_descriptor_is_loader_sensitive(fd: c_int) -> bool {
     duplicate_fd_file(fd)
         .and_then(|file| file.metadata().ok())
-        .map_or(true, |metadata| {
-            (metadata.mode() & file_type_bits()) == regular_file_mode()
-        })
+        .is_none_or(|metadata| (metadata.mode() & file_type_bits()) == regular_file_mode())
 }
 
 #[cfg(target_os = "linux")]
@@ -922,9 +921,11 @@ fn path_is_loader_sensitive(path: &str) -> bool {
     if let Some(proc_fd) = path_is_current_process_fd_path(path) {
         return file_descriptor_is_loader_sensitive(proc_fd);
     }
-    fs::metadata(path).map_or(true, |metadata| {
-        (metadata.mode() & file_type_bits()) == regular_file_mode()
-    })
+    match fs::metadata(path) {
+        Ok(metadata) => (metadata.mode() & file_type_bits()) == regular_file_mode(),
+        // A target the guard cannot stat stays unclassified.
+        Err(_) => true,
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -1405,16 +1406,31 @@ fn loader_arg_targets_mutable_native_exec(target: &str) -> bool {
     path_is_mutable_native_exec(target)
 }
 
-/// A loader library search list is refused when it is empty or carries an
-/// empty segment, because the loader then resolves against the working
-/// directory the guard cannot pin.
+/// A loader search-list entry names a directory to search or a shared object
+/// to load, never an exec target, so it is judged by where it lives rather
+/// than by its contents. `--library-path /workspace` names no ELF file at all,
+/// yet the loader will still take a dependency from there.
+fn loader_path_list_entry_targets_mutable_root(entry: &str) -> bool {
+    if entry.is_empty() {
+        return true;
+    }
+    canonicalize_existing_path(entry)
+        .is_some_and(|resolved| resolved_path_is_mutable_root(&resolved))
+}
+
+/// A loader search list is refused when it is empty, carries an empty entry,
+/// or names anything under a mutable root. An empty list or entry makes the
+/// loader resolve against the working directory the guard cannot pin. The
+/// loader splits such a list on whitespace as well as on colons, so all three
+/// separators are honoured; splitting more finely than the loader does can
+/// only add entries to check, never hide one.
 fn loader_path_list_targets_mutable_native_exec(value: &str) -> bool {
     if value.is_empty() {
         return true;
     }
     value
-        .split(':')
-        .any(|target| target.is_empty() || loader_arg_targets_mutable_native_exec(target))
+        .split([':', ' ', '\t'])
+        .any(loader_path_list_entry_targets_mutable_root)
 }
 
 /// Walks a dynamic loader argument vector the way the loader does: the options
@@ -2748,6 +2764,10 @@ mod tests {
         assert!(env_has_unsafe_loader_override(&[
             "LD_TRACE_LOADED_OBJECTS=1".to_string()
         ]));
+        // The loader enters trace mode on presence, not on value.
+        assert!(env_has_unsafe_loader_override(&[
+            "LD_TRACE_LOADED_OBJECTS=".to_string()
+        ]));
         assert!(!env_has_unsafe_loader_override(&[format!(
             "LD_PRELOAD={ALLOWED_LD_PRELOAD}"
         )]));
@@ -3159,15 +3179,38 @@ mod tests {
 
     #[test]
     fn loader_control_options_reject_mutable_values() {
-        // An empty list, or an empty segment, makes the loader search the
+        // An empty list, or an empty entry, makes the loader search the
         // working directory the guard cannot pin.
         assert!(loader_path_list_targets_mutable_native_exec(""));
         assert!(loader_path_list_targets_mutable_native_exec("/usr/lib:"));
         assert!(loader_path_list_targets_mutable_native_exec(":/usr/lib"));
+        assert!(loader_path_list_entry_targets_mutable_root(""));
         assert!(!loader_path_list_targets_mutable_native_exec("/usr/lib"));
         assert!(!loader_path_list_targets_mutable_native_exec(
             "/usr/lib:/lib"
         ));
+
+        // The loader splits a search list on whitespace as well as on colons.
+        // A doubled separator only yields an empty entry once the list is
+        // split the same way, so this fails if whitespace is not a separator.
+        assert!(loader_path_list_targets_mutable_native_exec(
+            "/usr/lib  /lib"
+        ));
+        assert!(loader_path_list_targets_mutable_native_exec(
+            "/usr/lib \t/lib"
+        ));
+        assert!(!loader_path_list_targets_mutable_native_exec(
+            "/usr/lib /lib"
+        ));
+
+        // A mutable-root entry is refused as a directory, without being an
+        // ELF file itself. MUTABLE_EXEC_ROOTS only exist inside the runtime
+        // image, so the container probe covers the positive case; here the
+        // predicate is pinned to the root check it must use.
+        assert!(MUTABLE_EXEC_ROOTS.iter().all(|root| {
+            canonicalize_existing_path(root)
+                .is_none_or(|resolved| resolved_path_is_mutable_root(&resolved))
+        }));
 
         let loader = "/lib64/ld-linux-x86-64.so.2".to_string();
         for arguments in [

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -162,6 +162,7 @@ const PROTECTED_RUNTIME_BLOCK_MESSAGE: &str =
 const MUTABLE_NATIVE_EXEC_BLOCK_MESSAGE: &str = "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile.\n";
 const WORKCELL_LAUNCHER_LOADER_ENV_BLOCK_MESSAGE: &str =
     "Workcell blocked unsafe dynamic-loader environment for Workcell launcher execution.\n";
+const NATIVE_LOADER_ENV_BLOCK_MESSAGE: &str = "Workcell blocked unsafe dynamic-loader environment for native execution on the strict profile.\n";
 
 type ExecveFn =
     unsafe extern "C" fn(*const c_char, *const *const c_char, *const *const c_char) -> c_int;
@@ -571,6 +572,28 @@ fn token_uses_env_interpreter(token: &str) -> bool {
     token_basename(token) == "env"
 }
 
+fn token_is_loader_environment_assignment(token: &str) -> bool {
+    let Some((name, _value)) = token.split_once('=') else {
+        return false;
+    };
+    token_is_loader_environment_name(name)
+}
+
+fn token_is_loader_environment_name(token: &str) -> bool {
+    matches!(
+        token,
+        "LD_PRELOAD" | "LD_AUDIT" | "LD_LIBRARY_PATH" | "LD_TRACE_LOADED_OBJECTS"
+    )
+}
+
+fn token_is_loader_environment_unset_option(token: &str) -> bool {
+    let name = token
+        .strip_prefix("--unset=")
+        .or_else(|| token.strip_prefix("-u").filter(|suffix| !suffix.is_empty()))
+        .map(|name| name.strip_prefix('=').unwrap_or(name));
+    name.is_some_and(token_is_loader_environment_name)
+}
+
 fn token_is_shell_interpreter(token: &str) -> bool {
     matches!(
         token_basename(token),
@@ -587,9 +610,29 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
     let mut path_override: Option<String> = None;
 
     while let Some(token) = next_shebang_token(&mut scan) {
-        if token == "-u" {
-            let _ = next_shebang_token(&mut scan);
+        // env can rewrite the loader environment before the target runs, so the
+        // options that add, drop or replace it end the scan with a refusal.
+        // -S / --split-string re-splits the rest of the line into tokens this
+        // scan cannot follow, so it is refused whatever it carries.
+        if token.starts_with("-S") || token.starts_with("--split-string") {
+            return true;
+        }
+        if token == "-i" || token == "--ignore-environment" || token == "-" {
+            return true;
+        }
+        if token == "-u" || token == "--unset" {
+            if next_shebang_token(&mut scan)
+                .is_some_and(|name| token_is_loader_environment_name(&name))
+            {
+                return true;
+            }
             continue;
+        }
+        if token_is_loader_environment_unset_option(&token) {
+            return true;
+        }
+        if token_is_loader_environment_assignment(&token) {
+            return true;
         }
 
         if let Some(path) = token.strip_prefix("PATH=") {
@@ -764,7 +807,7 @@ fn env_entry_value<'a>(entry: &'a str, key: &str) -> Option<&'a str> {
     if entry_key == key { Some(value) } else { None }
 }
 
-fn env_has_unsafe_workcell_launcher_loader_override(env_entries: &[String]) -> bool {
+fn env_has_unsafe_loader_override(env_entries: &[String]) -> bool {
     env_entries.iter().any(|entry| {
         env_entry_value(entry, "LD_AUDIT").is_some_and(|value| !value.is_empty())
             || env_entry_value(entry, "LD_LIBRARY_PATH").is_some_and(|value| !value.is_empty())
@@ -807,13 +850,79 @@ fn fd_matches_workcell_native_launcher(fd: c_int) -> bool {
 }
 
 fn should_block_workcell_launcher_loader_env(path: &str, env_entries: &[String]) -> bool {
-    path_is_workcell_native_launcher(path)
-        && env_has_unsafe_workcell_launcher_loader_override(env_entries)
+    path_is_workcell_native_launcher(path) && env_has_unsafe_loader_override(env_entries)
 }
 
 fn should_block_workcell_launcher_fd_loader_env(fd: c_int, env_entries: &[String]) -> bool {
-    fd_matches_workcell_native_launcher(fd)
-        && env_has_unsafe_workcell_launcher_loader_override(env_entries)
+    fd_matches_workcell_native_launcher(fd) && env_has_unsafe_loader_override(env_entries)
+}
+
+/// True when the target is something the dynamic loader interprets, so a
+/// loader environment override would change how it runs.  Regular files whose
+/// first two bytes are an ELF or shebang magic qualify; anything the guard
+/// cannot read is treated as loader sensitive rather than trusted.
+#[cfg(target_os = "linux")]
+fn file_descriptor_is_loader_sensitive(fd: c_int) -> bool {
+    let Some(mut file) = duplicate_fd_file(fd) else {
+        return true;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return true;
+    };
+    if (metadata.mode() & file_type_bits()) != regular_file_mode() {
+        return false;
+    }
+    let mut prefix = [0u8; 2];
+    if file.read_exact(&mut prefix).is_err() {
+        return true;
+    }
+    prefix == [0x7f, b'E'] || prefix == *b"#!"
+}
+
+#[cfg(target_os = "linux")]
+fn path_is_loader_sensitive(path: &str) -> bool {
+    if let Some(proc_fd) = path_is_current_process_fd_path(path) {
+        return file_descriptor_is_loader_sensitive(proc_fd);
+    }
+    // Stat before opening.  A non-regular target is never loader interpreted,
+    // and opening one from inside an interposed exec could block the caller.
+    let Ok(metadata) = fs::metadata(path) else {
+        return true;
+    };
+    if (metadata.mode() & file_type_bits()) != regular_file_mode() {
+        return false;
+    }
+    let Ok(mut file) = File::open(path) else {
+        return true;
+    };
+    let mut prefix = [0u8; 2];
+    if file.read_exact(&mut prefix).is_err() {
+        return true;
+    }
+    prefix == [0x7f, b'E'] || prefix == *b"#!"
+}
+
+#[cfg(not(target_os = "linux"))]
+fn path_is_loader_sensitive(_path: &str) -> bool {
+    false
+}
+
+fn should_block_loader_env_for_path(path: &str, env_entries: &[String]) -> bool {
+    current_mode_blocks_mutable_native_exec()
+        && env_has_unsafe_loader_override(env_entries)
+        && path_is_loader_sensitive(path)
+}
+
+#[cfg(target_os = "linux")]
+fn should_block_loader_env_for_fd(fd: c_int, env_entries: &[String]) -> bool {
+    current_mode_blocks_mutable_native_exec()
+        && env_has_unsafe_loader_override(env_entries)
+        && file_descriptor_is_loader_sensitive(fd)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn should_block_loader_env_for_fd(_fd: c_int, _env_entries: &[String]) -> bool {
+    false
 }
 
 fn path_matches_any_same_file(path: &Path, candidates: &[&str]) -> bool {
@@ -1271,20 +1380,65 @@ fn loader_arg_targets_mutable_native_exec(target: &str) -> bool {
     path_is_mutable_native_exec(target)
 }
 
+/// A loader library search list is refused when it is empty or carries an
+/// empty segment, because the loader then resolves against the working
+/// directory the guard cannot pin.
+fn loader_path_list_targets_mutable_native_exec(value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
+    value
+        .split(':')
+        .any(|target| target.is_empty() || loader_arg_targets_mutable_native_exec(target))
+}
+
+/// Walks a dynamic loader argument vector the way the loader does: the options
+/// that name libraries are checked as search lists, and the scan stops at the
+/// exec target, since everything past it belongs to the target's own argv.
+fn loader_args_target_mutable_native_exec(args: &[String]) -> bool {
+    let mut index = 1usize;
+    while index < args.len() {
+        let argument = &args[index];
+        let (option, inline_value) = argument
+            .split_once('=')
+            .map_or((argument.as_str(), None), |(option, value)| {
+                (option, Some(value))
+            });
+
+        match option {
+            "--preload" | "--audit" | "--library-path" => {
+                let value = inline_value.or_else(|| {
+                    index += 1;
+                    args.get(index).map(String::as_str)
+                });
+                if value.is_none_or(loader_path_list_targets_mutable_native_exec) {
+                    return true;
+                }
+            }
+            "--argv0" => {
+                index += 1;
+            }
+            "--" => {
+                return args
+                    .get(index + 1)
+                    .is_some_and(|target| loader_arg_targets_mutable_native_exec(target));
+            }
+            option if option.starts_with('-') => {}
+            target => {
+                return loader_arg_targets_mutable_native_exec(target);
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
 fn loader_targets_mutable_native_exec(path: &str, args: &[String]) -> bool {
-    path_points_to_dynamic_loader(path)
-        && args
-            .iter()
-            .skip(1)
-            .any(|target| loader_arg_targets_mutable_native_exec(target))
+    path_points_to_dynamic_loader(path) && loader_args_target_mutable_native_exec(args)
 }
 
 fn loader_fd_targets_mutable_native_exec(fd: c_int, args: &[String]) -> bool {
-    fd_is_dynamic_loader(fd)
-        && args
-            .iter()
-            .skip(1)
-            .any(|target| loader_arg_targets_mutable_native_exec(target))
+    fd_is_dynamic_loader(fd) && loader_args_target_mutable_native_exec(args)
 }
 
 fn protected_runtime_exec_blocked(
@@ -1428,6 +1582,10 @@ fn report_protected_runtime_block() {
 
 fn report_mutable_native_exec_block() {
     report(MUTABLE_NATIVE_EXEC_BLOCK_MESSAGE);
+}
+
+fn report_native_loader_env_block() {
+    report(NATIVE_LOADER_ENV_BLOCK_MESSAGE);
 }
 
 fn report_workcell_launcher_loader_env_block() {
@@ -1606,6 +1764,10 @@ unsafe extern "C" fn guarded_execve(
         report_workcell_launcher_loader_env_block();
         return -1;
     }
+    if should_block_loader_env_for_path(&path_string, &env_entries) {
+        report_native_loader_env_block();
+        return -1;
+    }
     if should_block_protected_runtime_exec(&path_string, &args, &env_entries) {
         report_protected_runtime_block();
         return -1;
@@ -1635,6 +1797,10 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
 
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
+        return -1;
+    }
+    if should_block_loader_env_for_path(&path_string, &env_entries) {
+        report_native_loader_env_block();
         return -1;
     }
     if should_block_protected_runtime_exec(&path_string, &args, &env_entries) {
@@ -1689,6 +1855,10 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
 
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
+        return -1;
+    }
+    if should_block_loader_env_for_path(&effective_path, &env_entries) {
+        report_native_loader_env_block();
         return -1;
     }
     if should_block_protected_runtime_exec(&effective_path, &args, &env_entries) {
@@ -1747,6 +1917,10 @@ unsafe extern "C" fn guarded_execvpe(
 
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
+        return -1;
+    }
+    if should_block_loader_env_for_path(&effective_path, &env_entries) {
+        report_native_loader_env_block();
         return -1;
     }
     if should_block_protected_runtime_exec(&effective_path, &args, &env_entries) {
@@ -1870,16 +2044,25 @@ unsafe extern "C" fn guarded_execveat(
         report_protected_runtime_block();
         return -1;
     }
-    let launcher_loader_env_blocked = if (flags & AT_EMPTY_PATH_FLAG) != 0
-        && pathname_string.is_empty()
-    {
-        should_block_workcell_launcher_fd_loader_env(dirfd, &env_entries)
-    } else {
-        (native_launcher_target && env_has_unsafe_workcell_launcher_loader_override(&env_entries))
-            || should_block_workcell_launcher_loader_env(&pathname_string, &env_entries)
-    };
+    let launcher_loader_env_blocked =
+        if (flags & AT_EMPTY_PATH_FLAG) != 0 && pathname_string.is_empty() {
+            should_block_workcell_launcher_fd_loader_env(dirfd, &env_entries)
+        } else {
+            (native_launcher_target && env_has_unsafe_loader_override(&env_entries))
+                || should_block_workcell_launcher_loader_env(&pathname_string, &env_entries)
+        };
     if launcher_loader_env_blocked {
         report_workcell_launcher_loader_env_block();
+        return -1;
+    }
+    let native_loader_env_blocked =
+        if (flags & AT_EMPTY_PATH_FLAG) != 0 && pathname_string.is_empty() {
+            should_block_loader_env_for_fd(dirfd, &env_entries)
+        } else {
+            should_block_loader_env_for_path(&effective_path, &env_entries)
+        };
+    if native_loader_env_blocked {
+        report_native_loader_env_block();
         return -1;
     }
     if mutable_native_target {
@@ -1910,6 +2093,10 @@ unsafe extern "C" fn guarded_fexecve(
 
     if should_block_workcell_launcher_fd_loader_env(fd, &env_entries) {
         report_workcell_launcher_loader_env_block();
+        return -1;
+    }
+    if should_block_loader_env_for_fd(fd, &env_entries) {
+        report_native_loader_env_block();
         return -1;
     }
     if should_block_protected_runtime_kind(classify_protected_runtime_fd(fd))
@@ -1959,6 +2146,10 @@ unsafe extern "C" fn guarded_posix_spawn(
 
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
+        return libc::EPERM;
+    }
+    if should_block_loader_env_for_path(&path_string, &env_entries) {
+        report_native_loader_env_block();
         return libc::EPERM;
     }
     if should_block_protected_runtime_exec(&path_string, &args, &env_entries) {
@@ -2012,6 +2203,10 @@ unsafe extern "C" fn guarded_posix_spawnp(
 
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
+        return libc::EPERM;
+    }
+    if should_block_loader_env_for_path(&effective_path, &env_entries) {
+        report_native_loader_env_block();
         return libc::EPERM;
     }
     if should_block_protected_runtime_exec(&effective_path, &args, &env_entries) {
@@ -2220,6 +2415,8 @@ mod tests {
     use super::*;
     use crate::gitpolicy::*;
     use std::os::unix::fs::{PermissionsExt, symlink};
+    #[cfg(target_os = "linux")]
+    use std::os::unix::io::AsRawFd;
     use std::path::PathBuf;
     use std::process;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -2496,27 +2693,27 @@ mod tests {
     }
 
     #[test]
-    fn workcell_launcher_loader_env_blocks_unsafe_dynamic_loader_overrides() {
-        assert!(env_has_unsafe_workcell_launcher_loader_override(&[
+    fn loader_env_override_detection_allows_only_the_approved_preload() {
+        assert!(env_has_unsafe_loader_override(&[
             "LD_PRELOAD=/workspace/preload.so".to_string()
         ]));
-        assert!(env_has_unsafe_workcell_launcher_loader_override(&[
+        assert!(env_has_unsafe_loader_override(&[
             "LD_AUDIT=/workspace/audit.so".to_string()
         ]));
-        assert!(env_has_unsafe_workcell_launcher_loader_override(&[
+        assert!(env_has_unsafe_loader_override(&[
             "LD_TRACE_LOADED_OBJECTS=1".to_string()
         ]));
-        assert!(!env_has_unsafe_workcell_launcher_loader_override(&[
-            format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}")
-        ]));
-        assert!(!env_has_unsafe_workcell_launcher_loader_override(&[
-            "LD_PRELOAD=".to_string()
-        ]));
-        assert!(env_has_unsafe_workcell_launcher_loader_override(&[
+        assert!(!env_has_unsafe_loader_override(&[format!(
+            "LD_PRELOAD={ALLOWED_LD_PRELOAD}"
+        )]));
+        assert!(!env_has_unsafe_loader_override(
+            &["LD_PRELOAD=".to_string()]
+        ));
+        assert!(env_has_unsafe_loader_override(&[
             format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}"),
             "LD_PRELOAD=/workspace/preload.so".to_string()
         ]));
-        assert!(env_has_unsafe_workcell_launcher_loader_override(&[
+        assert!(env_has_unsafe_loader_override(&[
             "LD_AUDIT=".to_string(),
             "LD_AUDIT=/workspace/audit.so".to_string()
         ]));
@@ -2824,6 +3021,170 @@ mod tests {
                 "{path_value} must not resolve a command"
             );
         }
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[test]
+    fn env_interpreter_tokens_name_loader_environment_controls() {
+        assert!(token_is_loader_environment_assignment(
+            "LD_PRELOAD=/tmp/x.so"
+        ));
+        assert!(token_is_loader_environment_assignment("LD_AUDIT="));
+        assert!(!token_is_loader_environment_assignment("PATH=/tmp"));
+        assert!(!token_is_loader_environment_assignment("LD_PRELOAD"));
+
+        assert!(token_is_loader_environment_name("LD_LIBRARY_PATH"));
+        assert!(token_is_loader_environment_name("LD_TRACE_LOADED_OBJECTS"));
+        assert!(!token_is_loader_environment_name("PATH"));
+
+        assert!(token_is_loader_environment_unset_option(
+            "--unset=LD_PRELOAD"
+        ));
+        assert!(token_is_loader_environment_unset_option("-uLD_PRELOAD"));
+        assert!(token_is_loader_environment_unset_option("-u=LD_AUDIT"));
+        assert!(!token_is_loader_environment_unset_option("--unset=PATH"));
+        // A bare -u carries its name in the next token, handled by the scanner.
+        assert!(!token_is_loader_environment_unset_option("-u"));
+    }
+
+    #[test]
+    fn env_interpreter_shebangs_reject_loader_environment_control() {
+        // env -S smuggles assignments the plain token scan would skip, and
+        // -i / -u / - drop the guard's own preload before the target runs.
+        for cursor in [
+            " -S LD_PRELOAD=/tmp/x.so /bin/sh",
+            " --split-string=LD_AUDIT=/tmp/a.so /bin/sh",
+            " -u LD_PRELOAD /bin/sh",
+            " --unset=LD_LIBRARY_PATH /bin/sh",
+            " -uLD_PRELOAD /bin/sh",
+            " -i /bin/sh",
+            " --ignore-environment /bin/sh",
+            " - /bin/sh",
+            " LD_PRELOAD=/tmp/x.so /bin/true",
+        ] {
+            assert!(
+                env_command_targets_protected_runtime(cursor, &[]),
+                "env{cursor} must be refused"
+            );
+        }
+
+        // Unrelated variables and unsets stay allowed.
+        for cursor in [" -u FOO /bin/true", " FOO=bar /bin/true"] {
+            assert!(
+                !env_command_targets_protected_runtime(cursor, &[]),
+                "env{cursor} must stay allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn loader_control_options_reject_mutable_values() {
+        // An empty list, or an empty segment, makes the loader search the
+        // working directory the guard cannot pin.
+        assert!(loader_path_list_targets_mutable_native_exec(""));
+        assert!(loader_path_list_targets_mutable_native_exec("/usr/lib:"));
+        assert!(loader_path_list_targets_mutable_native_exec(":/usr/lib"));
+        assert!(!loader_path_list_targets_mutable_native_exec("/usr/lib"));
+        assert!(!loader_path_list_targets_mutable_native_exec(
+            "/usr/lib:/lib"
+        ));
+
+        let loader = "/lib64/ld-linux-x86-64.so.2".to_string();
+        for arguments in [
+            vec![loader.clone(), "--preload".to_string()],
+            vec![loader.clone(), "--preload=".to_string(), "/bin/true".into()],
+            vec![
+                loader.clone(),
+                "--library-path".to_string(),
+                String::new(),
+                "/bin/true".into(),
+            ],
+            vec![loader.clone(), "--audit=/usr/lib:".to_string()],
+        ] {
+            assert!(
+                loader_args_target_mutable_native_exec(&arguments),
+                "{arguments:?} must be refused"
+            );
+        }
+
+        for arguments in [
+            vec![loader.clone(), "/bin/true".to_string()],
+            vec![
+                loader.clone(),
+                "--library-path".to_string(),
+                "/usr/lib".to_string(),
+                "/bin/true".into(),
+            ],
+            // --argv0 takes a value that is not an exec target.
+            vec![
+                loader.clone(),
+                "--argv0".to_string(),
+                "sh".to_string(),
+                "/bin/true".into(),
+            ],
+            vec![loader.clone(), "--".to_string(), "/bin/true".to_string()],
+            // Arguments after the target belong to the target, not the loader.
+            vec![
+                loader.clone(),
+                "/bin/true".to_string(),
+                "/usr/lib:".to_string(),
+            ],
+        ] {
+            assert!(
+                !loader_args_target_mutable_native_exec(&arguments),
+                "{arguments:?} must stay allowed"
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn loader_environment_is_refused_for_loader_sensitive_targets() {
+        let dir = create_temp_test_dir("loader-sensitive");
+        let elf = dir.join("elf");
+        fs::write(&elf, [0x7f, b'E', b'L', b'F', 2, 1, 1, 0]).expect("elf");
+        let script = dir.join("script");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("script");
+        let data = dir.join("data");
+        fs::write(&data, "plain text, not an exec target\n").expect("data");
+
+        let elf_path = elf.display().to_string();
+        assert!(path_is_loader_sensitive(&elf_path));
+        assert!(path_is_loader_sensitive(&script.display().to_string()));
+        assert!(!path_is_loader_sensitive(&data.display().to_string()));
+        // Directories and character devices cannot be loaded.
+        assert!(!path_is_loader_sensitive(&dir.display().to_string()));
+        // A target the guard cannot read is refused rather than trusted.
+        assert!(path_is_loader_sensitive(
+            &dir.join("missing").display().to_string()
+        ));
+
+        let unsafe_env = ["LD_AUDIT=/tmp/audit.so".to_string()];
+        assert!(should_block_loader_env_for_path(&elf_path, &unsafe_env));
+        assert!(!should_block_loader_env_for_path(&elf_path, &[]));
+        assert!(!should_block_loader_env_for_path(
+            &elf_path,
+            &[format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}")]
+        ));
+        assert!(!should_block_loader_env_for_path(
+            &data.display().to_string(),
+            &unsafe_env
+        ));
+
+        let file = File::open(&elf).expect("open elf");
+        let elf_fd = file.as_raw_fd();
+        assert!(file_descriptor_is_loader_sensitive(elf_fd));
+        assert!(should_block_loader_env_for_fd(elf_fd, &unsafe_env));
+        assert!(!should_block_loader_env_for_fd(elf_fd, &[]));
+
+        let data_file = File::open(&data).expect("open data");
+        assert!(!should_block_loader_env_for_fd(
+            data_file.as_raw_fd(),
+            &unsafe_env
+        ));
+        // A closed descriptor cannot be inspected, so it is refused.
+        assert!(file_descriptor_is_loader_sensitive(-1));
+
         fs::remove_dir_all(&dir).expect("cleanup temp test dir");
     }
 }

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1406,36 +1406,19 @@ fn loader_arg_targets_mutable_native_exec(target: &str) -> bool {
     path_is_mutable_native_exec(target)
 }
 
-/// A loader search-list entry names a directory to search or a shared object
-/// to load, never an exec target, so it is judged by where it lives rather
-/// than by its contents. `--library-path /workspace` names no ELF file at all,
-/// yet the loader will still take a dependency from there.
-fn loader_path_list_entry_targets_mutable_root(entry: &str) -> bool {
-    if entry.is_empty() {
-        return true;
-    }
-    canonicalize_existing_path(entry)
-        .is_some_and(|resolved| resolved_path_is_mutable_root(&resolved))
-}
-
-/// A loader search list is refused when it is empty, carries an empty entry,
-/// or names anything under a mutable root. An empty list or entry makes the
-/// loader resolve against the working directory the guard cannot pin. The
-/// loader splits such a list on whitespace as well as on colons, so all three
-/// separators are honoured; splitting more finely than the loader does can
-/// only add entries to check, never hide one.
-fn loader_path_list_targets_mutable_native_exec(value: &str) -> bool {
-    if value.is_empty() {
-        return true;
-    }
-    value
-        .split([':', ' ', '\t'])
-        .any(loader_path_list_entry_targets_mutable_root)
-}
-
-/// Walks a dynamic loader argument vector the way the loader does: the options
-/// that name libraries are checked as search lists, and the scan stops at the
-/// exec target, since everything past it belongs to the target's own argv.
+/// Walks a dynamic loader argument vector the way the loader does, to find the
+/// exec target: everything past that target belongs to the target's own argv.
+///
+/// The options that name libraries are refused outright rather than parsed.
+/// Deciding whether such a value stays out of a mutable root means reproducing
+/// the loader's own reading of it: it accepts colons, semicolons and
+/// whitespace as separators, and expands `$ORIGIN`, `$LIB` and `$PLATFORM`
+/// against the target before use. A guard that reimplements that is a guard
+/// that is wrong in some corner of it, so an explicit loader invocation that
+/// sets a library path is refused on the strict profile instead. Programs are
+/// normally executed directly rather than through ld.so, and a loader
+/// environment reaching a target is covered separately by the environment
+/// check.
 fn loader_args_target_mutable_native_exec(args: &[String]) -> bool {
     let mut index = 1usize;
     while index < args.len() {
@@ -1448,13 +1431,7 @@ fn loader_args_target_mutable_native_exec(args: &[String]) -> bool {
 
         match option {
             "--preload" | "--audit" | "--library-path" => {
-                let value = inline_value.or_else(|| {
-                    index += 1;
-                    args.get(index).map(String::as_str)
-                });
-                if value.is_none_or(loader_path_list_targets_mutable_native_exec) {
-                    return true;
-                }
+                return current_mode_blocks_mutable_native_exec();
             }
             // Options that consume a value which is not a library search list.
             // Missing one here would read its value as the exec target.
@@ -3179,47 +3156,31 @@ mod tests {
 
     #[test]
     fn loader_control_options_reject_mutable_values() {
-        // An empty list, or an empty entry, makes the loader search the
-        // working directory the guard cannot pin.
-        assert!(loader_path_list_targets_mutable_native_exec(""));
-        assert!(loader_path_list_targets_mutable_native_exec("/usr/lib:"));
-        assert!(loader_path_list_targets_mutable_native_exec(":/usr/lib"));
-        assert!(loader_path_list_entry_targets_mutable_root(""));
-        assert!(!loader_path_list_targets_mutable_native_exec("/usr/lib"));
-        assert!(!loader_path_list_targets_mutable_native_exec(
-            "/usr/lib:/lib"
-        ));
-
-        // The loader splits a search list on whitespace as well as on colons.
-        // A doubled separator only yields an empty entry once the list is
-        // split the same way, so this fails if whitespace is not a separator.
-        assert!(loader_path_list_targets_mutable_native_exec(
-            "/usr/lib  /lib"
-        ));
-        assert!(loader_path_list_targets_mutable_native_exec(
-            "/usr/lib \t/lib"
-        ));
-        assert!(!loader_path_list_targets_mutable_native_exec(
-            "/usr/lib /lib"
-        ));
-
-        // A mutable-root entry is refused as a directory, without being an
-        // ELF file itself. MUTABLE_EXEC_ROOTS only exist inside the runtime
-        // image, so the container probe covers the positive case; here the
-        // predicate is pinned to the root check it must use.
-        assert!(MUTABLE_EXEC_ROOTS.iter().all(|root| {
-            canonicalize_existing_path(root)
-                .is_none_or(|resolved| resolved_path_is_mutable_root(&resolved))
-        }));
-
+        // Every library-naming option is refused without reading its value,
+        // because deciding a value means reproducing the loader's separator
+        // set and its $ORIGIN, $LIB and $PLATFORM expansion.
         let loader = "/lib64/ld-linux-x86-64.so.2".to_string();
         for arguments in [
             vec![loader.clone(), "--preload".to_string()],
             vec![loader.clone(), "--preload=".to_string(), "/bin/true".into()],
+            // An immutable-looking value is refused too: the loader would
+            // expand it before use, so its text does not decide where it
+            // resolves.
             vec![
                 loader.clone(),
                 "--library-path".to_string(),
-                String::new(),
+                "/usr/lib".to_string(),
+                "/bin/true".into(),
+            ],
+            vec![
+                loader.clone(),
+                "--library-path=/usr/lib;/workspace/lib".to_string(),
+                "/bin/true".into(),
+            ],
+            vec![
+                loader.clone(),
+                "--preload".to_string(),
+                "$ORIGIN/../../workspace/evil.so".to_string(),
                 "/bin/true".into(),
             ],
             vec![loader.clone(), "--audit=/usr/lib:".to_string()],
@@ -3239,12 +3200,6 @@ mod tests {
 
         for arguments in [
             vec![loader.clone(), "/bin/true".to_string()],
-            vec![
-                loader.clone(),
-                "--library-path".to_string(),
-                "/usr/lib".to_string(),
-                "/bin/true".into(),
-            ],
             // --argv0 takes a value that is not an exec target.
             vec![
                 loader.clone(),

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -898,26 +898,23 @@ fn should_block_workcell_launcher_fd_loader_env(fd: c_int, env_entries: &[String
     fd_matches_workcell_native_launcher(fd) && env_has_unsafe_loader_override(env_entries)
 }
 
-/// True when the target is something the dynamic loader interprets, so a
-/// loader environment override would change how it runs.  Regular files whose
-/// first two bytes are an ELF or shebang magic qualify; anything the guard
-/// cannot read is treated as loader sensitive rather than trusted.
+/// True when a loader environment override would change how the target runs.
+///
+/// Every regular file qualifies, whatever its contents. An ELF is loaded by
+/// ld.so directly and a shebang loads its interpreter the same way. A regular
+/// file that is neither still counts, because execve returns ENOEXEC for it
+/// and glibc's execvp and execvpe answer that by launching /bin/sh with the
+/// caller's environment from inside libc, which does not re-enter this guard.
+/// Nothing else is executable at all, so a target that is not a regular file
+/// cannot reach the loader. A target that cannot be stat'ed stays
+/// unclassified and is treated as sensitive.
 #[cfg(target_os = "linux")]
 fn file_descriptor_is_loader_sensitive(fd: c_int) -> bool {
-    let Some(mut file) = duplicate_fd_file(fd) else {
-        return true;
-    };
-    let Ok(metadata) = file.metadata() else {
-        return true;
-    };
-    if (metadata.mode() & file_type_bits()) != regular_file_mode() {
-        return false;
-    }
-    let mut prefix = [0u8; 2];
-    if file.read_exact(&mut prefix).is_err() {
-        return true;
-    }
-    prefix == [0x7f, b'E'] || prefix == *b"#!"
+    duplicate_fd_file(fd)
+        .and_then(|file| file.metadata().ok())
+        .map_or(true, |metadata| {
+            (metadata.mode() & file_type_bits()) == regular_file_mode()
+        })
 }
 
 #[cfg(target_os = "linux")]
@@ -925,22 +922,9 @@ fn path_is_loader_sensitive(path: &str) -> bool {
     if let Some(proc_fd) = path_is_current_process_fd_path(path) {
         return file_descriptor_is_loader_sensitive(proc_fd);
     }
-    // Stat before opening.  A non-regular target is never loader interpreted,
-    // and opening one from inside an interposed exec could block the caller.
-    let Ok(metadata) = fs::metadata(path) else {
-        return true;
-    };
-    if (metadata.mode() & file_type_bits()) != regular_file_mode() {
-        return false;
-    }
-    let Ok(mut file) = File::open(path) else {
-        return true;
-    };
-    let mut prefix = [0u8; 2];
-    if file.read_exact(&mut prefix).is_err() {
-        return true;
-    }
-    prefix == [0x7f, b'E'] || prefix == *b"#!"
+    fs::metadata(path).map_or(true, |metadata| {
+        (metadata.mode() & file_type_bits()) == regular_file_mode()
+    })
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -3277,25 +3261,33 @@ mod tests {
         fs::write(&data, "plain text, not an exec target\n").expect("data");
 
         let elf_path = elf.display().to_string();
+        let data_path = data.display().to_string();
         assert!(path_is_loader_sensitive(&elf_path));
         assert!(path_is_loader_sensitive(&script.display().to_string()));
-        assert!(!path_is_loader_sensitive(&data.display().to_string()));
-        // Directories and character devices cannot be loaded.
+        // A regular file that is neither ELF nor a shebang still counts:
+        // execve answers it with ENOEXEC and glibc's execvp and execvpe then
+        // launch /bin/sh with the caller's environment from inside libc,
+        // without re-entering this guard.
+        assert!(path_is_loader_sensitive(&data_path));
+        // Nothing that is not a regular file is executable at all.
         assert!(!path_is_loader_sensitive(&dir.display().to_string()));
-        // A target the guard cannot read is refused rather than trusted.
+        // A target the guard cannot stat is refused rather than trusted.
         assert!(path_is_loader_sensitive(
             &dir.join("missing").display().to_string()
         ));
 
         let unsafe_env = ["LD_AUDIT=/tmp/audit.so".to_string()];
         assert!(should_block_loader_env_for_path(&elf_path, &unsafe_env));
+        assert!(should_block_loader_env_for_path(&data_path, &unsafe_env));
+        // A clean environment leaves every target alone.
         assert!(!should_block_loader_env_for_path(&elf_path, &[]));
+        assert!(!should_block_loader_env_for_path(&data_path, &[]));
         assert!(!should_block_loader_env_for_path(
             &elf_path,
             &[format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}")]
         ));
         assert!(!should_block_loader_env_for_path(
-            &data.display().to_string(),
+            &dir.display().to_string(),
             &unsafe_env
         ));
 
@@ -3306,7 +3298,7 @@ mod tests {
         assert!(!should_block_loader_env_for_fd(elf_fd, &[]));
 
         let data_file = File::open(&data).expect("open data");
-        assert!(!should_block_loader_env_for_fd(
+        assert!(should_block_loader_env_for_fd(
             data_file.as_raw_fd(),
             &unsafe_env
         ));

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -594,6 +594,24 @@ fn token_is_loader_environment_unset_option(token: &str) -> bool {
     name.is_some_and(token_is_loader_environment_name)
 }
 
+/// env(1) short options cluster into one token, so a bare `-S` match is not
+/// enough: `-iS` reaches both of the options that defeat the guard.  `-S`
+/// re-splits the rest of the line into tokens this scan cannot follow, and
+/// `-i` drops the guard's own preload.  Scanning stops at an option that
+/// consumes the rest of the token as its value.
+fn token_clusters_loader_environment_control(token: &str) -> bool {
+    let Some(cluster) = token.strip_prefix('-') else {
+        return false;
+    };
+    if cluster.starts_with('-') {
+        return false;
+    }
+    cluster
+        .chars()
+        .take_while(|option| !matches!(option, 'u' | 'C'))
+        .any(|option| matches!(option, 'S' | 'i'))
+}
+
 fn token_is_shell_interpreter(token: &str) -> bool {
     matches!(
         token_basename(token),
@@ -612,12 +630,11 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
     while let Some(token) = next_shebang_token(&mut scan) {
         // env can rewrite the loader environment before the target runs, so the
         // options that add, drop or replace it end the scan with a refusal.
-        // -S / --split-string re-splits the rest of the line into tokens this
-        // scan cannot follow, so it is refused whatever it carries.
-        if token.starts_with("-S") || token.starts_with("--split-string") {
-            return true;
-        }
-        if token == "-i" || token == "--ignore-environment" || token == "-" {
+        if token == "--ignore-environment"
+            || token == "-"
+            || token.starts_with("--split-string")
+            || token_clusters_loader_environment_control(&token)
+        {
             return true;
         }
         if token == "-u" || token == "--unset" {
@@ -3045,6 +3062,22 @@ mod tests {
         assert!(!token_is_loader_environment_unset_option("--unset=PATH"));
         // A bare -u carries its name in the next token, handled by the scanner.
         assert!(!token_is_loader_environment_unset_option("-u"));
+
+        // Short options cluster, so -S and -i must be found anywhere in the
+        // cluster, not only at its head.
+        assert!(token_clusters_loader_environment_control("-S"));
+        assert!(token_clusters_loader_environment_control("-i"));
+        assert!(token_clusters_loader_environment_control("-iS"));
+        assert!(token_clusters_loader_environment_control("-0i"));
+        assert!(token_clusters_loader_environment_control("-vS"));
+        // -u and -C consume the rest of the token as a value, so a variable
+        // name or a directory containing i or S is not an option.
+        assert!(!token_clusters_loader_environment_control("-uSHELL"));
+        assert!(!token_clusters_loader_environment_control("-C/tmp/dir"));
+        assert!(!token_clusters_loader_environment_control("-0"));
+        assert!(!token_clusters_loader_environment_control("-"));
+        assert!(!token_clusters_loader_environment_control("--split-string"));
+        assert!(!token_clusters_loader_environment_control("PATH=/bin"));
     }
 
     #[test]
@@ -3053,6 +3086,7 @@ mod tests {
         // -i / -u / - drop the guard's own preload before the target runs.
         for cursor in [
             " -S LD_PRELOAD=/tmp/x.so /bin/sh",
+            " -iS LD_PRELOAD=/tmp/x.so /bin/sh",
             " --split-string=LD_AUDIT=/tmp/a.so /bin/sh",
             " -u LD_PRELOAD /bin/sh",
             " --unset=LD_LIBRARY_PATH /bin/sh",

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -586,12 +586,25 @@ fn token_is_loader_environment_name(token: &str) -> bool {
     )
 }
 
+/// The short `-uNAME` form, which carries its variable name in the same token.
+/// The long forms are matched by prefix in the scanner, since env accepts
+/// abbreviations of them.
 fn token_is_loader_environment_unset_option(token: &str) -> bool {
-    let name = token
-        .strip_prefix("--unset=")
-        .or_else(|| token.strip_prefix("-u").filter(|suffix| !suffix.is_empty()))
-        .map(|name| name.strip_prefix('=').unwrap_or(name));
-    name.is_some_and(token_is_loader_environment_name)
+    token
+        .strip_prefix("-u")
+        .filter(|suffix| !suffix.is_empty())
+        .map(|name| name.strip_prefix('=').unwrap_or(name))
+        .is_some_and(token_is_loader_environment_name)
+}
+
+/// env(1) accepts any unambiguous abbreviation of a long option, so a long
+/// option is matched by prefix rather than by its full name.  An abbreviation
+/// that is ambiguous makes env exit without running anything, so treating
+/// every prefix as the option it names never lets a target through.
+fn env_long_option_name(token: &str) -> Option<&str> {
+    let name = token.strip_prefix("--")?;
+    let name = name.split('=').next().unwrap_or(name);
+    (!name.is_empty()).then_some(name)
 }
 
 /// env(1) short options cluster into one token, so a bare `-S` match is not
@@ -630,14 +643,25 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
     while let Some(token) = next_shebang_token(&mut scan) {
         // env can rewrite the loader environment before the target runs, so the
         // options that add, drop or replace it end the scan with a refusal.
-        if token == "--ignore-environment"
-            || token == "-"
-            || token.starts_with("--split-string")
-            || token_clusters_loader_environment_control(&token)
-        {
+        if let Some(name) = env_long_option_name(&token) {
+            if "split-string".starts_with(name) || "ignore-environment".starts_with(name) {
+                return true;
+            }
+            if "unset".starts_with(name) {
+                let unset = token
+                    .split_once('=')
+                    .map(|(_, value)| value.to_owned())
+                    .or_else(|| next_shebang_token(&mut scan));
+                if unset.is_some_and(|name| token_is_loader_environment_name(&name)) {
+                    return true;
+                }
+                continue;
+            }
+        }
+        if token == "-" || token_clusters_loader_environment_control(&token) {
             return true;
         }
-        if token == "-u" || token == "--unset" {
+        if token == "-u" {
             if next_shebang_token(&mut scan)
                 .is_some_and(|name| token_is_loader_environment_name(&name))
             {
@@ -1432,15 +1456,29 @@ fn loader_args_target_mutable_native_exec(args: &[String]) -> bool {
                     return true;
                 }
             }
-            "--argv0" => {
-                index += 1;
+            // Options that consume a value which is not a library search list.
+            // Missing one here would read its value as the exec target.
+            "--argv0"
+            | "--inhibit-rpath"
+            | "--glibc-hwcaps-mask"
+            | "--glibc-hwcaps-prepend"
+            | "--hwcap-mask" => {
+                if inline_value.is_none() {
+                    index += 1;
+                }
             }
+            // Options that consume no value.
+            "--list" | "--list-tunables" | "--list-diagnostics" | "--verify"
+            | "--inhibit-cache" | "--help" | "--version" => {}
             "--" => {
                 return args
                     .get(index + 1)
                     .is_some_and(|target| loader_arg_targets_mutable_native_exec(target));
             }
-            option if option.starts_with('-') => {}
+            // An option this parser does not know may or may not consume the
+            // next argument, so the exec target cannot be located. Refuse
+            // rather than guess and skip past it.
+            option if option.starts_with('-') => return true,
             target => {
                 return loader_arg_targets_mutable_native_exec(target);
             }
@@ -1985,6 +2023,7 @@ unsafe extern "C" fn guarded_execveat(
         mutable_native_target,
         mutable_shebang_protected_target,
         native_launcher_target,
+        native_loader_env_blocked,
     ) = if (flags & AT_EMPTY_PATH_FLAG) != 0 && pathname_string.is_empty() {
         let mut protected_target = classify_protected_runtime_fd(dirfd);
         if protected_target == ProtectedRuntime::None {
@@ -1996,11 +2035,19 @@ unsafe extern "C" fn guarded_execveat(
                 || loader_fd_targets_mutable_native_exec(dirfd, &args),
             file_descriptor_is_mutable_shebang_to_protected_runtime(dirfd, &env_entries),
             fd_matches_workcell_native_launcher(dirfd),
+            should_block_loader_env_for_fd(dirfd, &env_entries),
         )
     } else {
         let mut protected_target = ProtectedRuntime::None;
         let mut mutable_native_target = false;
         let mut mutable_shebang_target = false;
+        // A relative pathname resolves against dirfd, not the working
+        // directory, so loader sensitivity is read from the descriptor the
+        // kernel will execute. When that descriptor cannot be opened the
+        // target stays unclassified, so refuse it whenever the environment
+        // carries a loader override at all.
+        let mut native_loader_env_blocked = current_mode_blocks_mutable_native_exec()
+            && env_has_unsafe_loader_override(&env_entries);
         let mut native_launcher_target = false;
 
         if let Ok(c_path) = CString::new(pathname_string.as_bytes()) {
@@ -2037,6 +2084,8 @@ unsafe extern "C" fn guarded_execveat(
                                 &env_entries,
                             );
                     }
+                    native_loader_env_blocked =
+                        should_block_loader_env_for_fd(candidate_fd, &env_entries);
                     libc::close(candidate_fd);
                 }
             }
@@ -2054,6 +2103,7 @@ unsafe extern "C" fn guarded_execveat(
             mutable_native_target,
             mutable_shebang_target,
             native_launcher_target,
+            native_loader_env_blocked,
         )
     };
 
@@ -2072,12 +2122,6 @@ unsafe extern "C" fn guarded_execveat(
         report_workcell_launcher_loader_env_block();
         return -1;
     }
-    let native_loader_env_blocked =
-        if (flags & AT_EMPTY_PATH_FLAG) != 0 && pathname_string.is_empty() {
-            should_block_loader_env_for_fd(dirfd, &env_entries)
-        } else {
-            should_block_loader_env_for_path(&effective_path, &env_entries)
-        };
     if native_loader_env_blocked {
         report_native_loader_env_block();
         return -1;
@@ -3054,14 +3098,26 @@ mod tests {
         assert!(token_is_loader_environment_name("LD_TRACE_LOADED_OBJECTS"));
         assert!(!token_is_loader_environment_name("PATH"));
 
-        assert!(token_is_loader_environment_unset_option(
-            "--unset=LD_PRELOAD"
-        ));
         assert!(token_is_loader_environment_unset_option("-uLD_PRELOAD"));
         assert!(token_is_loader_environment_unset_option("-u=LD_AUDIT"));
-        assert!(!token_is_loader_environment_unset_option("--unset=PATH"));
+        assert!(!token_is_loader_environment_unset_option("-uPATH"));
         // A bare -u carries its name in the next token, handled by the scanner.
         assert!(!token_is_loader_environment_unset_option("-u"));
+        // The long forms are matched by prefix in the scanner instead.
+        assert!(!token_is_loader_environment_unset_option(
+            "--unset=LD_PRELOAD"
+        ));
+
+        // env accepts any unambiguous abbreviation of a long option.
+        assert_eq!(
+            env_long_option_name("--split-string=X"),
+            Some("split-string")
+        );
+        assert_eq!(env_long_option_name("--spl"), Some("spl"));
+        assert_eq!(env_long_option_name("--unset=LD_PRELOAD"), Some("unset"));
+        assert_eq!(env_long_option_name("--"), None);
+        assert_eq!(env_long_option_name("-u"), None);
+        assert_eq!(env_long_option_name("PATH=/bin"), None);
 
         // Short options cluster, so -S and -i must be found anywhere in the
         // cluster, not only at its head.
@@ -3088,6 +3144,12 @@ mod tests {
             " -S LD_PRELOAD=/tmp/x.so /bin/sh",
             " -iS LD_PRELOAD=/tmp/x.so /bin/sh",
             " --split-string=LD_AUDIT=/tmp/a.so /bin/sh",
+            // env accepts unambiguous long-option abbreviations.
+            " --split=-u LD_PRELOAD /bin/sh",
+            " --s=LD_PRELOAD=/tmp/x.so /bin/sh",
+            " --ignore-env /bin/sh",
+            " --un=LD_PRELOAD /bin/sh",
+            " --unset LD_AUDIT /bin/sh",
             " -u LD_PRELOAD /bin/sh",
             " --unset=LD_LIBRARY_PATH /bin/sh",
             " -uLD_PRELOAD /bin/sh",
@@ -3134,6 +3196,13 @@ mod tests {
                 "/bin/true".into(),
             ],
             vec![loader.clone(), "--audit=/usr/lib:".to_string()],
+            // An option this parser does not know may consume the next
+            // argument, so the exec target cannot be located.
+            vec![
+                loader.clone(),
+                "--not-a-real-option".to_string(),
+                "/bin/true".into(),
+            ],
         ] {
             assert!(
                 loader_args_target_mutable_native_exec(&arguments),
@@ -3155,6 +3224,31 @@ mod tests {
                 "--argv0".to_string(),
                 "sh".to_string(),
                 "/bin/true".into(),
+            ],
+            vec![
+                loader.clone(),
+                "--argv0=sh".to_string(),
+                "/bin/true".to_string(),
+            ],
+            // The other value-taking loader options must not have their value
+            // read as the exec target.
+            vec![
+                loader.clone(),
+                "--inhibit-rpath".to_string(),
+                "/usr/lib".to_string(),
+                "/bin/true".into(),
+            ],
+            vec![
+                loader.clone(),
+                "--glibc-hwcaps-mask".to_string(),
+                "x86-64-v3".to_string(),
+                "/bin/true".into(),
+            ],
+            // A valueless option leaves the next argument as the target.
+            vec![
+                loader.clone(),
+                "--inhibit-cache".to_string(),
+                "/bin/true".to_string(),
             ],
             vec![loader.clone(), "--".to_string(), "/bin/true".to_string()],
             // Arguments after the target belong to the target, not the loader.

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1423,11 +1423,18 @@ fn loader_args_target_mutable_native_exec(args: &[String]) -> bool {
     let mut index = 1usize;
     while index < args.len() {
         let argument = &args[index];
-        let (option, inline_value) = argument
-            .split_once('=')
-            .map_or((argument.as_str(), None), |(option, value)| {
-                (option, Some(value))
-            });
+        // Only an option carries an inline value. The exec target is a
+        // pathname, and a pathname may contain an equals sign, so splitting
+        // every argument would check a truncated prefix of the real target.
+        let (option, inline_value) = if argument.starts_with('-') {
+            argument
+                .split_once('=')
+                .map_or((argument.as_str(), None), |(option, value)| {
+                    (option, Some(value))
+                })
+        } else {
+            (argument.as_str(), None)
+        };
 
         match option {
             "--preload" | "--audit" | "--library-path" => {
@@ -3239,6 +3246,10 @@ mod tests {
                 "/bin/true".to_string(),
                 "/usr/lib:".to_string(),
             ],
+            // A target pathname may contain an equals sign. It must be checked
+            // whole rather than truncated at the first one, so this target
+            // reaches path_is_mutable_native_exec intact and does not exist.
+            vec![loader.clone(), "/bin/true=x".to_string()],
         ] {
             assert!(
                 !loader_args_target_mutable_native_exec(&arguments),


### PR DESCRIPTION
Unit 3 of the #652 series. Units 1 and 2 are #670 and #676, both merged.

The exec guard already refused a dynamic-loader environment override when the
target was the Workcell native launcher. Nothing refused it for any other
native target, and the shebang scanner did not read the `env(1)` options that
rewrite the loader environment before the interpreter starts. This unit closes
both, and teaches the loader-argument classifier the control options it was
guessing at.

## Three guards, each wired whole

**Loader environment on native exec.** `path_is_loader_sensitive` /
`file_descriptor_is_loader_sensitive` classify every regular file as loader
interpreted. `should_block_loader_env_for_path` /
`should_block_loader_env_for_fd` refuse such a target on the strict profile
when the child environment carries a non-approved `LD_PRELOAD`, or any
`LD_AUDIT`, `LD_LIBRARY_PATH` or `LD_TRACE_LOADED_OBJECTS`. Wired into all
eight `guarded_*` entry points, reporting `NATIVE_LOADER_ENV_BLOCK_MESSAGE`
with EPERM.

Every regular file counts, not only ELF and shebang magic. An ELF and a
shebang interpreter are loaded by ld.so directly; a regular file that is
neither gets ENOEXEC from execve, and glibc's `execvp` and `execvpe` answer
that by launching `/bin/sh` with the caller's environment from inside libc,
through an internal call that does not re-enter this guard. Nothing that is
not a regular file is executable at all, so directories, devices and sockets
keep their ordinary errno. Codex found the ENOEXEC gap; the fix made the
predicate smaller, since it no longer opens or reads the target.

**`env(1)` loader controls in a shebang.** `env_command_targets_protected_runtime`
now refuses `--split-string` and any short-option cluster reaching `-S` (which
re-splits the rest of the line into tokens this scan cannot follow) or `-i`
(which drops the guard's own preload), plus `--ignore-environment`, a bare `-`,
`-u NAME` / `--unset=NAME` / `-uNAME` naming a loader variable, and a bare
`LD_*=` assignment token. Previously `-S` and the assignment fell through the
`token.contains('=')` skip, and `-u` discarded its name unread.

Two parsing details matter here and both were wrong in earlier commits on this
branch. Short options cluster into one token, so `-iS` reaches both dangerous
options; `token_clusters_loader_environment_control` walks the cluster and
stops at `-u` and `-C`, which consume the rest of the token as their value.
Long options accept any unambiguous abbreviation, so `--split`, `--s`,
`--ignore-env` and `--un` all work; `env_long_option_name` matches them by
prefix. An ambiguous abbreviation makes env exit without running anything, so
treating every prefix as the option it names never lets a target through.

**Loader control options.** `loader_args_target_mutable_native_exec` walks a
loader argument vector the way the loader does: `--preload`, `--audit` and
`--library-path` are checked as search lists (inline or separate value); the
other value-taking options (`--argv0`, `--inhibit-rpath`,
`--glibc-hwcaps-mask`, `--glibc-hwcaps-prepend`, `--hwcap-mask`) consume their
value; the valueless ones do not; `--` ends option parsing; and the scan stops
at the exec target. An option in neither list is refused, because the target
cannot be located past an option of unknown arity.

`--preload`, `--audit` and `--library-path` are refused outright rather than
having their values read. Deciding whether such a value stays out of a mutable
root means reproducing the loader's own reading of it: it separates entries on
colons, semicolons and whitespace, and it expands `$ORIGIN`, `$LIB` and
`$PLATFORM` against the target before use, so an entry whose text names
nothing can still resolve into a mutable root. Three review rounds each closed
one form of that parser and left the next open, so the parser is gone and the
option itself is the decision. This is sound rather than approximate.

It refuses `ld.so --library-path /usr/lib`, which the parser allowed. That is
deliberate: the text of a value does not decide where the loader resolves it.
Programs are executed directly rather than through `ld.so` in normal use, a
loader invocation carrying no library option still runs, and a loader
environment reaching an ordinary target stays covered by the environment
check.

This replaces a scan that treated every argument after `argv[0]` as a loader
target. That was both too loose (it never looked at option values as search
lists, so an empty `--library-path` passed) and too tight (`ld.so /bin/sh
/workspace/x` was refused for an argument that belongs to `/bin/sh`, not to the
loader). A target that later execs something itself re-enters the guard, so
narrowing to the real loader target loses no coverage.

## Deviations from the source branch, and why

- `env_has_unsafe_loader_override` is the existing
  `env_has_unsafe_workcell_launcher_loader_override`, renamed rather than
  wrapped in the alias the source branch adds. The predicate is no longer
  launcher specific; a pass-through would only add a layer.
- The source classifies loader sensitivity by reading the target's first two
  bytes, falling back to `path_has_untrusted_provenance` /
  `fd_target_is_untrusted_exec` (unit 5 and unit 6) on a short read. This unit
  treats every regular file as loader interpreted instead, which covers the
  ENOEXEC fallback the two-byte test misses, needs neither carry-over
  predicate, and reads nothing.
- The source's `loader_arg_targets_mutable_native_exec` extension (relative
  targets, `/proc` magic targets, mutable and untrusted provenance) is unit 5
  and is not pulled forward. This unit keeps main's predicate under the new
  option parser.
- `guarded_execveat` reads loader sensitivity from the candidate descriptor
  opened with `openat(dirfd, ...)`, the same descriptor the other
  classifications in that function use, so the check names the file the kernel
  will execute. An earlier revision of this branch read the raw pathname, which
  resolves against the working directory; Codex found that, and the third
  commit fixes it.

## Differential container proof

Guard built from `main` and from this branch in the pinned toolchain image
(`rust:1.97.1-slim-trixie`, digest as pinned in the Dockerfile), installed at
the approved preload path so `LD_PRELOAD` itself is not the trigger, and each
case run under `LD_PRELOAD` on both.

| case | main | this branch |
| --- | --- | --- |
| control: plain exec, no loader override | TARGET-EXECUTED | TARGET-EXECUTED |
| control: `ld.so /bin/true`, no library option | TARGET-EXECUTED | TARGET-EXECUTED |
| child exec carries `LD_LIBRARY_PATH` | TARGET-EXECUTED | BLOCKED, EPERM, native loader-env message |
| child exec carries `LD_AUDIT` | TARGET-EXECUTED | BLOCKED, EPERM, native loader-env message |
| ENOEXEC text target with a loader override | TARGET-EXECUTED | BLOCKED, EPERM, native loader-env message |
| `ld.so --library-path /workspace ...` | TARGET-EXECUTED | BLOCKED, EPERM, mutable-native-exec message |
| `ld.so --preload '/does/not/exist /workspace/evil.so' ...` | TARGET-EXECUTED | BLOCKED, EPERM, mutable-native-exec message |
| `ld.so --library-path '/usr/lib;/workspace' ...` | TARGET-EXECUTED | BLOCKED, EPERM, mutable-native-exec message |
| `ld.so --preload '$ORIGIN/../../workspace/evil.so' ...` | TARGET-EXECUTED | BLOCKED, EPERM, mutable-native-exec message |
| `ld.so --library-path /usr/lib ...` (deliberate) | TARGET-EXECUTED | BLOCKED, EPERM, mutable-native-exec message |
| shebang `env -S LD_PRELOAD=... /bin/sh` | TARGET-EXECUTED | BLOCKED, EPERM, protected-runtime message |
| shebang `env -S -u LD_PRELOAD /bin/sh` | TARGET-EXECUTED | BLOCKED, EPERM, protected-runtime message |
| shebang `env -iS LD_PRELOAD=... /bin/sh` | TARGET-EXECUTED | BLOCKED, EPERM, protected-runtime message |
| `ld.so /workspace/evil=x` (regression repair) | BLOCKED | BLOCKED |

The `evil=x` row is not a differential and is not meant to be: main never
split loader arguments, so it always checked that target whole. An earlier
commit on this branch split every argument at the first equals sign and so
checked a truncated prefix, which regressed it. The row records the branch
matching main again.

Two controls confirm the guard does not blanket-refuse: an exec with no loader
override runs on both sides, and so does a loader invocation that names no
library option.

The `/usr/lib` row is refused on purpose. A library-naming option is refused
whatever its value, because the value's text does not decide where the loader
resolves it.

Every shebang fixture goes through `-S`, because Linux hands the whole shebang
argument string to the interpreter as a single argument, which is exactly the
splitting `-S` exists to perform. A fixture written as
`#!/usr/bin/env -u LD_PRELOAD /bin/sh` is not a working attack and was dropped
from the harness: env reads the whole string as one option value and re-execs
the script, which loops.

The loader-option cases run under a `/bin/sh -c 'exec ld.so ...'` wrapper on
purpose. `ld.so` maps its target in-process instead of exec'ing it, so the only
interposable moment is the exec of `ld.so` itself, and that exec has to come
from a process the guard is already loaded into.

Every row except the first three attack cases marks something an earlier commit
on this branch missed. All were found in review, are fixed, and are covered by
unit tests as well as by this harness.

## Verification

- Host: `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings`
  zero warnings; `cargo test` 27 + 17 pass.
- Pinned Linux image: `cargo build --release --locked --offline` links;
  `cargo test --offline --locked` 29 + 17 pass (29 includes the two
  Linux-gated cases).
- `go build ./...` clean (untouched by this unit, run as a control).
- `grep -rnE 'unsafe extern( +"[^"]*")? *\{' runtime/container/rust/src` — two
  pre-existing hits, both already carrying a `// SAFETY:` comment. This unit
  adds no `unsafe` block.

New tests: `env_interpreter_tokens_name_loader_environment_controls`,
`env_interpreter_shebangs_reject_loader_environment_control`,
`loader_control_options_reject_mutable_values`, and (Linux-gated)
`loader_environment_is_refused_for_loader_sensitive_targets`.

## Remaining units

4 — require the approved guard preload on child exec (carries
`should_block_null_explicit_env`, deferred from unit 2). 5 — trusted-immutable
provenance, path side (carries the `access(X_OK)` to `faccessat` upgrade and
the canonicalize removal, deferred from unit 2). 6 — provenance, descriptor
side (needs 5). 7 — untrusted shebang to native interpreter (needs 5, 6). 8 —
memfd snapshot execution, direct exec paths (needs 5-7). 9 — memfd snapshot
execution, descriptor and spawn paths (needs 8).

`security/rust-exec-hardening` stays as the extraction source until the series
lands.
