### PR TITLE
^B Require the approved guard preload on every child exec

### DIFF
--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -69,11 +69,6 @@ The launcher removes these environment values at startup:
 - Linux loader values such as `LD_PRELOAD` and `LD_LIBRARY_PATH`.
 - Each `DYLD_*` value.
 
-The launcher then sets `LD_PRELOAD` to the approved Workcell exec guard. Thus,
-the removal keeps caller-supplied loader values out, but each child process
-keeps the guard. On the strict profile, the exec guard refuses a child
-environment that does not have this exact value.
-
 The launcher resolves the real host home before it sources Go host wrappers. It
 sets a default cache root for Workcell Go tools. The Go environment helper supplies
 `GOPATH`, `GOMODCACHE`, and `GOCACHE` when they have no value.

--- a/docs/launcher-contract.md
+++ b/docs/launcher-contract.md
@@ -69,6 +69,11 @@ The launcher removes these environment values at startup:
 - Linux loader values such as `LD_PRELOAD` and `LD_LIBRARY_PATH`.
 - Each `DYLD_*` value.
 
+The launcher then sets `LD_PRELOAD` to the approved Workcell exec guard. Thus,
+the removal keeps caller-supplied loader values out, but each child process
+keeps the guard. On the strict profile, the exec guard refuses a child
+environment that does not have this exact value.
+
 The launcher resolves the real host home before it sources Go host wrappers. It
 sets a default cache root for Workcell Go tools. The Go environment helper supplies
 `GOPATH`, `GOMODCACHE`, and `GOCACHE` when they have no value.

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -213,6 +213,11 @@ strict path, it blocks direct native ELF files from mutable paths. It also
 blocks mutable shebang scripts that select a protected runtime. Workcell
 supplies guarded wrappers for tools such as Git and Node.
 
+The in-container Workcell launcher removes caller-supplied loader values at
+startup. It then sets `LD_PRELOAD` to the approved guard. On the strict path,
+the guard refuses a child environment that does not have this exact value.
+Thus, each child process keeps the interposer.
+
 The guard is defense in depth. A fully static process does not load the
 interposer for its own later `exec` call. `/workspace` does not have a kernel
 `noexec` mount. Thus, a fully static caller can make a direct `exec` call that

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -485,6 +485,11 @@ RUN export \
   && printf '/usr/local/lib/libworkcell_exec_guard.so\n' > /etc/ld.so.preload \
   && rm -rf /tmp/workcell-rust-target /workcell-rust
 
+# /etc/ld.so.preload loads the exec guard into every process from here on, and
+# the guard refuses a child environment without its own preload. Declare it
+# before the next RUN, or the build's own commands are the first thing refused.
+ENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
+
 # Copy adapters and control-plane scripts AFTER cargo build so that changes to
 # these frequently-modified files do not invalidate the Rust compilation cache.
 COPY adapters /opt/workcell/adapters
@@ -560,6 +565,11 @@ COPY --from=runtime-builder /usr/local/lib/libworkcell_exec_guard.so /usr/local/
 COPY --from=runtime-builder /usr/local/libexec/workcell /usr/local/libexec/workcell
 COPY runtime/container/control-plane-manifest.json /usr/local/libexec/workcell/control-plane-manifest.json
 
+# /etc/ld.so.preload loads the exec guard into every process from here on, and
+# the guard refuses a child environment without its own preload. Declare it
+# before the next RUN, or the build's own commands are the first thing refused.
+ENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
+
 RUN mv /usr/bin/git /usr/local/libexec/workcell/real/git \
   && chmod 0644 /usr/local/libexec/workcell/real/git \
   && mv /usr/local/bin/node /usr/local/libexec/workcell/real/node \
@@ -617,7 +627,6 @@ WORKDIR /workspace
 
 ENV HOME=/state/agent-home
 ENV CODEX_HOME=/state/agent-home/.codex
-ENV LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so
 ENV PATH=/usr/local/bin:/usr/bin:/bin
 
 # Defense-in-depth: default to the fixed unprivileged workcell UID/GID so that

