### PR TITLE
^F Lint every tracked bash script and detect masked returns in the fail-open subset

### DIFF
--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -111,16 +111,26 @@ If that skill is unavailable, use this fallback:
 4. Inspect later issue comments, inline comments, formal reviews, and trigger
    reactions.
 5. Inspect all earlier unresolved Codex findings on the pull request.
-6. React with 👍 to each correct finding.
-7. React with 👎 only when direct evidence proves the finding false.
-8. Give a short written reason for each rebuttal or uncertain finding.
-9. Fix or rebut each actionable finding.
-10. Revalidate and push each signed fix before another review round.
-11. Repeat this fallback after every push.
-12. If no response appears in 15 minutes, post one more standalone trigger.
-13. Treat a second silence, usage limit, or connector failure as a blocker.
-14. Require a fresh clean marker for the current head before ready or merge.
-15. Resolve each fixed or rebutted thread with GitHub `resolveReviewThread`.
+6. Classify each finding against the standard dispositions in AGENTS.md
+   `Code Review Rules` before you react. Apply the recorded disposition in
+   one round.
+7. Resolve the cited commit identifier before you act on a finding that
+   cites one. A 422 from the commits API proves that the finding has no
+   subject.
+8. React with 👍 to each correct finding.
+9. React with 👎 only when direct evidence proves the finding false.
+10. Give a short written reason for each rebuttal or uncertain finding.
+11. Fix or rebut each actionable finding.
+12. Revalidate and push each signed fix before another review round.
+13. Repeat this fallback after every push.
+14. If no response appears in 15 minutes, post one more standalone trigger.
+15. Treat a second silence, usage limit, or connector failure as a blocker.
+16. Require a fresh clean marker for the current head before ready or merge.
+17. Do not spend a review round on a finding that has a recorded
+    disposition. Codex review capacity is a limited resource. The loop
+    reached its usage limit 41 times during the 2026-09 wave. A standing
+    disposition covered 21 percent of the findings in that wave.
+18. Resolve each fixed or rebutted thread with GitHub `resolveReviewThread`.
 
 After each push, stabilize the intended head and required local evidence. Then
 run the loop. Use only the selected loop's bounded retry. Do not add manual

--- a/.agents/skills/workcell-pr-lifecycle/SKILL.md
+++ b/.agents/skills/workcell-pr-lifecycle/SKILL.md
@@ -115,8 +115,10 @@ If that skill is unavailable, use this fallback:
    `Code Review Rules` before you react. Apply the recorded disposition in
    one round.
 7. Resolve the cited commit identifier before you act on a finding that
-   cites one. A 422 from the commits API proves that the finding has no
-   subject.
+   cites one. Probe an abbreviated hash as written. A 422 from the commits
+   API proves that the finding has no subject. A finding that cites no
+   object uses its own branch. So does a finding that cites a validly
+   signed object. Both branches are in AGENTS.md `Code Review Rules`.
 8. React with 👍 to each correct finding.
 9. React with 👎 only when direct evidence proves the finding false.
 10. Give a short written reason for each rebuttal or uncertain finding.
@@ -127,9 +129,11 @@ If that skill is unavailable, use this fallback:
 15. Treat a second silence, usage limit, or connector failure as a blocker.
 16. Require a fresh clean marker for the current head before ready or merge.
 17. Do not spend a review round on a finding that has a recorded
-    disposition. Codex review capacity is a limited resource. The loop
-    reached its usage limit 41 times during the 2026-09 wave. A standing
-    disposition covered 21 percent of the findings in that wave.
+    disposition. This rule holds for a repeat of that finding. A repeat
+    carries a new object or a "fresh evidence" claim, and that framing does
+    not change the disposition. Codex review capacity is a limited resource.
+    The loop reached its usage limit 41 times during the 2026-09 wave. Three
+    pull requests each burned six or more rounds on one repeated finding.
 18. Resolve each fixed or rebutted thread with GitHub `resolveReviewThread`.
 
 After each push, stabilize the intended head and required local evidence. Then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,9 +156,12 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   success instead of failing closed.
 - A new validator over file content must call the shared shell-invocation
   parser. Register each validator in the shared evasion corpus. The corpus
-  covers comments, inline comments, heredoc bodies, multiple heredoc
-  delimiters on one line, here-strings, arithmetic shifts, quoted echo
-  decoys, prefix extension, line continuations, and unrelated job placement.
+  covers these evasions:
+  - a full-line comment and an inline comment
+  - a heredoc body, and two heredoc delimiters on one line
+  - a here-string and an arithmetic shift
+  - a quoted echo decoy and a prefix extension
+  - a line continuation and placement in an unrelated job
 - A shell script that reads a directory inventory to make a trust decision
   must prove that the walk completed. Emit a completion sentinel after a
   successful walk, or capture the exit status of the walk. Bash does not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,50 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   comment-stripped syntax, or that ships without a negative fixture.
 - Flag any external lookup or parser that treats an error as absence or
   success instead of failing closed.
+- A new validator over file content must call the shared shell-invocation
+  parser. Register each validator in the shared evasion corpus. The corpus
+  covers comments, inline comments, heredoc bodies, multiple heredoc
+  delimiters on one line, here-strings, arithmetic shifts, quoted echo
+  decoys, prefix extension, line continuations, and unrelated job placement.
+- A shell script that reads a directory inventory to make a trust decision
+  must prove that the walk completed. Emit a completion sentinel after a
+  successful walk, or capture the exit status of the walk. Bash does not
+  propagate the exit status of a process substitution. An empty result is
+  not a pass. See `scripts/verify-release-outputs.sh` for the house form.
+- A test that asserts a security-sensitive flag must compare tokens from the
+  argument vector. Do not match a substring of the flattened argument
+  string. Reject a later duplicate in every accepted spelling.
+
+### Standard review dispositions
+
+Some review findings recur with a known, already-decided answer. Resolve
+these findings in one round with the recorded disposition. Do not derive the
+argument again. Do not start another review round to settle them.
+
+- **Unverifiable commit identifier.** A finding can demand that a commit is
+  signed or created again. Resolve the cited object first. The object does
+  not exist if `git cat-file -e <sha>` fails and
+  `GET /repos/<owner>/<repo>/commits/<sha>` returns 422. The finding then
+  has no subject. Rebut with 👎 and cite both results. List the base-to-head
+  commits with their `commit.verification.verified` values. Then resolve the
+  thread. `scripts/check-publish-commit-signatures.sh` enforces the
+  signature policy locally before publication. Cite that gate, not a hand
+  audit. Do not create commits again in response to such a finding.
+
+- **Check/use gap at a language boundary.** A finding can ask for
+  `O_NOFOLLOW` parent-descriptor discipline in a shell script. Record that
+  the remedy needs fd-relative `openat`. Bash cannot express it. React 👍
+  and state the threat model and the residual risk. Then adopt the
+  descriptor discipline and port the file, or record the language-boundary
+  justification in the file header. Do not let a port-to-Go decision ride in
+  on a fail-open fix.
+
+- **Staged-by-design series finding.** A finding can be correct while a
+  later unit of a published split series holds its fix. React 👍. Reply with
+  the unit that closes the finding and the series plan that schedules it.
+  Then resolve the thread. The merge gate refuses an unresolved thread, so
+  the series plan carries the visibility. Scheduled work is not a rebuttal
+  and not a fix.
 
 ## Pull request workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,15 +177,28 @@ Some review findings recur with a known, already-decided answer. Resolve
 these findings in one round with the recorded disposition. Do not derive the
 argument again. Do not start another review round to settle them.
 
-- **Unverifiable commit identifier.** A finding can demand that a commit is
-  signed or created again. Resolve the cited object first. The object does
-  not exist if `git cat-file -e <sha>` fails and
-  `GET /repos/<owner>/<repo>/commits/<sha>` returns 422. The finding then
-  has no subject. Rebut with 👎 and cite both results. List the base-to-head
-  commits with their `commit.verification.verified` values. Then resolve the
-  thread. `scripts/check-publish-commit-signatures.sh` enforces the
+- **Commit signature demand.** A finding can demand that a commit is signed
+  or created again. Resolve the cited object first, then apply the branch
+  that matches. `scripts/check-publish-commit-signatures.sh` enforces the
   signature policy locally before publication. Cite that gate, not a hand
   audit. Do not create commits again in response to such a finding.
+  - *The finding cites a full or abbreviated object that does not resolve.*
+    Probe the exact cited form, and probe an abbreviation as written. The
+    object does not exist if `git cat-file -e <sha>` fails and
+    `GET /repos/<owner>/<repo>/commits/<sha>` returns 422. The finding then
+    has no subject. Rebut with 👎 and cite both results. List the
+    base-to-head commits with their `commit.verification.verified` values.
+    Then resolve the thread.
+  - *The finding cites no object.* The resolve step does not apply. Cite the
+    head commit `commit.verification.verified` value and the local gate.
+    Rebut with 👎. Then resolve the thread.
+  - *The finding cites an object that resolves and is validly signed.*
+    `GET /repos/<owner>/<repo>/commits/<sha>` reports
+    `verification.verified: true`. That single result is the whole rebuttal.
+    Rebut with 👎 and cite it. Then resolve the thread.
+  - *The finding repeats.* Apply the same recorded disposition. Do not start
+    a new review round. A repeat carries a new object or a "fresh evidence"
+    claim. That framing does not change the disposition.
 
 - **Check/use gap at a language boundary.** A finding can ask for
   `O_NOFOLLOW` parent-descriptor discipline in a shell script. Record that