--- a/runtime/container/apt-broker.sh
+++ b/runtime/container/apt-broker.sh
@@ -99,8 +99,11 @@ apt_broker_process_request() {
     return 0
   fi
 
+  # env -i clears the environment, so the exec guard preload has to be put back
+  # explicitly: the guard refuses any child environment that does not carry it.
   broker_env=(
     "HOME=/root"
+    "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so"
     "PATH=${WORKCELL_APT_BROKER_PATH}"
   )
   if [[ -f "${env_file}" ]] && [[ ! -L "${env_file}" ]]; then

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -188,7 +188,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/apt-broker.sh",
       "runtime_path": "/usr/local/libexec/workcell/apt-broker.sh",
-      "sha256": "b5884449980950b4d1f657e50a0fe3fb5ed1ebc6a80d1ac10382c4d46143c960"
+      "sha256": "80ccef258fd23a1c3fa9009ff862f7c9f8e186068e674053c8f78b10153ae188"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/rust/src/bin/common/launcher_common.rs
+++ b/runtime/container/rust/src/bin/common/launcher_common.rs
@@ -15,6 +15,10 @@ unsafe extern "C" {
 }
 
 pub const BASH_PATH: &str = "/bin/bash";
+// Kept in sync by hand with ALLOWED_LD_PRELOAD in src/lib.rs. The guard is a
+// cdylib of interposed exec symbols, so the launcher cannot link it to share
+// the constant without also defining execve/execv/... in its own binary.
+pub const GUARD_PRELOAD: &str = "/usr/local/lib/libworkcell_exec_guard.so";
 
 #[cfg(not(test))]
 static MANAGED_CHILD_PID: AtomicI32 = AtomicI32::new(0);
@@ -53,6 +57,11 @@ pub fn sanitize_env() {
         // SAFETY: called during single-threaded launcher startup before any thread or child is spawned; no concurrent env access.
         unsafe { env::remove_var(key) };
     }
+    // Restore only the immutable Workcell guard after removing caller-controlled
+    // loader state, so every descendant exec inherits the interposer the guard
+    // itself now requires.
+    // SAFETY: called during single-threaded launcher startup before any thread or child is spawned; no concurrent env access.
+    unsafe { env::set_var("LD_PRELOAD", GUARD_PRELOAD) };
 }
 
 pub fn set_env_var(key: &str, value: &str) {

--- a/runtime/container/rust/src/bin/workcell-launcher.rs
+++ b/runtime/container/rust/src/bin/workcell-launcher.rs
@@ -442,12 +442,17 @@ mod tests {
         launcher_common::sanitize_env();
 
         assert!(env::var_os("BASH_ENV").is_none());
-        assert!(env::var_os("LD_PRELOAD").is_none());
+        assert_eq!(
+            env::var_os("LD_PRELOAD").as_deref(),
+            Some(std::ffi::OsStr::new(launcher_common::GUARD_PRELOAD))
+        );
         assert!(env::var_os("NODE_OPTIONS").is_none());
         assert!(env::var_os("NODE_EXTRA_CA_CERTS").is_none());
         assert!(env::var_os("SSL_CERT_FILE").is_none());
         assert!(env::var_os("SSL_CERT_DIR").is_none());
         assert!(env::var_os("WORKCELL_COPILOT_AUTH_REQUIRED").is_none());
+        // SAFETY: test-only environment cleanup while holding the test environment lock.
+        unsafe { env::remove_var("LD_PRELOAD") };
     }
 
     #[test]

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -129,6 +129,18 @@ const APPROVED_NATIVE_LAUNCHERS: &[&str] = &[
     "/usr/local/libexec/workcell/core/git",
 ];
 
+// The bash scripts an approved native launcher hands control to. Only this
+// transition may exec without the guard preload already in the child
+// environment, because the scripts themselves are what install it.
+#[cfg(target_os = "linux")]
+const APPROVED_CONTROL_SCRIPTS: &[&str] = &[
+    "/usr/local/libexec/workcell/entrypoint.sh",
+    "/usr/local/libexec/workcell/development-wrapper.sh",
+    "/usr/local/libexec/workcell/git-wrapper.sh",
+    "/usr/local/libexec/workcell/node-wrapper.sh",
+    "/usr/local/libexec/workcell/provider-wrapper.sh",
+];
+
 const MUTABLE_EXEC_ROOTS: &[&str] = &["/workspace", "/state"];
 const ALLOWED_LD_PRELOAD: &str = "/usr/local/lib/libworkcell_exec_guard.so";
 // Bounds on the exec inputs this guard copies out of caller memory before it
@@ -163,6 +175,7 @@ const MUTABLE_NATIVE_EXEC_BLOCK_MESSAGE: &str = "Workcell blocked direct native 
 const WORKCELL_LAUNCHER_LOADER_ENV_BLOCK_MESSAGE: &str =
     "Workcell blocked unsafe dynamic-loader environment for Workcell launcher execution.\n";
 const NATIVE_LOADER_ENV_BLOCK_MESSAGE: &str = "Workcell blocked unsafe dynamic-loader environment for native execution on the strict profile.\n";
+const MISSING_GUARD_ENV_BLOCK_MESSAGE: &str = "Workcell blocked child execution without the approved exec guard preload on the strict profile.\n";
 
 type ExecveFn =
     unsafe extern "C" fn(*const c_char, *const *const c_char, *const *const c_char) -> c_int;
@@ -394,6 +407,15 @@ fn effective_env_ptr(envp: *const *const c_char) -> *const *const c_char {
 fn current_process_env_entries() -> Result<Vec<String>, ExecInputTooLarge> {
     // SAFETY: environ is libc-initialized; read in the calling thread with no concurrent setenv/putenv.
     collect_cstring_array(unsafe { environ.cast() })
+}
+
+// A NULL envp gives the child an empty environment, so it strips the guard
+// preload just as effectively as an explicit environment that omits it. The
+// classifiers read `effective_env_ptr`, which substitutes the caller's own
+// environment for NULL and would therefore see a preload the child never gets;
+// this check has to run on the raw pointer, before that substitution.
+fn should_block_null_explicit_env(envp: *const *const c_char) -> bool {
+    envp.is_null() && current_mode_blocks_mutable_native_exec()
 }
 
 // libc consults only PATH from the caller's environment when it searches, so
@@ -948,6 +970,65 @@ fn should_block_loader_env_for_fd(fd: c_int, env_entries: &[String]) -> bool {
 
 #[cfg(not(target_os = "linux"))]
 fn should_block_loader_env_for_fd(_fd: c_int, _env_entries: &[String]) -> bool {
+    false
+}
+
+// The child environment must carry the guard and nothing else in LD_PRELOAD:
+// a second entry would let an attacker-chosen library load alongside it, and
+// the loader silently drops the whole variable for set-user-ID targets, so
+// "contains the guard" is not the same question as "is exactly the guard".
+#[cfg(target_os = "linux")]
+fn env_has_approved_guard_preload(env_entries: &[String]) -> bool {
+    let mut preload_entries = 0;
+    for entry in env_entries {
+        let Some(value) = env_entry_value(entry, "LD_PRELOAD") else {
+            continue;
+        };
+        preload_entries += 1;
+        if preload_entries > 1 || value != ALLOWED_LD_PRELOAD {
+            return false;
+        }
+    }
+    preload_entries == 1
+}
+
+#[cfg(target_os = "linux")]
+fn current_process_is_approved_native_launcher() -> bool {
+    fs::read_link("/proc/self/exe")
+        .is_ok_and(|exe| path_matches_any_same_file(&exe, APPROVED_NATIVE_LAUNCHERS))
+}
+
+#[cfg(target_os = "linux")]
+fn path_is_approved_control_script(path: &str) -> bool {
+    path.starts_with('/') && path_matches_any_same_file(Path::new(path), APPROVED_CONTROL_SCRIPTS)
+}
+
+// The one exec that legitimately precedes the preload: an approved native
+// launcher handing control to bash running an approved control script, which is
+// the script that sets LD_PRELOAD for everything below it. Both paths must be
+// absolute, so the same-file check resolves the file the kernel will run rather
+// than a working-directory namesake.
+#[cfg(target_os = "linux")]
+fn is_approved_launcher_control_transition(path: &str, args: &[String]) -> bool {
+    path.starts_with('/')
+        && current_process_is_approved_native_launcher()
+        && path_matches_any_same_file(Path::new(path), APPROVED_WRAPPER_LAUNCHERS)
+        && args
+            .get(1)
+            .is_some_and(|script| path_is_approved_control_script(script))
+}
+
+// `path` is the target being executed; pass "" for descriptor targets, which
+// have no path to match and so can never be the control transition.
+#[cfg(target_os = "linux")]
+fn should_block_missing_guard_env(path: &str, args: &[String], env_entries: &[String]) -> bool {
+    current_mode_blocks_mutable_native_exec()
+        && !env_has_approved_guard_preload(env_entries)
+        && !is_approved_launcher_control_transition(path, args)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn should_block_missing_guard_env(_path: &str, _args: &[String], _env_entries: &[String]) -> bool {
     false
 }
 
@@ -1627,6 +1708,10 @@ fn report_native_loader_env_block() {
     report(NATIVE_LOADER_ENV_BLOCK_MESSAGE);
 }
 
+fn report_missing_guard_env_block() {
+    report(MISSING_GUARD_ENV_BLOCK_MESSAGE);
+}
+
 fn report_workcell_launcher_loader_env_block() {
     report(WORKCELL_LAUNCHER_LOADER_ENV_BLOCK_MESSAGE);
 }
@@ -1797,8 +1882,16 @@ unsafe extern "C" fn guarded_execve(
 ) -> c_int {
     let path_string = bounded_exec_input!(bounded_c_string(path), -1);
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
+    if should_block_null_explicit_env(envp) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
 
+    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -1834,6 +1927,10 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
     let env_entries = bounded_exec_input!(current_process_env_entries(), -1);
 
+    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -1892,6 +1989,10 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
         }
     };
 
+    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -1929,6 +2030,10 @@ unsafe extern "C" fn guarded_execvpe(
 ) -> c_int {
     let file_string = bounded_exec_input!(bounded_c_string(file), -1);
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
+    if should_block_null_explicit_env(envp) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
     let effective_path = match resolve_exec_search_target(&file_string) {
         Ok(Some(path)) => path,
@@ -1954,6 +2059,10 @@ unsafe extern "C" fn guarded_execvpe(
         }
     };
 
+    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -1993,6 +2102,10 @@ unsafe extern "C" fn guarded_execveat(
 ) -> c_int {
     let pathname_string = bounded_exec_input!(bounded_c_string(pathname), -1);
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
+    if should_block_null_explicit_env(envp) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
     let git_target = is_git_execveat_target(dirfd, &pathname_string, flags);
     let effective_path =
@@ -2001,6 +2114,10 @@ unsafe extern "C" fn guarded_execveat(
         } else {
             pathname_string.clone()
         };
+    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
 
     let (
         protected_target,
@@ -2134,8 +2251,18 @@ unsafe extern "C" fn guarded_fexecve(
     envp: *const *const c_char,
 ) -> c_int {
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
+    if should_block_null_explicit_env(envp) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
 
+    // A descriptor target has no path, so it can never be the approved
+    // launcher control transition; pass an empty path to say so.
+    if should_block_missing_guard_env("", &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
     if should_block_workcell_launcher_fd_loader_env(fd, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -2186,9 +2313,17 @@ unsafe extern "C" fn guarded_posix_spawn(
 ) -> c_int {
     let path_string = bounded_exec_input!(bounded_c_string(path), libc::E2BIG);
     let args = bounded_exec_input!(collect_cstring_array(argv), libc::E2BIG);
+    if should_block_null_explicit_env(envp) {
+        report_missing_guard_env_block();
+        return libc::EPERM;
+    }
     let env_entries =
         bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), libc::E2BIG);
 
+    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return libc::EPERM;
+    }
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return libc::EPERM;
@@ -2229,6 +2364,10 @@ unsafe extern "C" fn guarded_posix_spawnp(
 ) -> c_int {
     let file_string = bounded_exec_input!(bounded_c_string(file), libc::E2BIG);
     let args = bounded_exec_input!(collect_cstring_array(argv), libc::E2BIG);
+    if should_block_null_explicit_env(envp) {
+        report_missing_guard_env_block();
+        return libc::EPERM;
+    }
     let env_entries =
         bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), libc::E2BIG);
     let effective_path = match resolve_exec_search_target(&file_string) {
@@ -2246,6 +2385,10 @@ unsafe extern "C" fn guarded_posix_spawnp(
         Err(ExecSearchError::LookupFailed(errno)) => return errno,
     };
 
+    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return libc::EPERM;
+    }
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return libc::EPERM;
@@ -2948,6 +3091,53 @@ mod tests {
                 .len(),
             MAX_EXEC_STRING_BYTES + 1
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn guard_environment_requires_the_exact_preload() {
+        assert!(env_has_approved_guard_preload(&[format!(
+            "LD_PRELOAD={ALLOWED_LD_PRELOAD}"
+        )]));
+        assert!(!env_has_approved_guard_preload(&[]));
+        assert!(!env_has_approved_guard_preload(
+            &["LD_PRELOAD=".to_string()]
+        ));
+        assert!(!env_has_approved_guard_preload(&[
+            "LD_PRELOAD=/workspace/guard.so".to_string()
+        ]));
+        // The loader honours every LD_PRELOAD entry it is given, so an extra
+        // one alongside the approved guard is still an attacker-chosen library.
+        assert!(!env_has_approved_guard_preload(&[
+            "LD_PRELOAD=".to_string(),
+            format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}"),
+        ]));
+        assert!(!env_has_approved_guard_preload(&[
+            format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}"),
+            format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}"),
+        ]));
+        // A relative target cannot be same-file checked against the file the
+        // kernel will actually run, so it is never an approved control script.
+        assert!(!path_is_approved_control_script("entrypoint.sh"));
+        assert!(!is_approved_launcher_control_transition(
+            "bin/bash",
+            &["bash".to_string(), APPROVED_CONTROL_SCRIPTS[0].to_string()],
+        ));
+    }
+
+    #[test]
+    fn null_child_environment_is_treated_as_a_missing_guard_preload() {
+        let entry = CString::new(format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}")).expect("entry");
+        let envp: [*const c_char; 2] = [entry.as_ptr(), std::ptr::null()];
+
+        assert!(!should_block_null_explicit_env(envp.as_ptr()));
+        // A NULL envp hands the child an empty environment, so it strips the
+        // preload even though `effective_env_ptr` would report the caller's own.
+        assert_eq!(
+            should_block_null_explicit_env(std::ptr::null()),
+            current_mode_blocks_mutable_native_exec()
+        );
+        assert!(!effective_env_ptr(std::ptr::null::<*const c_char>()).is_null());
     }
 
     #[test]

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1886,16 +1886,8 @@ unsafe extern "C" fn guarded_execve(
 ) -> c_int {
     let path_string = bounded_exec_input!(bounded_c_string(path), -1);
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
-    if should_block_null_explicit_env(envp) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
 
-    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -1918,6 +1910,15 @@ unsafe extern "C" fn guarded_execve(
     }
     if let Some(reason) = should_block_reason(&path_string, &args) {
         report_arg_block(reason);
+        return -1;
+    }
+
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_null_explicit_env(envp)
+        || should_block_missing_guard_env(&path_string, &args, &env_entries)
+    {
+        report_missing_guard_env_block();
         return -1;
     }
 
@@ -1931,10 +1932,6 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
     let env_entries = bounded_exec_input!(current_process_env_entries(), -1);
 
-    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -1957,6 +1954,13 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
     }
     if let Some(reason) = should_block_reason(&path_string, &args) {
         report_arg_block(reason);
+        return -1;
+    }
+
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
+        report_missing_guard_env_block();
         return -1;
     }
 
@@ -1993,10 +1997,6 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
         }
     };
 
-    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -2022,6 +2022,13 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
         return -1;
     }
 
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
+        report_missing_guard_env_block();
+        return -1;
+    }
+
     // SAFETY: forwards the caller's original, unmodified execvp arguments to the real libc execvp resolved via RTLD_NEXT.
     unsafe { execvp_fn()(file, argv) }
 }
@@ -2034,10 +2041,6 @@ unsafe extern "C" fn guarded_execvpe(
 ) -> c_int {
     let file_string = bounded_exec_input!(bounded_c_string(file), -1);
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
-    if should_block_null_explicit_env(envp) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
     let effective_path = match resolve_exec_search_target(&file_string) {
         Ok(Some(path)) => path,
@@ -2063,10 +2066,6 @@ unsafe extern "C" fn guarded_execvpe(
         }
     };
 
-    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -2092,6 +2091,15 @@ unsafe extern "C" fn guarded_execvpe(
         return -1;
     }
 
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_null_explicit_env(envp)
+        || should_block_missing_guard_env(&effective_path, &args, &env_entries)
+    {
+        report_missing_guard_env_block();
+        return -1;
+    }
+
     // SAFETY: forwards the caller's original, unmodified execvpe arguments to the real libc execvpe resolved via RTLD_NEXT.
     unsafe { execvpe_fn()(file, argv, envp) }
 }
@@ -2106,10 +2114,6 @@ unsafe extern "C" fn guarded_execveat(
 ) -> c_int {
     let pathname_string = bounded_exec_input!(bounded_c_string(pathname), -1);
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
-    if should_block_null_explicit_env(envp) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
     let git_target = is_git_execveat_target(dirfd, &pathname_string, flags);
     let effective_path =
@@ -2118,10 +2122,6 @@ unsafe extern "C" fn guarded_execveat(
         } else {
             pathname_string.clone()
         };
-    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return -1;
-    }
 
     let (
         protected_target,
@@ -2244,6 +2244,15 @@ unsafe extern "C" fn guarded_execveat(
         return -1;
     }
 
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_null_explicit_env(envp)
+        || should_block_missing_guard_env(&effective_path, &args, &env_entries)
+    {
+        report_missing_guard_env_block();
+        return -1;
+    }
+
     // SAFETY: forwards the caller's original, unmodified execveat arguments to the real libc execveat resolved via RTLD_NEXT.
     unsafe { execveat_fn()(dirfd, pathname, argv, envp, flags) }
 }