--- a/runtime/container/bin/sudo-wrapper.sh
+++ b/runtime/container/bin/sudo-wrapper.sh
@@ -46,6 +46,7 @@ sudo_wrapper_broker_available() {
   [[ "${broker_cmdline}" == *"/usr/local/libexec/workcell/apt-broker.sh"* ]]
 }
 
+# shellcheck disable=SC2329 # reached only through the INT and TERM trap handlers
 sudo_wrapper_request_cancel() {
   local reason="$1"
   local cancel_path=""

--- a/runtime/container/bin/sudo-wrapper.sh
+++ b/runtime/container/bin/sudo-wrapper.sh
@@ -46,7 +46,7 @@ sudo_wrapper_broker_available() {
   [[ "${broker_cmdline}" == *"/usr/local/libexec/workcell/apt-broker.sh"* ]]
 }
 
-# shellcheck disable=SC2329 # reached only through the INT and TERM trap handlers
+# shellcheck disable=SC2317,SC2329 # reached only through the INT and TERM trap handlers
 sudo_wrapper_request_cancel() {
   local reason="$1"
   local cancel_path=""
@@ -68,7 +68,7 @@ sudo_wrapper_request_cleanup() {
   rm -f "${stdout_path}" "${stderr_path}" >/dev/null 2>&1 || true
 }
 
-# shellcheck disable=SC2329
+# shellcheck disable=SC2317,SC2329 # reached only through the INT and TERM trap handlers
 sudo_wrapper_request_signal_exit() {
   local reason="$1"
   local signal_status="$2"

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -6,7 +6,7 @@
     },
     {
       "repo_path": "scripts/check-publish-commit-signatures.sh",
-      "sha256": "8c79f6a37251e007026ac111994d2e171940a695152b8d9462f423d5f52779e8"
+      "sha256": "864c914e668d2949392f2bde0624962b52900c3caf4a4dddfb224beb4e1c4054"
     },
     {
       "repo_path": "scripts/lib/extract_direct_mounts",
@@ -206,13 +206,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/bin/sudo-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/sudo-wrapper.sh",
-      "sha256": "081b450611b9a2c0702a2541c7dd04062725365661c5f358eac209c8ac37af40"
+      "sha256": "e2492c0f7691c2af73d6e6c7c192486b5845a9927e4462b5e97c0988b17bbcc7"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/detached-stdin-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/detached-stdin-wrapper.sh",
-      "sha256": "8abf7c68352a6133b03bd3b7bd3e308b0d9cfeddc45e4fa5df05a12dc95ef3f3"
+      "sha256": "7e60e90cfdfb9c0a45ee24c1b74562ccba0fda7abdff09c7c8d79dfa3081433c"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -206,13 +206,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/bin/sudo-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/sudo-wrapper.sh",
-      "sha256": "e2492c0f7691c2af73d6e6c7c192486b5845a9927e4462b5e97c0988b17bbcc7"
+      "sha256": "df1d09211d67504250fa006fbdbca1d09caf03a12c3746ff8855bbf67373174d"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/detached-stdin-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/detached-stdin-wrapper.sh",
-      "sha256": "7e60e90cfdfb9c0a45ee24c1b74562ccba0fda7abdff09c7c8d79dfa3081433c"
+      "sha256": "72960634238283bfb47deaa5638f9a4d8d17db1491209f8e51f6734b082abfc4"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/detached-stdin-wrapper.sh
+++ b/runtime/container/detached-stdin-wrapper.sh
@@ -54,7 +54,7 @@ cleanup() {
   rm -f "${stdin_path}" "${exec_path}"
 }
 
-# shellcheck disable=SC2329 # reached only through handle_signal, a trap handler
+# shellcheck disable=SC2317,SC2329 # reached only through handle_signal, a trap handler
 forward_child_signal() {
   local signal="$1"
 
@@ -122,7 +122,7 @@ sync_terminal_size() {
   fi
 }
 
-# shellcheck disable=SC2329 # installed as the WINCH trap handler
+# shellcheck disable=SC2317,SC2329 # installed as the WINCH trap handler
 handle_terminal_resize() {
   # Docker Desktop can emit a burst of SIGWINCH events while the container
   # terminal settles. Let the burst coalesce before copying its final size to
@@ -148,7 +148,7 @@ wait_for_child() {
   done
 }
 
-# shellcheck disable=SC2329 # installed as the INT and TERM trap handler
+# shellcheck disable=SC2317,SC2329 # installed as the INT and TERM trap handler
 handle_signal() {
   local signal="$1"
   local status=0

--- a/runtime/container/detached-stdin-wrapper.sh
+++ b/runtime/container/detached-stdin-wrapper.sh
@@ -54,6 +54,7 @@ cleanup() {
   rm -f "${stdin_path}" "${exec_path}"
 }
 
+# shellcheck disable=SC2329 # reached only through handle_signal, a trap handler
 forward_child_signal() {
   local signal="$1"
 
@@ -121,6 +122,7 @@ sync_terminal_size() {
   fi
 }
 
+# shellcheck disable=SC2329 # installed as the WINCH trap handler
 handle_terminal_resize() {
   # Docker Desktop can emit a burst of SIGWINCH events while the container
   # terminal settles. Let the burst coalesce before copying its final size to
@@ -146,6 +148,7 @@ wait_for_child() {
   done
 }
 
+# shellcheck disable=SC2329 # installed as the INT and TERM trap handler
 handle_signal() {
   local signal="$1"
   local status=0

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -39,10 +39,23 @@ trap 'rm -f "${link_records}"' EXIT
 # excluded: they simulate external content, not documentation.
 excluded='^(runtime/container/rust/vendor|runtime/container/providers/node_modules|runtime/container/rust/target|dist|tmp)/|(^|/)testdata/'
 
+# Capture the listing before the exclusion filter runs. `git ls-files | grep
+# || true` erases Git's exit status twice over, so a failed or truncated
+# listing would silently shrink this inventory and every check below would
+# pass over the files it never read. `set -e` aborts on the capture instead.
+# The `|| true` stays on the filter alone, where an empty result is a real
+# outcome, and the inventory assertion rejects a vacuously empty result.
+md_listing="$(git ls-files '*.md')"
+
 md_files=()
 while IFS= read -r mf; do
   [[ -n "${mf}" ]] && md_files+=("${mf}")
-done < <(git ls-files '*.md' | grep -vE "${excluded}" || true)
+done < <(printf '%s\n' "${md_listing}" | grep -vE "${excluded}" || true)
+
+if [[ "${#md_files[@]}" -eq 0 ]]; then
+  echo "check-doc-links: markdown inventory is empty; refusing a vacuous pass" >&2
+  exit 1
+fi
 
 # --- Broken relative-link check + referrer index ----------------------------
 for f in "${md_files[@]}"; do

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -23,7 +23,10 @@ cd "${ROOT_DIR}"
 
 bt='`'
 failures=0
-note() { echo "check-doc-links: $*" >&2; failures=$((failures + 1)); }
+note() {
+  echo "check-doc-links: $*" >&2
+  failures=$((failures + 1))
+}
 
 # Referrer index: one "linker<TAB>canonical-target" line per navigable link,
 # keyed by resolved absolute path so distinct files that share a basename are
@@ -47,7 +50,7 @@ for f in "${md_files[@]}"; do
   while IFS= read -r target; do
     [[ -n "${target}" ]] || continue
     case "${target}" in
-      http://*|https://*|mailto:*|tel:*|'#'*) continue ;;
+      http://* | https://* | mailto:* | tel:* | '#'*) continue ;;
     esac
     # Drop any #fragment; only the path portion is validated.
     path="${target%%#*}"
@@ -61,23 +64,27 @@ for f in "${md_files[@]}"; do
     # Canonicalize fully (resolving any trailing ..) and require the target to
     # stay within the repository checkout so a traversal such as ../../etc/passwd
     # or ../../.. cannot pass by matching a host path.
+    # shellcheck disable=SC2312 # a failed cd yields a path outside ROOT_DIR, which the containment case below rejects
     if [[ -d "${resolved}" ]]; then
       canon="$(cd "${resolved}" && pwd -P)"
     else
       canon="$(cd "$(dirname "${resolved}")" && pwd -P)/$(basename "${resolved}")"
     fi
     case "${canon}" in
-      "${ROOT_DIR}"|"${ROOT_DIR}"/*) : ;;
-      *) note "link escapes repository: ${f} -> ${target}"; continue ;;
+      "${ROOT_DIR}" | "${ROOT_DIR}"/*) : ;;
+      *)
+        note "link escapes repository: ${f} -> ${target}"
+        continue
+        ;;
     esac
-    printf '%s\t%s\n' "${f}" "${canon}" >> "${link_records}"
+    printf '%s\t%s\n' "${f}" "${canon}" >>"${link_records}"
   done < <(
     # Strip fenced code blocks, then inline code spans, so example markdown
     # (fenced or `inline`) is not treated as a navigable link.
-    awk '/^[[:space:]]*```/{fence=!fence; next} !fence' "${f}" \
-      | sed -E "s/${bt}[^${bt}]*${bt}//g" \
-      | grep -oE '\]\([^) ]+\)' \
-      | sed -E 's/^\]\(//; s/\)$//' || true
+    awk '/^[[:space:]]*```/{fence=!fence; next} !fence' "${f}" |
+      sed -E "s/${bt}[^${bt}]*${bt}//g" |
+      grep -oE '\]\([^) ]+\)' |
+      sed -E 's/^\]\(//; s/\)$//' || true
   )
 done
 
@@ -85,15 +92,21 @@ done
 # A docs/*.md page is an orphan when no other tracked markdown file navigably
 # links to it. Matching is by canonical path, so a page is not treated as
 # referenced merely because some unrelated file shares its basename.
+# Capture the listing before the loop reads it. A process substitution hides a
+# `git ls-files` failure, which would leave this orphan check iterating nothing
+# and reporting a clean result over a docs tree it never enumerated.
+docs_listing="$(git ls-files 'docs/*.md')"
+
 while IFS= read -r doc; do
+  [[ -n "${doc}" ]] || continue
   doc_canon="${ROOT_DIR}/${doc}"
   if awk -F'\t' -v t="${doc_canon}" -v self="${doc}" \
-      '$2==t && $1!=self {found=1} END{exit found?0:1}' "${link_records}"; then
+    '$2==t && $1!=self {found=1} END{exit found?0:1}' "${link_records}"; then
     : # navigably linked from another markdown file
   else
     note "orphan doc: ${doc} is linked from no other tracked markdown file"
   fi
-done < <(git ls-files 'docs/*.md')
+done <<<"${docs_listing}"
 
 if [[ "${failures}" -gt 0 ]]; then
   echo "check-doc-links: FAILED with ${failures} issue(s)" >&2

--- a/scripts/check-doc-support-matrix-fields.sh
+++ b/scripts/check-doc-support-matrix-fields.sh
@@ -28,18 +28,18 @@ done
 
 # Field names emitted by Go MetadataLines(), scoped to that function body.
 go_fields="$(
-  awk '/^func MetadataLines\(/{f=1} f{print} f&&/^}/{exit}' "${GO_FILE}" \
-    | grep -oE '"[a-z0-9_]+=%s"' \
-    | sed -E 's/"([a-z0-9_]+)=%s"/\1/' \
-    | sort -u
+  awk '/^func MetadataLines\(/{f=1} f{print} f&&/^}/{exit}' "${GO_FILE}" |
+    grep -oE '"[a-z0-9_]+=%s"' |
+    sed -E 's/"([a-z0-9_]+)=%s"/\1/' |
+    sort -u
 )"
 
 # Field names printed by the shell print_support_matrix_state(), scoped to it.
 sh_fields="$(
-  awk '/^print_support_matrix_state\(\) \{/{f=1} f{print} f&&/^}/{exit}' "${SH_FILE}" \
-    | grep -oE "'[a-z0-9_]+=%s" \
-    | sed -E "s/'([a-z0-9_]+)=%s/\1/" \
-    | sort -u
+  awk '/^print_support_matrix_state\(\) \{/{f=1} f{print} f&&/^}/{exit}' "${SH_FILE}" |
+    grep -oE "'[a-z0-9_]+=%s" |
+    sed -E "s/'([a-z0-9_]+)=%s/\1/" |
+    sort -u
 )"
 
 # Field names documented between the machine-checked markers in the doc. Only
@@ -48,10 +48,10 @@ sh_fields="$(
 # sourced from a variable so the extraction patterns stay in double quotes.
 bt='`'
 doc_fields="$(
-  awk '/<!-- support-matrix-fields:begin -->/{f=1;next} /<!-- support-matrix-fields:end -->/{f=0} f' "${DOC_FILE}" \
-    | grep -oE "^\\| ${bt}[a-z0-9_]+${bt}" \
-    | sed -E "s/^\\| ${bt}([a-z0-9_]+)${bt}/\\1/" \
-    | sort -u
+  awk '/<!-- support-matrix-fields:begin -->/{f=1;next} /<!-- support-matrix-fields:end -->/{f=0} f' "${DOC_FILE}" |
+    grep -oE "^\\| ${bt}[a-z0-9_]+${bt}" |
+    sed -E "s/^\\| ${bt}([a-z0-9_]+)${bt}/\\1/" |
+    sort -u
 )"
 
 [[ -n "${go_fields}" ]] || fail "extracted no fields from Go MetadataLines()"
@@ -63,8 +63,8 @@ report_diff() {
   local only_a only_b
   only_a="$(comm -23 <(printf '%s\n' "${set_a}") <(printf '%s\n' "${set_b}") | tr '\n' ' ')"
   only_b="$(comm -13 <(printf '%s\n' "${set_a}") <(printf '%s\n' "${set_b}") | tr '\n' ' ')"
-  [[ -n "${only_a// }" ]] && echo "  only in ${label_a}: ${only_a}" >&2
-  [[ -n "${only_b// }" ]] && echo "  only in ${label_b}: ${only_b}" >&2
+  [[ -n "${only_a// /}" ]] && echo "  only in ${label_a}: ${only_a}" >&2
+  [[ -n "${only_b// /}" ]] && echo "  only in ${label_b}: ${only_b}" >&2
 }
 
 if [[ "${go_fields}" != "${sh_fields}" ]]; then

--- a/scripts/check-pinned-inputs.sh
+++ b/scripts/check-pinned-inputs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -p
 # shellcheck source=scripts/lib/trusted-entrypoint.sh
+# shellcheck disable=SC2312 # repo-wide bootstrap; the path is the running script's own directory
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then

--- a/scripts/check-pr-shape.sh
+++ b/scripts/check-pr-shape.sh
@@ -113,6 +113,7 @@ run_workspace_safe_git_command_in_dir() {
   local -a git_command=()
   local override=""
 
+  # shellcheck disable=SC2312 # the helper ends in `|| true`; an empty override set is its designed result
   while IFS= read -r -d '' override; do
     filter_overrides+=("${override}")
   done < <(workspace_git_filter_override_args "${workspace}")
@@ -296,6 +297,12 @@ changed_lines=0
 binary_files=0
 changed_areas_text=""
 
+# Capture both diffs before the loops read them. A process substitution hides a
+# `git diff` failure, and an unread diff would present as a zero-file, zero-line
+# change that satisfies every shape budget below. `set -e` now aborts instead.
+numstat_diff="$(run_workspace_safe_git_command_in_dir "${REPO_ROOT}" diff --numstat --find-renames "${merge_base}..${head_commit}")"
+name_status_diff="$(run_workspace_safe_git_command_in_dir "${REPO_ROOT}" diff --name-status --find-renames "${merge_base}..${head_commit}")"
+
 while IFS=$'\t' read -r additions deletions path; do
   [[ -n "${path:-}" ]] || continue
   changed_files=$((changed_files + 1))
@@ -304,7 +311,7 @@ while IFS=$'\t' read -r additions deletions path; do
   else
     changed_lines=$((changed_lines + additions + deletions))
   fi
-done < <(run_workspace_safe_git_command_in_dir "${REPO_ROOT}" diff --numstat --find-renames "${merge_base}..${head_commit}")
+done <<<"${numstat_diff}"
 
 while IFS=$'\t' read -r status first_path second_path; do
   [[ -n "${status:-}" ]] || continue
@@ -317,7 +324,7 @@ while IFS=$'\t' read -r status first_path second_path; do
       record_changed_area "${first_path:-}"
       ;;
   esac
-done < <(run_workspace_safe_git_command_in_dir "${REPO_ROOT}" diff --name-status --find-renames "${merge_base}..${head_commit}")
+done <<<"${name_status_diff}"
 
 changed_area_count="$(printf '%s' "${changed_areas_text}" | grep -c . || true)"
 
@@ -359,6 +366,7 @@ fail_pr_shape() {
       "${binary_files}" \
       "${CERTIFIED_ADAPTER_MAX_BINARY_FILES}" >&2
   fi
+  # shellcheck disable=SC2312 # diagnostic text on the failure path; the exit status below is already decided
   printf '  areas=%s\n' "$(printf '%s' "${changed_areas_text}" | sort | paste -sd, -)" >&2
   echo "Split unrelated fixes, opportunistic cleanup, or separate reviewer-sized concerns before publishing." >&2
   exit 2

--- a/scripts/check-public-contract.sh
+++ b/scripts/check-public-contract.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -p
 # shellcheck source=scripts/lib/trusted-entrypoint.sh
+# shellcheck disable=SC2312 # repo-wide bootstrap; the path is the running script's own directory
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then

--- a/scripts/check-public-repo-hygiene.sh
+++ b/scripts/check-public-repo-hygiene.sh
@@ -6,19 +6,17 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 public_files=(
 )
 
-while IFS= read -r path; do
-  [[ -n "${path}" ]] || continue
-  public_files+=("${path}")
-done < <(
+# Capture each inventory before the loop reads it. A process substitution hides
+# a `find` failure, and this script only reports on the files it collects: an
+# unread inventory would present as a clean public surface. `set -e` with
+# `pipefail` now aborts on a failed or partial walk instead.
+root_public_listing="$(
   find "${ROOT_DIR}" -maxdepth 1 -type f \
     \( -name '*.md' -o -name '*.toml' -o -name '*.cff' -o -name 'LICENSE' -o -name 'NOTICE' \) \
     -print | sort
-)
+)"
 
-while IFS= read -r path; do
-  [[ -n "${path}" ]] || continue
-  public_files+=("${path}")
-done < <(
+tree_public_listing="$(
   find \
     "${ROOT_DIR}/.agents" \
     "${ROOT_DIR}/docs" \
@@ -27,7 +25,17 @@ done < <(
     -type f \
     \( -name '*.md' -o -name '*.toml' -o -name '*.1' \) \
     -print | sort
-)
+)"
+
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  public_files+=("${path}")
+done <<<"${root_public_listing}"
+
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  public_files+=("${path}")
+done <<<"${tree_public_listing}"
 
 check_public_surfaces() {
   local findings

--- a/scripts/check-publish-commit-signatures.sh
+++ b/scripts/check-publish-commit-signatures.sh
@@ -227,6 +227,13 @@ printf '%s\n' "${object_dir}" >"${verification_git_dir}/objects/info/alternates"
 base_commit="$(resolve_verification_commit_or_die "${verification_git_dir}" "${base_object}" "${BASE_REF}")"
 head_commit="$(resolve_verification_commit_or_die "${verification_git_dir}" "${head_object}" "${HEAD_REF}")"
 
+# Bash does not propagate a process-substitution failure, so a `rev-list` that
+# died part way through would feed this loop a truncated commit list and leave
+# the unread commits unverified. Capture the walk first: `set -e` then aborts on
+# a failed or partial listing instead of reporting a pass over commits that were
+# never read.
+commit_list="$(run_clean_host_command_in_dir "${verify_root}" "${HOST_GIT_BIN}" --no-replace-objects --git-dir "${verification_git_dir}" rev-list --reverse "${base_commit}..${head_commit}")"
+
 while IFS= read -r commit; do
   [[ -n "${commit}" ]] || continue
   commit_count=$((commit_count + 1))
@@ -237,7 +244,7 @@ while IFS= read -r commit; do
     fi
     exit 2
   fi
-done < <(run_clean_host_command_in_dir "${verify_root}" "${HOST_GIT_BIN}" --no-replace-objects --git-dir "${verification_git_dir}" rev-list --reverse "${base_commit}..${head_commit}")
+done <<<"${commit_list}"
 
 if ((commit_count == 0)); then
   echo "publish-pr found no commits ahead of ${BASE_REF}: ${HEAD_REF}" >&2

--- a/scripts/check-repo-readiness.sh
+++ b/scripts/check-repo-readiness.sh
@@ -359,6 +359,7 @@ while true; do
   if [[ "${REPO_READINESS}" == "ready" || "${WATCH}" -eq 0 ]]; then
     break
   fi
+  # shellcheck disable=SC2312 # `date +%s` reads the clock; it has no failure mode that masks a decision
   if [[ "$(date +%s)" -ge "${deadline}" ]]; then
     break
   fi

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -332,7 +332,11 @@ is_bash_shebang() {
   IFS=$' \t' read -r -a tokens <<<"${line#'#!'}"
   for token in "${tokens[@]}"; do
     token="${token#--split-string=}"
-    token="${token#-S}"
+    # A short option cluster can precede the split string, as in `-iSbash`.
+    # Take whatever follows the last `S` in such a cluster.
+    if [[ "${token}" == -* && "${token}" != --* && "${token}" == *S* ]]; then
+      token="${token##*S}"
+    fi
     token="${token//\"/}"
     token="${token//\'/}"
     [[ "${token##*/}" == "bash" ]] && return 0
@@ -358,7 +362,10 @@ is_bash_shebang() {
 SHEBANG_STDOUT="$(mktemp "${TMPDIR:-/tmp}/workcell-shebangs.XXXXXX")"
 SHEBANG_STDERR="$(mktemp "${TMPDIR:-/tmp}/workcell-shebang-errors.XXXXXX")"
 shebang_read_status=0
-git -C "${ROOT_DIR}" grep --cached -z -I -n -E '^#!' \
+# `-a` rather than `-I`: Bash runs a script that carries a NUL byte, but `-I`
+# treats that blob as binary and omits it from the listing without an error.
+# The omitted path would then be classified as "not Bash" and left unlinted.
+git -C "${ROOT_DIR}" grep --cached -z -a -n -E '^#!' \
   >"${SHEBANG_STDOUT}" 2>"${SHEBANG_STDERR}" || shebang_read_status=$?
 
 if [[ "${shebang_read_status}" -gt 1 || -s "${SHEBANG_STDERR}" ]]; then

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -390,6 +390,11 @@ is_bash_shebang() {
   [[ -n "${command}" ]] || return 1
   command="${command//\"/}"
   command="${command//\'/}"
+  # `env -S` expands a variable reference and substitutes an empty string for an
+  # unset one, so `#!/usr/bin/env -S /bin/ba${UNSET}sh` runs Bash. That value
+  # cannot be resolved here. Report an unresolvable command as a candidate so
+  # the completeness gate demands the script instead of skipping it silently.
+  [[ "${command}" != *'$'* ]] || return 0
   [[ "${command##*/}" == "bash" ]]
 }
 

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -411,12 +411,25 @@ done
 # are optional checks and stay off by default. Enable them on the scripts where
 # a masked return would admit an unverified release, commit, or public surface.
 # Ratchet: add files as they are cleaned, never remove one.
-fail_open_critical_shell_files=(
-  "${ROOT_DIR}/scripts/verify-release-outputs.sh"
-  "${ROOT_DIR}/scripts/verify-release-artifact.sh"
-  "${ROOT_DIR}"/scripts/check-*.sh
-  "${ROOT_DIR}"/.githooks/*
-)
+# Select the subset from the verified inventory above, not from a filesystem
+# glob. A glob matches whatever the checkout holds, so an untracked or
+# symlinked `scripts/check-evil.sh` would enter the subset and ShellCheck would
+# open its target outside the repository. Selecting from `shell_files` keeps
+# this subset inside the list the completeness check has already verified.
+fail_open_critical_shell_files=()
+for file in "${shell_files[@]}"; do
+  case "${file#"${ROOT_DIR}/"}" in
+    scripts/verify-release-outputs.sh | scripts/verify-release-artifact.sh | scripts/check-*.sh | .githooks/*)
+      fail_open_critical_shell_files+=("${file}")
+      ;;
+  esac
+done
+
+if [[ "${#fail_open_critical_shell_files[@]}" -eq 0 ]]; then
+  echo "Fail-open-critical subset is empty; masked-return coverage is unverified" >&2
+  exit 1
+fi
+
 for file in "${fail_open_critical_shell_files[@]}"; do
   shellcheck -x -o check-extra-masked-returns "${file}"
 done

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -153,8 +153,11 @@ shell_files=(
   "${ROOT_DIR}/.githooks/pre-push"
   "${ROOT_DIR}/scripts/bootstrap-dev.sh"
   "${ROOT_DIR}/scripts/check-dead-code.sh"
+  "${ROOT_DIR}/scripts/check-doc-links.sh"
+  "${ROOT_DIR}/scripts/check-doc-support-matrix-fields.sh"
   "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"
   "${ROOT_DIR}/scripts/check-pr-shape.sh"
+  "${ROOT_DIR}/scripts/check-publish-commit-signatures.sh"
   "${ROOT_DIR}/scripts/check-repo-readiness.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
   "${ROOT_DIR}/scripts/check-public-contract.sh"
@@ -166,6 +169,9 @@ shell_files=(
   "${ROOT_DIR}/scripts/workcell"
   "${ROOT_DIR}/scripts/check-workflows.sh"
   "${ROOT_DIR}/scripts/ci/build-validator-image.sh"
+  "${ROOT_DIR}/scripts/ci/cost-report.sh"
+  "${ROOT_DIR}/scripts/ci/flaky-report.sh"
+  "${ROOT_DIR}/scripts/ci/lib/local-docker-parity.sh"
   "${ROOT_DIR}/scripts/ci/job-docs.sh"
   "${ROOT_DIR}/scripts/ci/job-fuzz.sh"
   "${ROOT_DIR}/scripts/ci/job-mutation.sh"
@@ -204,12 +210,15 @@ shell_files=(
   "${ROOT_DIR}/scripts/generate-release-checksums.sh"
   "${ROOT_DIR}/scripts/generate-homebrew-formula.sh"
   "${ROOT_DIR}/scripts/generate-build-input-manifest.sh"
+  "${ROOT_DIR}/scripts/generate-workflow-lane-manifest.sh"
   "${ROOT_DIR}/scripts/install.sh"
   "${ROOT_DIR}/scripts/install-release.sh"
   "${ROOT_DIR}/scripts/install-workcell.sh"
   "${ROOT_DIR}/scripts/uninstall.sh"
   "${ROOT_DIR}/scripts/pre-merge.sh"
   "${ROOT_DIR}/scripts/provider-e2e.sh"
+  "${ROOT_DIR}/scripts/repo-publish-pr.sh"
+  "${ROOT_DIR}/scripts/retry.sh"
   "${ROOT_DIR}/scripts/publish-github-release.sh"
   "${ROOT_DIR}/scripts/check-release-tag-signature.sh"
   "${ROOT_DIR}/scripts/publish-provider-bump-pr.sh"
@@ -228,6 +237,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/verify-github-macos-release-test-runners.sh"
   "${ROOT_DIR}/scripts/verify-release-artifact.sh"
   "${ROOT_DIR}/scripts/verify-release-bundle.sh"
+  "${ROOT_DIR}/scripts/verify-release-outputs.sh"
   "${ROOT_DIR}/scripts/verify-invariants.sh"
   "${ROOT_DIR}/scripts/verify-operator-contract.sh"
   "${ROOT_DIR}/scripts/verify-workflow-lanes.sh"
@@ -239,8 +249,11 @@ shell_files=(
   "${ROOT_DIR}/scripts/with-validation-snapshot.sh"
   "${ROOT_DIR}/adapters/claude/hooks/guard-bash.sh"
   "${ROOT_DIR}/runtime/container/entrypoint.sh"
+  "${ROOT_DIR}/runtime/container/apt-broker.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-helper.sh"
   "${ROOT_DIR}/runtime/container/bin/apt-wrapper.sh"
+  "${ROOT_DIR}/runtime/container/bin/sudo-wrapper.sh"
+  "${ROOT_DIR}/runtime/container/detached-stdin-wrapper.sh"
   "${ROOT_DIR}/runtime/container/assurance.sh"
   "${ROOT_DIR}/runtime/container/development-wrapper.sh"
   "${ROOT_DIR}/runtime/container/bin/git"
@@ -252,11 +265,66 @@ shell_files=(
   "${ROOT_DIR}/scripts/run-scenario-tests.sh"
   "${ROOT_DIR}/scripts/verify-scenario-coverage.sh"
   "${ROOT_DIR}/scripts/verify-control-plane-parity.sh"
+  "${ROOT_DIR}/verify/invariants/control-plane-lockstep.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-probe.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/install-deps/brew.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/install-deps/sysctl.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/install-deps/uname.sh"
+)
+
+# These scripts are linted but are not executable in the tree. The container
+# image sets the mode on copy, and the parity library is sourced, not run.
+non_executable_shell_files=(
+  "${ROOT_DIR}/runtime/container/apt-broker.sh"
+  "${ROOT_DIR}/runtime/container/bin/sudo-wrapper.sh"
+  "${ROOT_DIR}/runtime/container/detached-stdin-wrapper.sh"
+  "${ROOT_DIR}/scripts/ci/lib/local-docker-parity.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh"
+  "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-probe.sh"
 )
 
 while IFS= read -r file; do
   shell_files+=("${file}")
 done < <(find "${ROOT_DIR}/tests/scenarios" -type f -name 'test-*.sh' -print | sort)
+
+# The list above is hand-maintained, so a new script can enter the tree
+# unlinted. Assert that the list covers every tracked bash script. Match on the
+# shebang, not on the file suffix: several linted scripts have no `.sh` name.
+declare -A linted_shell_files=()
+for file in "${shell_files[@]}"; do
+  linted_shell_files["${file#"${ROOT_DIR}/"}"]=1
+done
+
+# Bash does not propagate a process-substitution failure, so a `git ls-files`
+# error would leave this check reading an empty inventory and passing. Emit a
+# lone NUL after a successful listing and require it: a truncated listing then
+# fails closed instead of reporting complete coverage over a partial tree.
+unlinted_shell_files=()
+lint_inventory_completed=0
+while IFS= read -r -d '' tracked_path; do
+  if [[ -z "${tracked_path}" ]]; then
+    lint_inventory_completed=1
+    continue
+  fi
+  [[ -n "${linted_shell_files[${tracked_path}]:-}" ]] && continue
+  [[ -f "${ROOT_DIR}/${tracked_path}" ]] || continue
+  IFS= read -r shebang <"${ROOT_DIR}/${tracked_path}" || continue
+  [[ "${shebang}" == '#!'*bash* ]] || continue
+  unlinted_shell_files+=("${tracked_path}")
+done < <(git -C "${ROOT_DIR}" ls-files -z && printf '\0')
+
+if [[ "${lint_inventory_completed}" -ne 1 ]]; then
+  echo "Tracked file listing failed; shell lint coverage is unverified" >&2
+  exit 1
+fi
+
+if [[ "${#unlinted_shell_files[@]}" -gt 0 ]]; then
+  echo "Tracked bash scripts are missing from the validate-repo.sh lint list:" >&2
+  printf '  %s\n' "${unlinted_shell_files[@]}" >&2
+  echo "Add each script to shell_files so it is linted." >&2
+  exit 1
+fi
 
 should_skip_shellcheck_file() {
   local file="$1"
@@ -276,10 +344,34 @@ for file in "${shell_files[@]}"; do
   fi
   shellcheck -x "${file}"
 done
+
+# A lost exit status turns a trust decision into a vacuous pass: an unread
+# inventory looks the same as a clean one. SC2311 and SC2312 detect it, but they
+# are optional checks and stay off by default. Enable them on the scripts where
+# a masked return would admit an unverified release, commit, or public surface.
+# Ratchet: add files as they are cleaned, never remove one.
+fail_open_critical_shell_files=(
+  "${ROOT_DIR}/scripts/verify-release-outputs.sh"
+  "${ROOT_DIR}/scripts/verify-release-artifact.sh"
+  "${ROOT_DIR}"/scripts/check-*.sh
+  "${ROOT_DIR}"/.githooks/*
+)
+for file in "${fail_open_critical_shell_files[@]}"; do
+  shellcheck -x -o check-extra-masked-returns "${file}"
+done
+
 shfmt -ln=bash -i 2 -ci -d "${shell_files[@]}"
 "${ROOT_DIR}/scripts/lint-dockerfiles.sh"
 
+declare -A shell_files_without_exec_bit=()
+for file in "${non_executable_shell_files[@]}"; do
+  shell_files_without_exec_bit["${file}"]=1
+done
+
 for file in "${shell_files[@]}"; do
+  if [[ -n "${shell_files_without_exec_bit[${file}]:-}" ]]; then
+    continue
+  fi
   if [[ ! -x "${file}" ]]; then
     echo "Expected executable script: ${file}" >&2
     exit 1

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -284,9 +284,22 @@ non_executable_shell_files=(
   "${ROOT_DIR}/verify/invariants/harnesses/git-probes/snapshot-probe.sh"
 )
 
+# Capture the scenario-test walk before the loop reads it. This inventory
+# decides which scenario tests get linted at all, so a masked `find` failure
+# would quietly shrink the lint set that the completeness check below then
+# reports as complete. `set -e` with `pipefail` aborts on a failed walk, and an
+# empty result is rejected rather than treated as "no scenario tests".
+scenario_test_listing="$(find "${ROOT_DIR}/tests/scenarios" -type f -name 'test-*.sh' -print | sort)"
+
+if [[ -z "${scenario_test_listing}" ]]; then
+  echo "No scenario tests found under tests/scenarios; refusing a vacuous lint set" >&2
+  exit 1
+fi
+
 while IFS= read -r file; do
+  [[ -n "${file}" ]] || continue
   shell_files+=("${file}")
-done < <(find "${ROOT_DIR}/tests/scenarios" -type f -name 'test-*.sh' -print | sort)
+done <<<"${scenario_test_listing}"
 
 # The list above is hand-maintained, so a new script can enter the tree
 # unlinted. Assert that the list covers every tracked bash script. Match on the
@@ -323,6 +336,7 @@ is_bash_shebang() {
 # skipped before any path is opened.
 unlinted_shell_files=()
 lint_inventory_completed=0
+# shellcheck disable=SC2312 # the NUL sentinel and lint_inventory_completed assertion below are the compensating control
 while IFS= read -r -d '' index_entry; do
   if [[ -z "${index_entry}" ]]; then
     lint_inventory_completed=1

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -330,8 +330,17 @@ is_bash_shebang() {
 
   [[ "${line}" == '#!'* ]] || return 1
   IFS=$' \t' read -r -a tokens <<<"${line#'#!'}"
+  local long_option=""
   for token in "${tokens[@]}"; do
-    token="${token#--split-string=}"
+    # A long option can be abbreviated to any unambiguous prefix, so
+    # `--split-string=`, `--spl=` and `--s=` all introduce the split string.
+    if [[ "${token}" == --*=* ]]; then
+      long_option="${token%%=*}"
+      long_option="${long_option#--}"
+      if [[ -n "${long_option}" && "split-string" == "${long_option}"* ]]; then
+        token="${token#*=}"
+      fi
+    fi
     # A short option cluster can precede the split string, as in `-iSbash`.
     # Take whatever follows the last `S` in such a cluster.
     if [[ "${token}" == -* && "${token}" != --* && "${token}" == *S* ]]; then

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -317,40 +317,80 @@ for file in "${shell_files[@]}"; do
   linted_shell_files["${file#"${ROOT_DIR}/"}"]=1
 done
 
-# Accept only an interpreter whose basename is exactly `bash`. A bare `*bash*`
-# test also matches `#!/usr/bin/env bashful`. Both house forms put `bash` in its
-# own token: `#!/bin/bash -p` and `#!/usr/bin/env -S BASH_ENV= ENV= bash`.
-# `env` accepts the split string attached as well as detached: `-S bash`,
-# `-Sbash` and `--split-string=bash` all run Bash. Strip that option prefix,
-# and strip a quote, before the comparison.
+# Accept only the interpreter that the shebang actually selects. Testing every
+# token matches `#!/usr/bin/env -S echo bash`, which runs `echo`. Resolve the
+# command position instead: the first token is the interpreter, and when that
+# interpreter is `env`, skip its options and its `VAR=value` assignments to
+# reach the command. A split string may be attached or detached and its long
+# option may be abbreviated to any unambiguous prefix, so `-S bash`, `-Sbash`,
+# `-iSbash`, `--split-string=bash` and `--spl=bash` all select Bash.
 is_bash_shebang() {
   local line="$1"
   local -a tokens=()
-  local token=""
+  local token="" long_option="" command="" cluster=""
+  local index=0 position=0
 
   [[ "${line}" == '#!'* ]] || return 1
   IFS=$' \t' read -r -a tokens <<<"${line#'#!'}"
-  local long_option=""
-  for token in "${tokens[@]}"; do
-    # A long option can be abbreviated to any unambiguous prefix, so
-    # `--split-string=`, `--spl=` and `--s=` all introduce the split string.
-    if [[ "${token}" == --*=* ]]; then
-      long_option="${token%%=*}"
-      long_option="${long_option#--}"
-      if [[ -n "${long_option}" && "split-string" == "${long_option}"* ]]; then
-        token="${token#*=}"
-      fi
-    fi
-    # A short option cluster can precede the split string, as in `-iSbash`.
-    # Take whatever follows the last `S` in such a cluster.
-    if [[ "${token}" == -* && "${token}" != --* && "${token}" == *S* ]]; then
-      token="${token##*S}"
-    fi
-    token="${token//\"/}"
-    token="${token//\'/}"
-    [[ "${token##*/}" == "bash" ]] && return 0
-  done
-  return 1
+  [[ "${#tokens[@]}" -gt 0 ]] || return 1
+
+  if [[ "${tokens[0]##*/}" != "env" ]]; then
+    command="${tokens[0]}"
+  else
+    for ((index = 1; index < ${#tokens[@]}; index++)); do
+      token="${tokens[index]}"
+      case "${token}" in
+        --)
+          command="${tokens[index + 1]:-}"
+          break
+          ;;
+        --*=*)
+          long_option="${token%%=*}"
+          long_option="${long_option#--}"
+          if [[ -n "${long_option}" && "split-string" == "${long_option}"* ]]; then
+            token="${token#*=}"
+            if [[ -n "${token}" ]]; then
+              command="${token}"
+              break
+            fi
+          fi
+          ;;
+        -*)
+          # Walk the short option cluster one letter at a time. `S` introduces
+          # the split string, and `u` and `C` take a value that may be attached,
+          # so their argument must not be read as further option letters: the
+          # `S` in `-uPOSIXLY_CORRECT` names a variable, not a split string.
+          cluster="${token#-}"
+          for ((position = 0; position < ${#cluster}; position++)); do
+            case "${cluster:position:1}" in
+              S)
+                # Attached, the command is here. Detached, it follows, after
+                # any further assignments.
+                command="${cluster:position+1}"
+                break
+                ;;
+              u | C)
+                [[ -n "${cluster:position+1}" ]] || ((index++))
+                break
+                ;;
+              *) ;;
+            esac
+          done
+          [[ -z "${command}" ]] || break
+          ;;
+        *=*) ;;
+        *)
+          command="${token}"
+          break
+          ;;
+      esac
+    done
+  fi
+
+  [[ -n "${command}" ]] || return 1
+  command="${command//\"/}"
+  command="${command//\'/}"
+  [[ "${command##*/}" == "bash" ]]
 }
 
 # Read every first-line shebang from the index rather than from the worktree.

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -312,6 +312,8 @@ done
 # Accept only an interpreter whose basename is exactly `bash`. A bare `*bash*`
 # test also matches `#!/usr/bin/env bashful`. Both house forms put `bash` in its
 # own token: `#!/bin/bash -p` and `#!/usr/bin/env -S BASH_ENV= ENV= bash`.
+# `env -S` splits its argument and removes quotes, so `-S "bash" -e` runs Bash.
+# Strip a surrounding quote from each token before the comparison.
 is_bash_shebang() {
   local line="$1"
   local -a tokens=()
@@ -320,10 +322,34 @@ is_bash_shebang() {
   [[ "${line}" == '#!'* ]] || return 1
   IFS=$' \t' read -r -a tokens <<<"${line#'#!'}"
   for token in "${tokens[@]}"; do
+    token="${token//\"/}"
+    token="${token//\'/}"
     [[ "${token##*/}" == "bash" ]] && return 0
   done
   return 1
 }
+
+# Read every first-line shebang from the index rather than from the worktree.
+# A filesystem read trusts the whole path: a symlink at the leaf or at any
+# parent directory redirects it outside the checkout, and no Bash test closes
+# that gap because Bash cannot express fd-relative `openat`. Git resolves a
+# tracked path against the index instead, so no directory component is
+# followed and there is no window between the check and the read. It also
+# removes the end-of-file case, because Git yields the line rather than a
+# `read` status.
+declare -A tracked_shebangs=()
+# shellcheck disable=SC2312 # the non-empty assertion below is the compensating control
+while IFS= read -r -d '' shebang_path &&
+  IFS= read -r -d '' shebang_lineno &&
+  IFS= read -r shebang_line; do
+  [[ "${shebang_lineno}" == "1" ]] || continue
+  tracked_shebangs["${shebang_path}"]="${shebang_line}"
+done < <(git -C "${ROOT_DIR}" grep --cached -z -I -n -E '^#!')
+
+if [[ "${#tracked_shebangs[@]}" -eq 0 ]]; then
+  echo "Tracked shebang inventory is empty; shell lint coverage is unverified" >&2
+  exit 1
+fi
 
 # Bash does not propagate a process-substitution failure, so a `git ls-files`
 # error would leave this check reading an empty inventory and passing. Emit a
@@ -331,9 +357,8 @@ is_bash_shebang() {
 # fails closed instead of reporting complete coverage over a partial tree.
 #
 # `ls-files -s` reports the index mode, so the file type comes from Git rather
-# than from a filesystem probe that a symlink could redirect. Only a regular
-# blob can be a script, so a symlink (120000) and a submodule (160000) are
-# skipped before any path is opened.
+# than from a filesystem probe. Only a regular blob can be a script, so a
+# symlink (120000) and a submodule (160000) are skipped.
 unlinted_shell_files=()
 lint_inventory_completed=0
 # shellcheck disable=SC2312 # the NUL sentinel and lint_inventory_completed assertion below are the compensating control
@@ -346,20 +371,7 @@ while IFS= read -r -d '' index_entry; do
   tracked_path="${index_entry#*$'\t'}"
   [[ "${tracked_mode}" == "100644" || "${tracked_mode}" == "100755" ]] || continue
   [[ -n "${linted_shell_files[${tracked_path}]:-}" ]] && continue
-  # The index says this path is a regular file. A symlink in the worktree
-  # therefore means a replaced path, and reading it would leave the checkout.
-  # Refuse the run rather than read across the boundary or skip the file.
-  if [[ -L "${ROOT_DIR}/${tracked_path}" ]]; then
-    echo "Tracked regular file is a symlink in the worktree: ${tracked_path}" >&2
-    exit 1
-  fi
-  [[ -f "${ROOT_DIR}/${tracked_path}" ]] || continue
-  # `read` reports failure at end of file, but it still populates the variable
-  # when the final line carries no newline. Test the content, not the status,
-  # so a one-line script without a trailing newline is not skipped.
-  shebang=""
-  IFS= read -r shebang <"${ROOT_DIR}/${tracked_path}" || true
-  is_bash_shebang "${shebang}" || continue
+  is_bash_shebang "${tracked_shebangs[${tracked_path}]:-}" || continue
   unlinted_shell_files+=("${tracked_path}")
 done < <(git -C "${ROOT_DIR}" ls-files -sz && printf '\0')
 

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -76,10 +76,18 @@ esac
 
 CITOOLS_BIN=""
 BUILD_CACHE_DIR="${ROOT_DIR}/.workcell-build-cache"
+SHEBANG_STDOUT=""
+SHEBANG_STDERR=""
 
 cleanup() {
   if [[ -n "${CITOOLS_BIN}" && -e "${CITOOLS_BIN}" ]]; then
     rm -f "${CITOOLS_BIN}"
+  fi
+  if [[ -n "${SHEBANG_STDOUT}" && -e "${SHEBANG_STDOUT}" ]]; then
+    rm -f "${SHEBANG_STDOUT}"
+  fi
+  if [[ -n "${SHEBANG_STDERR}" && -e "${SHEBANG_STDERR}" ]]; then
+    rm -f "${SHEBANG_STDERR}"
   fi
   rm -rf "${BUILD_CACHE_DIR}"
 }
@@ -312,8 +320,9 @@ done
 # Accept only an interpreter whose basename is exactly `bash`. A bare `*bash*`
 # test also matches `#!/usr/bin/env bashful`. Both house forms put `bash` in its
 # own token: `#!/bin/bash -p` and `#!/usr/bin/env -S BASH_ENV= ENV= bash`.
-# `env -S` splits its argument and removes quotes, so `-S "bash" -e` runs Bash.
-# Strip a surrounding quote from each token before the comparison.
+# `env` accepts the split string attached as well as detached: `-S bash`,
+# `-Sbash` and `--split-string=bash` all run Bash. Strip that option prefix,
+# and strip a quote, before the comparison.
 is_bash_shebang() {
   local line="$1"
   local -a tokens=()
@@ -322,6 +331,8 @@ is_bash_shebang() {
   [[ "${line}" == '#!'* ]] || return 1
   IFS=$' \t' read -r -a tokens <<<"${line#'#!'}"
   for token in "${tokens[@]}"; do
+    token="${token#--split-string=}"
+    token="${token#-S}"
     token="${token//\"/}"
     token="${token//\'/}"
     [[ "${token##*/}" == "bash" ]] && return 0
@@ -337,14 +348,32 @@ is_bash_shebang() {
 # followed and there is no window between the check and the read. It also
 # removes the end-of-file case, because Git yields the line rather than a
 # `read` status.
+#
+# `git grep` exits 1 only when nothing matched, and the inventory assertion
+# below rejects that. It exits 0 with partial output when an indexed blob is
+# unreadable, and reports the failure on stderr alone. Read it through a file
+# so both channels are testable: a diagnostic means the index was not read
+# completely, and an omitted path would otherwise be classified as "not Bash"
+# and silently left unlinted.
+SHEBANG_STDOUT="$(mktemp "${TMPDIR:-/tmp}/workcell-shebangs.XXXXXX")"
+SHEBANG_STDERR="$(mktemp "${TMPDIR:-/tmp}/workcell-shebang-errors.XXXXXX")"
+shebang_read_status=0
+git -C "${ROOT_DIR}" grep --cached -z -I -n -E '^#!' \
+  >"${SHEBANG_STDOUT}" 2>"${SHEBANG_STDERR}" || shebang_read_status=$?
+
+if [[ "${shebang_read_status}" -gt 1 || -s "${SHEBANG_STDERR}" ]]; then
+  echo "Reading tracked shebangs from the index failed; shell lint coverage is unverified" >&2
+  sed 's/^/  /' "${SHEBANG_STDERR}" >&2
+  exit 1
+fi
+
 declare -A tracked_shebangs=()
-# shellcheck disable=SC2312 # the non-empty assertion below is the compensating control
 while IFS= read -r -d '' shebang_path &&
   IFS= read -r -d '' shebang_lineno &&
   IFS= read -r shebang_line; do
   [[ "${shebang_lineno}" == "1" ]] || continue
   tracked_shebangs["${shebang_path}"]="${shebang_line}"
-done < <(git -C "${ROOT_DIR}" grep --cached -z -I -n -E '^#!')
+done <"${SHEBANG_STDOUT}"
 
 if [[ "${#tracked_shebangs[@]}" -eq 0 ]]; then
   echo "Tracked shebang inventory is empty; shell lint coverage is unverified" >&2

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -296,23 +296,58 @@ for file in "${shell_files[@]}"; do
   linted_shell_files["${file#"${ROOT_DIR}/"}"]=1
 done
 
+# Accept only an interpreter whose basename is exactly `bash`. A bare `*bash*`
+# test also matches `#!/usr/bin/env bashful`. Both house forms put `bash` in its
+# own token: `#!/bin/bash -p` and `#!/usr/bin/env -S BASH_ENV= ENV= bash`.
+is_bash_shebang() {
+  local line="$1"
+  local -a tokens=()
+  local token=""
+
+  [[ "${line}" == '#!'* ]] || return 1
+  IFS=$' \t' read -r -a tokens <<<"${line#'#!'}"
+  for token in "${tokens[@]}"; do
+    [[ "${token##*/}" == "bash" ]] && return 0
+  done
+  return 1
+}
+
 # Bash does not propagate a process-substitution failure, so a `git ls-files`
 # error would leave this check reading an empty inventory and passing. Emit a
 # lone NUL after a successful listing and require it: a truncated listing then
 # fails closed instead of reporting complete coverage over a partial tree.
+#
+# `ls-files -s` reports the index mode, so the file type comes from Git rather
+# than from a filesystem probe that a symlink could redirect. Only a regular
+# blob can be a script, so a symlink (120000) and a submodule (160000) are
+# skipped before any path is opened.
 unlinted_shell_files=()
 lint_inventory_completed=0
-while IFS= read -r -d '' tracked_path; do
-  if [[ -z "${tracked_path}" ]]; then
+while IFS= read -r -d '' index_entry; do
+  if [[ -z "${index_entry}" ]]; then
     lint_inventory_completed=1
     continue
   fi
+  tracked_mode="${index_entry%% *}"
+  tracked_path="${index_entry#*$'\t'}"
+  [[ "${tracked_mode}" == "100644" || "${tracked_mode}" == "100755" ]] || continue
   [[ -n "${linted_shell_files[${tracked_path}]:-}" ]] && continue
+  # The index says this path is a regular file. A symlink in the worktree
+  # therefore means a replaced path, and reading it would leave the checkout.
+  # Refuse the run rather than read across the boundary or skip the file.
+  if [[ -L "${ROOT_DIR}/${tracked_path}" ]]; then
+    echo "Tracked regular file is a symlink in the worktree: ${tracked_path}" >&2
+    exit 1
+  fi
   [[ -f "${ROOT_DIR}/${tracked_path}" ]] || continue
-  IFS= read -r shebang <"${ROOT_DIR}/${tracked_path}" || continue
-  [[ "${shebang}" == '#!'*bash* ]] || continue
+  # `read` reports failure at end of file, but it still populates the variable
+  # when the final line carries no newline. Test the content, not the status,
+  # so a one-line script without a trailing newline is not skipped.
+  shebang=""
+  IFS= read -r shebang <"${ROOT_DIR}/${tracked_path}" || true
+  is_bash_shebang "${shebang}" || continue
   unlinted_shell_files+=("${tracked_path}")
-done < <(git -C "${ROOT_DIR}" ls-files -z && printf '\0')
+done < <(git -C "${ROOT_DIR}" ls-files -sz && printf '\0')
 
 if [[ "${lint_inventory_completed}" -ne 1 ]]; then
   echo "Tracked file listing failed; shell lint coverage is unverified" >&2

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -233,6 +233,7 @@ expected_digest="$(awk -v name="${ARTIFACT}" '$2 == name {print $1}' "${sums_pat
 if [[ -z "${expected_digest}" ]]; then
   fail "SHA256SUMS (verified) has no entry for ${ARTIFACT}; it is not part of this signed release"
 fi
+# shellcheck disable=SC2312 # wc counts an already-captured string; the empty case is rejected above
 if [[ "$(printf '%s\n' "${expected_digest}" | wc -l)" -ne 1 ]]; then
   fail "SHA256SUMS has multiple entries for ${ARTIFACT}; refusing ambiguous match"
 fi

--- a/scripts/verify-release-outputs.sh
+++ b/scripts/verify-release-outputs.sh
@@ -115,6 +115,7 @@ verify_checksum_binding() {
   local actual=""
 
   expected="$(awk -v name="${asset}" '$2 == name {print $1}' "${ASSETS_DIR}/SHA256SUMS")"
+  # shellcheck disable=SC2312 # wc counts an already-captured string; the digest regexp is the gate
   [[ "$(wc -l <<<"${expected}")" -eq 1 && "${expected}" =~ ^[0-9a-f]{64}$ ]] ||
     fail "SHA256SUMS has no unique digest for ${asset}"
   actual="$(sha256_of "${ASSETS_DIR}/${asset}")"
@@ -277,6 +278,7 @@ main() {
   # expect, to report success over an inventory that was never read.
   listed_count=0
   walk_completed=0
+  # shellcheck disable=SC2312 # the NUL sentinel and listed_count assertion below are the compensating control
   while IFS= read -r -d '' path; do
     if [[ -z "${path}" ]]; then
       walk_completed=1


### PR DESCRIPTION
## Summary

This is PR A of the review-invariants program. It adds deterministic counters
for the two largest recurring Codex finding classes.

Together the two classes are 88 of the 281 findings in the PRs 643-685 wave
(31 percent). Against the full history of 1622 findings over PRs 1-686, the
signature class alone is 266.

**Class A - commit signature demands (266 findings across all history, 0
accepted).** The counter already exists and already passes. The waste is review
rounds, not missing code. AGENTS.md now carries a `Standard review
dispositions` section that records the answer for three recurring findings: a
commit signature demand, a check/use gap at a language boundary, and a
staged-by-design series finding. Each disposition closes in one round. The
`workcell-pr-lifecycle` skill applies the dispositions before it reacts.

The signature disposition branches on what the finding cites, because the bot
uses four shapes: an unresolvable full hash, an unresolvable abbreviated hash,
no object at all (13 cases), and an object that resolves and is validly signed
(3 cases). A repeat of this class takes the same recorded disposition without a
new review round, whatever "fresh evidence" framing it carries. Three pull
requests each burned six or more rounds on one repeated finding, so the
disposition does not stop the loop without that rule.

**Class C - fail-open and TOCTOU in shell (28 findings in the wave).** SC2311
and SC2312 detect a masked return value. Both are optional checks and both were
off. They now run over the fail-open-critical subset: the two release verify
scripts, every `scripts/check-*.sh`, and the git hooks.

**Lint-list completeness (the enabler).** The shell lint list in
`scripts/validate-repo.sh` was hand-maintained and had no completeness check.
19 tracked bash scripts were unlinted, including `verify-release-outputs.sh`
and `check-publish-commit-signatures.sh`, and three scripts inside the runtime
container trust boundary. Without this check the masked-return check leaks,
because an unlisted script is never examined. All 19 are now linted and clean.

### Fail-open defects fixed

A process substitution does not propagate its exit status. A failed `git` or
`find` therefore presents as an empty inventory, and an empty inventory passes
every check that only inspects what it collected. These sites are fixed by
capturing the walk before the loop reads it, so `set -e` aborts instead:

| Script | Decision that a masked return would have admitted |
|---|---|
| `check-publish-commit-signatures.sh` | A truncated `rev-list` leaves later commits unverified. |
| `check-pr-shape.sh` (x2) | An unread diff satisfies every shape budget. |
| `check-public-repo-hygiene.sh` (x2) | An unread inventory reports a clean public surface. |
| `check-doc-links.sh` (x2) | An unread docs tree reports no broken links and no orphans. |
| `validate-repo.sh` | An unread scenario walk shrinks the lint set the completeness check then reports as complete. |

The last row is the lint builder's own defect: it built the scenario half of
its lint set through `done < <(find tests/scenarios ...)`.

The remaining hits in the subset are noise. Each one carries a targeted
`shellcheck disable` with a reason. No blanket disable is used, and no
`.shellcheckrc` is added.

### Follow-up

`fail_open_critical_shell_files` is a ratchet list. Add files as they are
cleaned; never remove one.

`scripts/validate-repo.sh` still has 12 masked-return hits in its other
inventories (the Go, JSON, TOML, docs, and Rust walks). They feed different
checks, not the lint list, and are left for a later unit. The file joins the
ratchet subset once they are clean.

`scripts/dev-quick-check.sh` keeps a second hand-maintained shell list and has
no completeness check. It is a local helper and no CI lane calls it, so the
gate belongs in `validate-repo.sh`. A later unit can share one list between the
two scripts.

The Bash shebang classifier is proved by ad-hoc fixtures (22 classifier cases
and several end-to-end proofs against the real check), not by a committed test.
Codex raised this in two rounds and is right that it is a coverage gap.
Registering a scenario test touches the scenario manifest and the coverage
verifier, which would push this PR past its shape budget mid-review, so a
committed fixture is recorded as follow-up rather than dropped.

**Linters still open mutable filesystem paths.** The index-backed change made
*discovery* independent of the filesystem, but `shellcheck`, `shfmt`,
`hadolint`, `markdownlint`, `yamllint`, `mandoc`, `gofmt`, `go build` and
`cargo` are all still handed worktree paths, as they were on `origin/main`
(104 such paths before this PR, 145 after). For the 19 scripts this PR adds to
the list — `runtime/container/apt-broker.sh` among them — the linter read of
that particular path is newly introduced here, even though the mechanism is
pre-existing. Closing this means linting index-backed copies rather than
worktree paths across every tool the script invokes, not just the ShellCheck
passes; guarding those alone would leave the identical read on eight other
tools while implying a containment property the script does not have. That is a
redesign of `validate-repo.sh` rather than an edit to one block. The residual is
disclosure of host file content into validation output on an already-compromised
checkout, not a change in what executes.

S4 through S10 of the program remain unbuilt.

## Testing

- `bash -n`, `shellcheck -x`, and `shfmt -ln=bash -i 2 -ci -d` pass on
  `scripts/validate-repo.sh`.
- ShellCheck 0.10.0 (the version the validator image ships) and 0.11.0 both
  pass over all 145 listed scripts, which is every tracked bash script plus 3
  sourced libraries.
- `-o check-extra-masked-returns` is clean over the whole fail-open-critical
  subset under both ShellCheck versions. The subset had 21 hits before this
  change.
- Negative proof for the completeness check: a new tracked bash script that is
  absent from the list makes the check fail and name the script. Reverted.
- Fail-closed proofs: a failed `git ls-files` reports
  `shell lint coverage is unverified`; an empty shebang inventory reports
  `shell lint coverage is unverified`; a failed scenario walk exits 1; an empty
  scenario directory exits 1. All 22 scenario tests are still collected.
- Defect-class proof for the capture fixes: the old process-substitution form
  exits 0 with a zero-item count over a failed walk. The capture form exits 128
  and never reaches the loop end.
- Whole-tree census: classifying every tracked first-line shebang yields 142
  Bash and 4 non-Bash, and the 4 are the three Rust `#![no_main]` fuzz targets
  and one vendored `#![allow(dead_code)]`. 142 matches the independent count of
  tracked Bash scripts, so the classifier has no false positive and no false
  negative on this tree.
- Classifier fixtures: 46 cases pass, covering every `env` split-string
  spelling (`-S bash`, `-S "bash"`, `-Sbash`, `--split-string=bash`,
  `-iSbash`, `-iS bash`, `-S/bin/bash`, and abbreviations such as `--spl=bash`
  and `--s=bash`), value-taking options in both spellings (`-uFOO bash`,
  `-u FOO bash`, `-C /tmp bash`), `-S echo bash` as the selected-interpreter
  negative, the
  repo's own `env -S -i PATH=... /bin/bash` form, and a matching `bashful`
  negative for each accepted spelling plus `#![no_main]` and
  `#![allow(dead_code)]`.
- Corrupt-blob proof: with one indexed blob removed, the old form built a
  non-empty map that passed the assertion while the affected script was absent
  from it and silently treated as non-Bash. The current form exits 1 and names
  the unreadable path.
- Mutated-checkout proofs, both directions: an index blob of `#!/bin/sh` behind
  a worktree decoy of `#!/bin/bash` is ignored, and an index blob of
  `#!/bin/bash -p` behind a decoy of `#!/bin/sh` is still reported.
- Subset proofs: membership is unchanged at 16 files; an untracked
  `scripts/check-evil.sh` symlink does not enter it; a tracked symlink of that
  name is excluded and is not demanded by the completeness check.
- `./scripts/check-doc-links.sh` passes: 108 markdown files, links and orphans
  clean. `./scripts/check-public-repo-hygiene.sh` passes.
- `./scripts/check-pr-shape.sh` and
  `./scripts/check-publish-commit-signatures.sh` both pass on this branch.
- Control-plane manifest regenerated; manifest and parity verifiers pass.
- markdownlint and codespell pass on the changed docs.
- No Go source is touched, so no Go test lane applies.

### Review round 1

Codex raised three P1 findings, each reproduced before it was fixed, in
`e9f1963e`:

- The **primary** Markdown inventory in `check-doc-links.sh` was still
  fail-open through `git ls-files | grep ... || true`. The first change in this
  branch had covered only the docs-only orphan listing.
- The completeness scan classified paths with `-f`, which follows a symlink. A
  tracked symlink to `/etc/hosts` was read across the checkout boundary.
- The shebang classifier skipped a one-line script with no trailing newline
  (`read` returns 1 at EOF but still populates the variable), and `*bash*`
  matched `#!/usr/bin/env bashful`.

The trap-handler suppressions were also widened to SC2317, because the
validator image ships ShellCheck 0.10.0, which reports the same indirect
invocation under the older code.

### Review round 2

Codex raised two P1 findings and one P2, each reproduced before it was fixed,
in `ad2dd7fd` and `446e8837`:

- The symlink guard was **leaf-only**. A symlinked *parent* directory still
  redirected the read outside the checkout. Rather than add another filesystem
  test, the scan now reads every first-line shebang from the index with
  `git grep --cached`. No directory component is followed and no check/use
  window exists. That removes the leaf case, the parent case, and the
  end-of-file case together, and deletes the `-L` test and the file read.
- The masked-return subset was still built from **filesystem globs**, which
  bypassed that same guard. An untracked `scripts/check-evil.sh` symlink to
  `/etc/hosts` entered the subset and ShellCheck parsed the host file. The
  subset is now selected from the verified `shell_files` inventory, which also
  makes it a guaranteed subset of the lint list.
- `env -S` removes quotes, so `#!/usr/bin/env -S "bash" -e` runs Bash while the
  classifier kept the quotes and silently excluded the script.


### Review round 3

Codex raised three P1 findings. Two were correct and are fixed in `ba2c0592`;
one is rebutted with evidence.

- **Unreadable indexed blob.** `git grep --cached` exits 0 with partial output
  when a blob cannot be read and reports the failure on stderr alone. The
  non-empty assertion passed and the omitted path was classified as not-Bash,
  so it stayed unlinted. That is an error treated as absence. The read now goes
  through a file so both channels are testable: any stderr diagnostic, or an
  exit status above 1, fails the run and names the path. Removing the process
  substitution also retired an SC2312 suppression.
- **Attached `env` split strings.** `-Sbash` and `--split-string=bash` both run
  Bash and both were silently excluded. Both prefixes are now stripped before
  the basename comparison.
- **Contract fixtures for control-plane edits — rebutted.** No fixture binds
  the content of the edited scripts. The current `sudo-wrapper.sh` digest
  appears in exactly one file in the tree, the manifest itself, which was
  regenerated. `docs/adapter-control-planes.md` carries no digests. The Go
  references are repo-path to runtime-path mappings that a comment-only edit
  does not change. The manifest, parity, lockstep and Go contract gates all
  pass, and `Container smoke` — the gate that rejected the stale digests
  earlier in this PR — is green.

### Review round 4

Codex raised two P1 findings and one P2. Two are fixed in `b277fbbf`; one is
recorded as staged work.

- **Binary blobs bypassed the gate.** `git grep -I` treats a blob holding a NUL
  byte as binary and omits it with no error, while Bash still runs the script.
  Reproduced with a tracked `scripts/nulscript.sh` that executed normally but
  was absent from the `-I` listing, so it was classified as not-Bash and left
  unlinted. The listing now uses `-a`. The tracked shebang count is unchanged
  at 146, so the wider read pulled in no spurious matches.
- **Combined `env` options.** `#!/usr/bin/env -iSbash` runs Bash, but the
  classifier stripped `-S` only at the start of a token. It now takes whatever
  follows the last `S` in a short option cluster, with a matching `bashful`
  negative for every accepted spelling.
- **Linters on mutable paths — staged.** See the follow-up section above.
- **Abbreviated `env` long options.** A long option accepts any unambiguous
  prefix, so `--spl=bash` and `--s=bash` also run Bash. The classifier now
  matches on the prefix relation — a `--name=value` token contributes its value
  when `name` is a prefix of `split-string` — rather than on a list of literal
  spellings, which closes the series instead of its next member. `--foo=bash`
  and `--ignore-environment=bash` are rejected as negative controls.

### Review round 5

Codex raised one P1 and one P2. The P1 is the staged item re-raised; the P2 is
fixed in `14edf09a`.

- **Selected interpreter.** The classifier tested every token, so
  `#!/usr/bin/env -S echo bash` matched even though `env` selects `echo` there
  (confirmed by executing such a file). It now resolves the command position:
  the first token is the interpreter, and when that is `env`, its options and
  `VAR=value` assignments are skipped to reach the command.
- Implementing that exposed a defect the finding did not name: scanning a short
  option cluster for `S` matched the `S` inside `-uPOSIXLY_CORRECT`, so this
  repository's own `#!/usr/bin/env -S -uPOSIXLY_CORRECT ... bash -p` form
  classified as **not** Bash. It was already listed, so the gate stayed silent.
  Clusters are now walked one letter at a time, because `u` and `C` take a value
  that must not be read as further option letters. The whole-tree census is what
  caught this.
- **Linters on mutable paths — staged, re-raised.** See the follow-up section
  above, which now records the newly-added-paths point.
- **Unresolvable interpreter.** `env -S` expands a variable reference and
  substitutes an empty string for an unset one, so
  `#!/usr/bin/env -S /bin/ba${UNSET}sh` runs Bash (confirmed by executing such a
  file) while the literal comparison returned false, letting an unlisted script
  escape the gate. The value cannot be resolved from the shebang, so an
  unresolvable command is now reported as a candidate — failing closed, a
  visible demand rather than a silent gap. No first-line shebang in this tree
  contains a variable reference, so the guard adds no demand here; the three
  `$`-bearing matches are heredoc fixtures on later lines of
  `scripts/container-smoke.sh`.