@@ -2255,18 +2264,8 @@ unsafe extern "C" fn guarded_fexecve(
     envp: *const *const c_char,
 ) -> c_int {
     let args = bounded_exec_input!(collect_cstring_array(argv), -1);
-    if should_block_null_explicit_env(envp) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     let env_entries = bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), -1);
 
-    // A descriptor target has no path, so it can never be the approved
-    // launcher control transition; pass an empty path to say so.
-    if should_block_missing_guard_env("", &args, &env_entries) {
-        report_missing_guard_env_block();
-        return -1;
-    }
     if should_block_workcell_launcher_fd_loader_env(fd, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return -1;
@@ -2302,6 +2301,17 @@ unsafe extern "C" fn guarded_fexecve(
         return -1;
     }
 
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    // A descriptor target has no path, so it can never be the approved
+    // launcher control transition; pass an empty path to say so.
+    if should_block_null_explicit_env(envp)
+        || should_block_missing_guard_env("", &args, &env_entries)
+    {
+        report_missing_guard_env_block();
+        return -1;
+    }
+
     // SAFETY: forwards the caller's original, unmodified fexecve arguments to the real libc fexecve resolved via RTLD_NEXT.
     unsafe { fexecve_fn()(fd, argv, envp) }
 }
@@ -2317,17 +2327,9 @@ unsafe extern "C" fn guarded_posix_spawn(
 ) -> c_int {
     let path_string = bounded_exec_input!(bounded_c_string(path), libc::E2BIG);
     let args = bounded_exec_input!(collect_cstring_array(argv), libc::E2BIG);
-    if should_block_null_explicit_env(envp) {
-        report_missing_guard_env_block();
-        return libc::EPERM;
-    }
     let env_entries =
         bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), libc::E2BIG);
 
-    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return libc::EPERM;
-    }
     if should_block_workcell_launcher_loader_env(&path_string, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return libc::EPERM;
@@ -2353,6 +2355,15 @@ unsafe extern "C" fn guarded_posix_spawn(
         return libc::EPERM;
     }
 
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_null_explicit_env(envp)
+        || should_block_missing_guard_env(&path_string, &args, &env_entries)
+    {
+        report_missing_guard_env_block();
+        return libc::EPERM;
+    }
+
     // SAFETY: forwards the caller's original, unmodified posix_spawn arguments to the real libc posix_spawn resolved via RTLD_NEXT.
     unsafe { posix_spawn_fn()(pid, path, file_actions, attrp, argv, envp) }
 }
@@ -2368,10 +2379,6 @@ unsafe extern "C" fn guarded_posix_spawnp(
 ) -> c_int {
     let file_string = bounded_exec_input!(bounded_c_string(file), libc::E2BIG);
     let args = bounded_exec_input!(collect_cstring_array(argv), libc::E2BIG);
-    if should_block_null_explicit_env(envp) {
-        report_missing_guard_env_block();
-        return libc::EPERM;
-    }
     let env_entries =
         bounded_exec_input!(collect_cstring_array(effective_env_ptr(envp)), libc::E2BIG);
     let effective_path = match resolve_exec_search_target(&file_string) {
@@ -2389,10 +2396,6 @@ unsafe extern "C" fn guarded_posix_spawnp(
         Err(ExecSearchError::LookupFailed(errno)) => return errno,
     };
 
-    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
-        report_missing_guard_env_block();
-        return libc::EPERM;
-    }
     if should_block_workcell_launcher_loader_env(&effective_path, &env_entries) {
         report_workcell_launcher_loader_env_block();
         return libc::EPERM;
@@ -2415,6 +2418,15 @@ unsafe extern "C" fn guarded_posix_spawnp(
     }
     if let Some(reason) = should_block_reason(&file_string, &args) {
         report_arg_block(reason);
+        return libc::EPERM;
+    }
+
+    // Last of the refusals: each one above names a more specific reason, and
+    // this is the fail-closed default for a child that would run unguarded.
+    if should_block_null_explicit_env(envp)
+        || should_block_missing_guard_env(&effective_path, &args, &env_entries)
+    {
+        report_missing_guard_env_block();
         return libc::EPERM;
     }
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -409,13 +409,14 @@ fn current_process_env_entries() -> Result<Vec<String>, ExecInputTooLarge> {
     collect_cstring_array(unsafe { environ.cast() })
 }
 
-// A NULL envp gives the child an empty environment, so it strips the guard
-// preload just as effectively as an explicit environment that omits it. The
-// classifiers read `effective_env_ptr`, which substitutes the caller's own
-// environment for NULL and would therefore see a preload the child never gets;
-// this check has to run on the raw pointer, before that substitution.
+// A NULL envp gives the child an empty environment, so it asks exactly the
+// question the missing-guard classifier answers about an empty environment.
+// The other classifiers read `effective_env_ptr`, which substitutes the
+// caller's own environment for NULL and would therefore see a preload the
+// child never gets; this check has to run on the raw pointer, before that
+// substitution.
 fn should_block_null_explicit_env(envp: *const *const c_char) -> bool {
-    envp.is_null() && current_mode_blocks_mutable_native_exec()
+    envp.is_null() && should_block_missing_guard_env("", &[], &[])
 }
 
 // libc consults only PATH from the caller's environment when it searches, so
@@ -3131,12 +3132,14 @@ mod tests {
         let envp: [*const c_char; 2] = [entry.as_ptr(), std::ptr::null()];
 
         assert!(!should_block_null_explicit_env(envp.as_ptr()));
-        // A NULL envp hands the child an empty environment, so it strips the
-        // preload even though `effective_env_ptr` would report the caller's own.
+        // A NULL envp hands the child an empty environment, which is exactly
+        // the environment the missing-guard classifier refuses.
         assert_eq!(
             should_block_null_explicit_env(std::ptr::null()),
-            current_mode_blocks_mutable_native_exec()
+            should_block_missing_guard_env("", &[], &[])
         );
+        // It cannot be asked of the classifiers, because this substitution
+        // would report the caller's own environment as the child's.
         assert!(!effective_env_ptr(std::ptr::null::<*const c_char>()).is_null());
     }
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -129,18 +129,6 @@ const APPROVED_NATIVE_LAUNCHERS: &[&str] = &[
     "/usr/local/libexec/workcell/core/git",
 ];
 
-// The bash scripts an approved native launcher hands control to. Only this
-// transition may exec without the guard preload already in the child
-// environment, because the scripts themselves are what install it.
-#[cfg(target_os = "linux")]
-const APPROVED_CONTROL_SCRIPTS: &[&str] = &[
-    "/usr/local/libexec/workcell/entrypoint.sh",
-    "/usr/local/libexec/workcell/development-wrapper.sh",
-    "/usr/local/libexec/workcell/git-wrapper.sh",
-    "/usr/local/libexec/workcell/node-wrapper.sh",
-    "/usr/local/libexec/workcell/provider-wrapper.sh",
-];
-
 const MUTABLE_EXEC_ROOTS: &[&str] = &["/workspace", "/state"];
 const ALLOWED_LD_PRELOAD: &str = "/usr/local/lib/libworkcell_exec_guard.so";
 // Bounds on the exec inputs this guard copies out of caller memory before it
@@ -416,7 +404,7 @@ fn current_process_env_entries() -> Result<Vec<String>, ExecInputTooLarge> {
 // child never gets; this check has to run on the raw pointer, before that
 // substitution.
 fn should_block_null_explicit_env(envp: *const *const c_char) -> bool {
-    envp.is_null() && should_block_missing_guard_env("", &[], &[])
+    envp.is_null() && should_block_missing_guard_env(&[])
 }
 
 // libc consults only PATH from the caller's environment when it searches, so
@@ -994,45 +982,17 @@ fn env_has_approved_guard_preload(env_entries: &[String]) -> bool {
     preload_entries == 1
 }
 
+// No exemption: an approved launcher would have to be recognised by pathname,
+// and the pathname checked is not the file the kernel later runs. The launcher
+// restores the preload before it execs, so there is nothing left for an
+// exemption to cover.
 #[cfg(target_os = "linux")]
-fn current_process_is_approved_native_launcher() -> bool {
-    fs::read_link("/proc/self/exe")
-        .is_ok_and(|exe| path_matches_any_same_file(&exe, APPROVED_NATIVE_LAUNCHERS))
-}
-
-#[cfg(target_os = "linux")]
-fn path_is_approved_control_script(path: &str) -> bool {
-    path.starts_with('/') && path_matches_any_same_file(Path::new(path), APPROVED_CONTROL_SCRIPTS)
-}
-
-// The one exec that may legitimately precede the preload: an approved native
-// launcher handing control to bash on an approved control script. The launcher
-// restores the preload before it execs, so in the shipped image this is a
-// fallback rather than a normal path; it keeps the container startable if that
-// restore is ever lost, and widens nothing else. Both paths must be absolute,
-// so the same-file check resolves the file the kernel will run rather than a
-// working-directory namesake.
-#[cfg(target_os = "linux")]
-fn is_approved_launcher_control_transition(path: &str, args: &[String]) -> bool {
-    path.starts_with('/')
-        && current_process_is_approved_native_launcher()
-        && path_matches_any_same_file(Path::new(path), APPROVED_WRAPPER_LAUNCHERS)
-        && args
-            .get(1)
-            .is_some_and(|script| path_is_approved_control_script(script))
-}
-
-// `path` is the target being executed; pass "" for descriptor targets, which
-// have no path to match and so can never be the control transition.
-#[cfg(target_os = "linux")]
-fn should_block_missing_guard_env(path: &str, args: &[String], env_entries: &[String]) -> bool {
-    current_mode_blocks_mutable_native_exec()
-        && !env_has_approved_guard_preload(env_entries)
-        && !is_approved_launcher_control_transition(path, args)
+fn should_block_missing_guard_env(env_entries: &[String]) -> bool {
+    current_mode_blocks_mutable_native_exec() && !env_has_approved_guard_preload(env_entries)
 }
 
 #[cfg(not(target_os = "linux"))]
-fn should_block_missing_guard_env(_path: &str, _args: &[String], _env_entries: &[String]) -> bool {
+fn should_block_missing_guard_env(_env_entries: &[String]) -> bool {
     false
 }
 
@@ -1915,9 +1875,7 @@ unsafe extern "C" fn guarded_execve(
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_null_explicit_env(envp)
-        || should_block_missing_guard_env(&path_string, &args, &env_entries)
-    {
+    if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
     }
@@ -1959,7 +1917,7 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_missing_guard_env(&path_string, &args, &env_entries) {
+    if should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
     }
@@ -2024,7 +1982,7 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_missing_guard_env(&effective_path, &args, &env_entries) {
+    if should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
     }
@@ -2093,9 +2051,7 @@ unsafe extern "C" fn guarded_execvpe(
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_null_explicit_env(envp)
-        || should_block_missing_guard_env(&effective_path, &args, &env_entries)
-    {
+    if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
     }
@@ -2246,9 +2202,7 @@ unsafe extern "C" fn guarded_execveat(
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_null_explicit_env(envp)
-        || should_block_missing_guard_env(&effective_path, &args, &env_entries)
-    {
+    if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
     }
@@ -2303,11 +2257,7 @@ unsafe extern "C" fn guarded_fexecve(
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    // A descriptor target has no path, so it can never be the approved
-    // launcher control transition; pass an empty path to say so.
-    if should_block_null_explicit_env(envp)
-        || should_block_missing_guard_env("", &args, &env_entries)
-    {
+    if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
     }
@@ -2357,9 +2307,7 @@ unsafe extern "C" fn guarded_posix_spawn(
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_null_explicit_env(envp)
-        || should_block_missing_guard_env(&path_string, &args, &env_entries)
-    {
+    if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return libc::EPERM;
     }
@@ -2423,9 +2371,7 @@ unsafe extern "C" fn guarded_posix_spawnp(
 
     // Last of the refusals: each one above names a more specific reason, and
     // this is the fail-closed default for a child that would run unguarded.
-    if should_block_null_explicit_env(envp)
-        || should_block_missing_guard_env(&effective_path, &args, &env_entries)
-    {
+    if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return libc::EPERM;
     }
@@ -3132,13 +3078,6 @@ mod tests {
             format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}"),
             format!("LD_PRELOAD={ALLOWED_LD_PRELOAD}"),
         ]));
-        // A relative target cannot be same-file checked against the file the
-        // kernel will actually run, so it is never an approved control script.
-        assert!(!path_is_approved_control_script("entrypoint.sh"));
-        assert!(!is_approved_launcher_control_transition(
-            "bin/bash",
-            &["bash".to_string(), APPROVED_CONTROL_SCRIPTS[0].to_string()],
-        ));
     }
 
     #[test]
@@ -3151,7 +3090,7 @@ mod tests {
         // the environment the missing-guard classifier refuses.
         assert_eq!(
             should_block_null_explicit_env(std::ptr::null()),
-            should_block_missing_guard_env("", &[], &[])
+            should_block_missing_guard_env(&[])
         );
         // It cannot be asked of the classifiers, because this substitution
         // would report the caller's own environment as the child's.

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -974,10 +974,11 @@ fn should_block_loader_env_for_fd(_fd: c_int, _env_entries: &[String]) -> bool {
     false
 }
 
-// The child environment must carry the guard and nothing else in LD_PRELOAD:
-// a second entry would let an attacker-chosen library load alongside it, and
-// the loader silently drops the whole variable for set-user-ID targets, so
-// "contains the guard" is not the same question as "is exactly the guard".
+// The child environment must carry the guard and nothing else in LD_PRELOAD.
+// The loader honours every entry it is given, so a second one loads an
+// attacker-chosen library alongside the guard: "contains the guard" is not the
+// same question as "is exactly the guard", and only the second one is safe to
+// answer yes to.
 #[cfg(target_os = "linux")]
 fn env_has_approved_guard_preload(env_entries: &[String]) -> bool {
     let mut preload_entries = 0;
@@ -1004,11 +1005,13 @@ fn path_is_approved_control_script(path: &str) -> bool {
     path.starts_with('/') && path_matches_any_same_file(Path::new(path), APPROVED_CONTROL_SCRIPTS)
 }
 
-// The one exec that legitimately precedes the preload: an approved native
-// launcher handing control to bash running an approved control script, which is
-// the script that sets LD_PRELOAD for everything below it. Both paths must be
-// absolute, so the same-file check resolves the file the kernel will run rather
-// than a working-directory namesake.
+// The one exec that may legitimately precede the preload: an approved native
+// launcher handing control to bash on an approved control script. The launcher
+// restores the preload before it execs, so in the shipped image this is a
+// fallback rather than a normal path; it keeps the container startable if that
+// restore is ever lost, and widens nothing else. Both paths must be absolute,
+// so the same-file check resolves the file the kernel will run rather than a
+// working-directory namesake.
 #[cfg(target_os = "linux")]
 fn is_approved_launcher_control_transition(path: &str, args: &[String]) -> bool {
     path.starts_with('/')

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3796,7 +3796,10 @@ EOF
     echo "expected fd loader option invocation of the real Copilot payload to fail" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/copilot-loader-fd-argv0.out
+  # `env -u LD_PRELOAD bash -c` hands bash a child environment without the
+  # guard preload, so the guard now refuses the first hop and the loader is
+  # never reached. Either refusal proves the launch does not happen.
+  grep -Eq "Workcell blocked direct protected runtime execution|Workcell blocked child execution without the approved exec guard preload" /tmp/copilot-loader-fd-argv0.out
   cp "$LOADER" "$EXEC_TMP/workcell-loader-copy"
   chmod 0700 "$EXEC_TMP/workcell-loader-copy"
   if env -u LD_PRELOAD "$EXEC_TMP/workcell-loader-copy" --argv0 copilot /usr/local/libexec/workcell/real/copilot --version >/tmp/copilot-loader-copy-argv0.out 2>&1; then
@@ -3808,7 +3811,10 @@ EOF
     echo "expected deleted-fd loader option invocation of the real Copilot payload to fail" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/copilot-loader-deleted-fd-argv0.out
+  # `env -u LD_PRELOAD bash -c` hands bash a child environment without the
+  # guard preload, so the guard now refuses the first hop and the loader is
+  # never reached. Either refusal proves the launch does not happen.
+  grep -Eq "Workcell blocked direct protected runtime execution|Workcell blocked child execution without the approved exec guard preload" /tmp/copilot-loader-deleted-fd-argv0.out
   cp /bin/true "$EXEC_TMP/workcell-state-native"
   chmod 0700 "$EXEC_TMP/workcell-state-native"
   if env -u LD_PRELOAD bash -c 'exec 9<"$1"; /proc/self/fd/9 "$2" --version' bash "$LOADER" "$EXEC_TMP/workcell-state-native" >/tmp/state-native-loader-fd-target.out 2>&1; then echo "expected strict profile to reject fd loader-mediated native executable launches from /state" >&2; exit 1; fi

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -4078,19 +4078,18 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
-  # Keep the guard preload in the cleared environment, so this case still
-  # reaches the protected-runtime classifier rather than stopping at the
-  # missing-preload refusal exercised immediately below.
-  if env -i LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node.out 2>&1; then
+  if env -i PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node.out 2>&1; then
     echo "expected strict profile to reject env basename resolution to a protected Node copy" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
-  if env -i PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node-no-preload.out 2>&1; then
+  # A cleared environment strips the guard preload from the child, which the
+  # guard refuses on its own once no more specific reason applies.
+  if env -i PATH=/usr/local/bin:/usr/bin:/bin /usr/bin/env true >/tmp/env-no-preload.out 2>&1; then
     echo "expected strict profile to reject a child environment without the approved guard preload" >&2
     exit 1
   fi
-  grep -q "Workcell blocked child execution without the approved exec guard preload" /tmp/env-path-node-no-preload.out
+  grep -q "Workcell blocked child execution without the approved exec guard preload" /tmp/env-no-preload.out
   cat <<'EOF' >"${workspace_exec_scratch}/workcell-child-envp-bypass.js"
 const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3209,6 +3209,12 @@ run_container_stdin codex bash -c 'exec 3<&0; exec </dev/null; source /dev/fd/3'
   set -Eeuo pipefail
   trap 'failure_status=$?; if [[ $- == *e* ]]; then trap - ERR; echo "Codex smoke block failed at input line ${LINENO}." >&2; exit "${failure_status}"; fi' ERR
   /usr/local/bin/workcell-entrypoint codex --version >/dev/null
+  # `env -u LD_PRELOAD bash -c` hands bash a child environment without the guard
+  # preload, so the guard refuses that first hop and the loader the command
+  # names is never reached. Either refusal proves the launch does not happen.
+  assert_refused_at_or_before_target() {
+    grep -Eq "$1|Workcell blocked child execution without the approved exec guard preload" "$2"
+  }
   codex_user_script=/run/workcell/container-smoke-codex-user.sh
   cat >"${codex_user_script}" <<'CODEX_USER_SCRIPT'
     set -Eeuo pipefail
@@ -3796,10 +3802,7 @@ EOF
     echo "expected fd loader option invocation of the real Copilot payload to fail" >&2
     exit 1
   fi
-  # `env -u LD_PRELOAD bash -c` hands bash a child environment without the
-  # guard preload, so the guard now refuses the first hop and the loader is
-  # never reached. Either refusal proves the launch does not happen.
-  grep -Eq "Workcell blocked direct protected runtime execution|Workcell blocked child execution without the approved exec guard preload" /tmp/copilot-loader-fd-argv0.out
+  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/copilot-loader-fd-argv0.out
   cp "$LOADER" "$EXEC_TMP/workcell-loader-copy"
   chmod 0700 "$EXEC_TMP/workcell-loader-copy"
   if env -u LD_PRELOAD "$EXEC_TMP/workcell-loader-copy" --argv0 copilot /usr/local/libexec/workcell/real/copilot --version >/tmp/copilot-loader-copy-argv0.out 2>&1; then
@@ -3811,16 +3814,13 @@ EOF
     echo "expected deleted-fd loader option invocation of the real Copilot payload to fail" >&2
     exit 1
   fi
-  # `env -u LD_PRELOAD bash -c` hands bash a child environment without the
-  # guard preload, so the guard now refuses the first hop and the loader is
-  # never reached. Either refusal proves the launch does not happen.
-  grep -Eq "Workcell blocked direct protected runtime execution|Workcell blocked child execution without the approved exec guard preload" /tmp/copilot-loader-deleted-fd-argv0.out
+  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/copilot-loader-deleted-fd-argv0.out
   cp /bin/true "$EXEC_TMP/workcell-state-native"
   chmod 0700 "$EXEC_TMP/workcell-state-native"
   if env -u LD_PRELOAD bash -c 'exec 9<"$1"; /proc/self/fd/9 "$2" --version' bash "$LOADER" "$EXEC_TMP/workcell-state-native" >/tmp/state-native-loader-fd-target.out 2>&1; then echo "expected strict profile to reject fd loader-mediated native executable launches from /state" >&2; exit 1; fi
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-loader-fd-target.out
+  assert_refused_at_or_before_target "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-loader-fd-target.out
   if env -u LD_PRELOAD bash -c 'cp "$2" "$2.deleted"; exec 8<"$2.deleted"; rm -f "$2.deleted"; exec "$1" /proc/self/fd/8' bash "$LOADER" "$EXEC_TMP/workcell-state-native" >/tmp/state-native-loader-deleted-fd-target.out 2>&1; then echo "expected strict profile to reject deleted-fd loader-mediated native executable launches from /state" >&2; exit 1; fi
-  grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-loader-deleted-fd-target.out
+  assert_refused_at_or_before_target "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-loader-deleted-fd-target.out
   if "$EXEC_TMP/workcell-state-native" >/tmp/state-native.out 2>&1; then
     echo "expected strict profile to reject direct native executable launches from /state" >&2
     exit 1

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -4078,11 +4078,19 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
-  if env -i PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node.out 2>&1; then
+  # Keep the guard preload in the cleared environment, so this case still
+  # reaches the protected-runtime classifier rather than stopping at the
+  # missing-preload refusal exercised immediately below.
+  if env -i LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node.out 2>&1; then
     echo "expected strict profile to reject env basename resolution to a protected Node copy" >&2
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
+  if env -i PATH="${workspace_exec_scratch}" /usr/bin/env node --version >/tmp/env-path-node-no-preload.out 2>&1; then
+    echo "expected strict profile to reject a child environment without the approved guard preload" >&2
+    exit 1
+  fi
+  grep -q "Workcell blocked child execution without the approved exec guard preload" /tmp/env-path-node-no-preload.out
   cat <<'EOF' >"${workspace_exec_scratch}/workcell-child-envp-bypass.js"
 const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");


### PR DESCRIPTION
Unit 4 of the #652 series. Units 1, 2 and 3 are #670, #676 and #684, all
merged.

The launcher removed `LD_PRELOAD` along with the rest of the caller-controlled
loader state and never put it back, and the guard never asked for it. So the
exec guard covered exactly the process the loader happened to preload it into.
Any child started with an explicit environment ran unguarded, and a caller
already inside the guard could drop the interposer from all of its own
descendants just by handing them an environment without it — or no environment
at all.

This unit is the two halves of one guard: the launcher restores the preload,
and the guard requires it.

## One guard, wired whole

**Restore.** `launcher_common::sanitize_env` sets
`LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so` after clearing the
sanitized keys, so what survives the clear is the immutable Workcell guard and
nothing else. `sanitize_env_clears_sensitive_loader_and_node_state` asserts the
exact value instead of asserting the variable is gone.

**Require.** `should_block_missing_guard_env` refuses, on the strict profile,
any exec whose child environment does not carry exactly
`LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so`. Wired into all eight
`guarded_*` entry points, reporting `MISSING_GUARD_ENV_BLOCK_MESSAGE` with
EPERM, and placed last in each chain: order does not change whether a call is
refused, only which reason it is refused for, and this is the fail-closed
default for a child that would otherwise run unguarded, so every more specific
reason speaks first. An earlier revision put it first and made it answer for
an unsafe `LD_PRELOAD` too, which the container smoke assertions caught.

`env_has_approved_guard_preload` counts the entries rather than searching for
one. The loader honours every `LD_PRELOAD` entry it is given, so a second entry
loads an attacker-chosen library alongside the guard: "contains the guard" is
not the same question as "is exactly the guard", and only the second question
is safe to answer yes to.

**No exemption.** An earlier revision allowed one transition — an approved
native launcher exec'ing bash on an approved control script — recognised by
pathname. Review found the check/use gap: the file stat-compared is not the
file the entry point then executes, and losing that race costs the whole guard
rather than one classification. Closing it by pathname is not possible; it
needs descriptor discipline the entry points do not have yet. It also covers
nothing, because `sanitize_env` restores the preload before the launcher execs
and the image declares it besides. So it is gone, and the requirement is a
plain question about the child environment.

**NULL `envp`.** `should_block_null_explicit_env` is the
`should_block_null_explicit_env` carry-over deferred from unit 2; its reporter
is this unit's, so the two arrive together rather than leaving a classifier
half-wired. A NULL `envp` hands the child an empty environment, which strips
the guard exactly as effectively as an environment that omits it. It cannot be
decided alongside the other classifiers, because they all read
`effective_env_ptr`, which substitutes the caller's own environment for NULL
and would therefore see a preload the child never gets. So the NULL case is
decided on the raw pointer, before that substitution and before the
environment is copied.

## Differential proof

Pinned `rust:1.97.1-slim-trixie` (the digest the Dockerfile pins, aarch64).
The guard is built from `origin/main` and from this branch, installed at the
approved path in turn, and one C caller runs under
`LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so` against `/bin/echo`.

| case | child environment | main | this branch |
| --- | --- | --- | --- |
| `execve` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `execve` | `envp` is NULL | TARGET-EXECUTED | blocked, EPERM |
| `execve` | guard listed twice | TARGET-EXECUTED | blocked, EPERM |
| `execle` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `execvpe` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `execveat` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `fexecve` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `posix_spawn` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `posix_spawnp` | no `LD_PRELOAD` | TARGET-EXECUTED | blocked, EPERM |
| `execv` | `unsetenv` then inherit | TARGET-EXECUTED | blocked, EPERM |
| `execvp` | `unsetenv` then inherit | TARGET-EXECUTED | blocked, EPERM |
| `execve` | exactly the guard | TARGET-EXECUTED | TARGET-EXECUTED |
| `execv` | inherited, guard present | TARGET-EXECUTED | TARGET-EXECUTED |
| `execve` | guard + `LD_LIBRARY_PATH` | blocked, EPERM | blocked, EPERM |
| `execveat` | guard + `LD_LIBRARY_PATH` | blocked, EPERM | blocked, EPERM |
| `execve` | unapproved `LD_PRELOAD` | blocked, EPERM | blocked, EPERM |
| `env -i` | cleared, no preload | TARGET-EXECUTED | blocked, EPERM |
| `env -i` | cleared, preload kept | TARGET-EXECUTED | TARGET-EXECUTED |

All eight `guarded_*` entry points appear, plus the `execl`-family trampoline
from unit 1.

`execv` and `execvp` take no `envp`, so they are exercised by a caller that
calls `unsetenv("LD_PRELOAD")` first — the guard stays mapped, which is the
realistic shape of the attack: strip the variable, then exec and inherit.

The last five rows are controls. Two pass-through rows show the guard does not
blanket-refuse. The two `LD_LIBRARY_PATH` rows are blocked identically on both
sides by unit 3's loader-environment guard; they are there so the harness
proves it can observe a block at all before any differential row is believed.
The unapproved-`LD_PRELOAD` row pins the message: both sides report the
loader-environment refusal, not the new one.
That check matters: an earlier revision of this harness drove `execveat`
through `syscall(SYS_execveat, ...)` and reported the branch matching main.
The control row exposed it as a harness artifact — the built cdylib exports
`workcell_syscall_shim` but not `syscall`, so nothing was interposed and main
was not blocking either. Driving the exported `execveat` symbol instead gives
the differential above. The missing `syscall` export is pre-existing on main
and untouched here; it belongs with the trampoline work from unit 1, and is
recorded for a later unit rather than fixed in this one.

## Two places in the runtime needed the preload put back

**The image build itself.** Writing `/etc/ld.so.preload` loads the guard into
every process from that layer on, but the image declared `LD_PRELOAD` only in
the final environment block. So the next `RUN` in each guarded stage was a
guarded caller with no preload in its environment, and its first child was
refused — the build stopped at `mkdir: Operation not permitted`. The
declaration now comes immediately after the loader configuration in
`runtime-builder`, and the one in `runtime` moved above the `RUN` that follows
the copied loader configuration. Those are the only two `RUN` steps that
execute after the guard is installed, and the final image configuration is
unchanged. Reproduced by Container smoke on the first revision of this branch,
and found by review in the same round.

**The apt broker.**

`apt-broker.sh` runs the privileged apt helper through `env -i` with an
explicit allow-list, which clears `LD_PRELOAD` along with everything else. With
the guard requiring its own preload, that exec fails closed and no package
request completes, so the broker's constructed environment now carries the
preload — the same treatment `sanitize_env` gives it. The preserved-variable
file cannot smuggle the name in: it accepts only `APT_LISTCHANGES_FRONTEND`,
`DEBCONF_NONINTERACTIVE_SEEN` and `DEBIAN_FRONTEND`, so a duplicate or foreign
value cannot be reached here. The control-plane manifest hash follows the
script.

Proved in the same image against both guards: `env -i HOME=... PATH=...` on a
target executes on main and is refused on this branch, and the same command
with the preload restored executes on both.

Container smoke gains one case for the new refusal, on a target nothing else
refuses so that it cannot be answered by a different guard. The four existing
fixtures that drive a loader through `env -u LD_PRELOAD bash -c` share one
helper that accepts the specific refusal or the missing-preload one: a shell
command string is the one shape the guard cannot see the target through, so it
answers at the first hop, where bash is handed an environment without the
preload. Either refusal proves the launch does not happen.

Fixtures that name the loader and its target directly are unchanged and still
assert their exact message. The guard reads the target out of the loader
argument vector at the first hop, and the protected-runtime and mutable-native
classifiers both run before the preload requirement, so the specific reason
still answers first. Eight such fixtures pass on the same run that isolated the
shell-mediated ones.

`sudo` is not affected. The container replaces it with `sudo-wrapper.sh`, which
files a broker request rather than exec'ing anything, so there is no
`env_reset` in the path. `entrypoint.sh` uses `env -u` on one non-loader
variable and keeps the rest of the environment; `development-wrapper.sh`,
`provider-wrapper.sh` and `bin/node` already export the preload. Those are all
the environment-clearing execs in the runtime image.

## Verification

- Host: `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings`
  zero warnings; `cargo test` 28 + 17 pass.
- Pinned Linux image: `cargo fmt --check` clean;
  `cargo clippy --all-targets --offline --locked -- -D warnings` zero
  warnings; `cargo build --release --locked --offline` links;
  `cargo test --offline --locked` 31 + 17 pass (31 includes the Linux-gated
  cases).
- `bash -n` and `shellcheck -x` clean on `apt-broker.sh`;
  `scripts/generate-control-plane-manifest.sh` regenerated the manifest and
  changed exactly the one hash.
- `go build ./...` clean (untouched by this unit, run as a control).
- `grep -rnE 'unsafe extern( +"[^"]*")? *\{' runtime/container/rust/src` — two
  pre-existing hits, both already carrying a `// SAFETY:` comment. This unit
  adds one `unsafe` block, the test-only `env::remove_var` cleanup, which
  carries its own.

New tests: `guard_environment_requires_the_exact_preload` (Linux-gated: the
exact-match rule, the empty and foreign values, both duplicate forms, and the
relative-path refusal in the control transition) and
`null_child_environment_is_treated_as_a_missing_guard_preload` (the raw-pointer
decision, and that `effective_env_ptr` would have masked it).

`GUARD_PRELOAD` in `launcher_common.rs` duplicates `ALLOWED_LD_PRELOAD` in
`lib.rs` by hand. The guard is a cdylib of interposed exec symbols, so the
launcher cannot link it to share the constant without also defining
`execve`/`execv`/... in its own binary. The launcher test asserts the value the
guard requires, so the two cannot drift silently.

## Remaining units

5 — trusted-immutable provenance, path side (carries the `access(X_OK)` to
`faccessat` upgrade and the canonicalize removal, deferred from unit 2, and the
path check/use gap dispositioned in unit 3). 6 — provenance, descriptor side
(needs 5). 7 — untrusted shebang to native interpreter (needs 5, 6). 8 — memfd
snapshot execution, direct exec paths (needs 5-7). 9 — memfd snapshot
execution, descriptor and spawn paths (needs 8).

`security/rust-exec-hardening` stays as the extraction source until the series
lands.
