### PR TITLE
Add an advisory hostile-environment lane, a production sun_path bound and passwd parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,55 @@ jobs:
       - name: Run Workcell container smoke
         run: ./scripts/container-smoke.sh
 
+  hostile-tmpdir:
+    name: Hostile TMPDIR (advisory)
+    # Reruns repository validation with TMPDIR pointed at a directory whose name
+    # holds a space, a literal $, a --prefixed token and 80 characters of
+    # padding.  Three separate review findings -- a value quoted with Go's %q
+    # and then re-expanded by bash, an argv flattened through $*, and a
+    # --hostname check that matched a substring of a path -- were each first
+    # reproduced by hand exactly that way, so this lane reproduces the class
+    # before review instead of during it.
+    #
+    # Advisory while its first failures are triaged: the job is deliberately
+    # absent from required_status_checks in policy/github-hosted-controls.toml
+    # and carries continue-on-error, so a red run reports without blocking a
+    # merge.  Gated on validate rather than pr-shape so the validator image
+    # layers are already in the shared buildx cache scope when this build runs.
+    continue-on-error: true
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          cache-binary: true
+          driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
+          version: ${{ env.WORKCELL_BUILDX_VERSION }}
+
+      - name: Validate repository under a hostile TMPDIR
+        env:
+          WORKCELL_VALIDATOR_IMAGE: workcell-validator:${{ github.sha }}
+          WORKCELL_VALIDATOR_BUILDX_CACHE_MODE: gha
+          WORKCELL_VALIDATOR_BUILDX_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('validator-pr-{0}', github.event.pull_request.number) || 'validator-main' }}
+          WORKCELL_VALIDATOR_BUILDX_CACHE_WRITE_MODE: ${{ github.event_name == 'push' && 'max' || 'min' }}
+          WORKCELL_VALIDATE_REPO_PROFILE: repo-core
+          WORKCELL_HOSTILE_TMPDIR: "1"
+        run: |
+          built_image="$(./scripts/ci/build-validator-image.sh)"
+          if [[ "${built_image}" != "${WORKCELL_VALIDATOR_IMAGE}" ]]; then
+            echo "Validator image builder returned an unexpected reference" >&2
+            exit 1
+          fi
+          ./scripts/ci/run-validate-in-validator.sh
+
   release-asset-acl:
     name: Release asset ACL (Darwin)
     needs: pr-shape

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,27 +134,43 @@ jobs:
       - name: Run Workcell container smoke
         run: ./scripts/container-smoke.sh
 
-  hostile-tmpdir:
-    name: Hostile TMPDIR (advisory)
-    # Reruns repository validation with TMPDIR pointed at a directory whose name
-    # holds a space, a literal $, a --prefixed token and 80 characters of
-    # padding.  Three separate review findings -- a value quoted with Go's %q
-    # and then re-expanded by bash, an argv flattened through $*, and a
-    # --hostname check that matched a substring of a path -- were each first
-    # reproduced by hand exactly that way, so this lane reproduces the class
-    # before review instead of during it.
+  hostile-env:
+    name: Hostile environment (${{ matrix.axis }})
+    # Reruns repository validation once per hostile axis.  Each axis is a shape
+    # that review has already caught defects with, reproduced here before review
+    # instead of during it:
     #
-    # Advisory while its first failures are triaged: the job is deliberately
+    #   tmpdir     TMPDIR whose name holds a space, a literal $, a --prefixed
+    #              token and 80 characters of padding.  Reproduced a value
+    #              quoted with Go's %q and re-expanded by bash, an argv
+    #              flattened through $*, and a --hostname check that matched a
+    #              substring of a path.
+    #   workspace  bind source holding a space and a comma.  The --mount record
+    #              is CSV, so the comma has to survive the encoder.
+    #   root       the container runs as uid 0, where a chmod assertion and a
+    #              write-only read assertion stop holding.
+    #   uidmap     the container runs as a uid that owns none of the bind and
+    #              that the image has no passwd record for.
+    #
+    # Advisory while the first failures are triaged: these jobs are deliberately
     # absent from required_status_checks in policy/github-hosted-controls.toml
-    # and carries continue-on-error, so a red run reports without blocking a
+    # and carry continue-on-error, so a red run reports without blocking a
     # merge.  Gated on validate rather than pr-shape so the validator image
-    # layers are already in the shared buildx cache scope when this build runs.
+    # layers are already in the shared buildx cache scope when these builds run.
     continue-on-error: true
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - axis: tmpdir
+          - axis: workspace
+          - axis: root
+          - axis: uidmap
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -167,14 +183,14 @@ jobs:
           driver-opts: image=${{ env.WORKCELL_BUILDKIT_IMAGE }}
           version: ${{ env.WORKCELL_BUILDX_VERSION }}
 
-      - name: Validate repository under a hostile TMPDIR
+      - name: Validate repository under a hostile environment
         env:
           WORKCELL_VALIDATOR_IMAGE: workcell-validator:${{ github.sha }}
           WORKCELL_VALIDATOR_BUILDX_CACHE_MODE: gha
           WORKCELL_VALIDATOR_BUILDX_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('validator-pr-{0}', github.event.pull_request.number) || 'validator-main' }}
           WORKCELL_VALIDATOR_BUILDX_CACHE_WRITE_MODE: ${{ github.event_name == 'push' && 'max' || 'min' }}
           WORKCELL_VALIDATE_REPO_PROFILE: repo-core
-          WORKCELL_HOSTILE_TMPDIR: "1"
+          WORKCELL_HOSTILE_ENV: ${{ matrix.axis }}
         run: |
           built_image="$(./scripts/ci/build-validator-image.sh)"
           if [[ "${built_image}" != "${WORKCELL_VALIDATOR_IMAGE}" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,12 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # One axis at a time.  The first run of this matrix built the validator
+      # image four times at once and two of the four died with curl exit 22
+      # fetching the pinned Debian snapshot, so the lane reported an
+      # infrastructure failure rather than a repository result.  Serialized, the
+      # first build populates the shared buildx cache scope the rest read.
+      max-parallel: 1
       matrix:
         include:
           - axis: tmpdir

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -42,7 +42,7 @@ For an approved large adapter PR, use both required options:
 | --- | --- |
 | `bench.yml` | Measures exec-guard performance on a schedule or manual run. |
 | `ci-insights.yml` | Writes weekly flake and cost reports. See [CI reliability](ci-efficiency-and-reliability.md). |
-| `ci.yml` | Runs repository validation, smoke tests, reproducibility, install checks, and PR-shape checks. |
+| `ci.yml` | Runs repository validation, smoke tests, reproducibility, install checks, PR-shape checks, and advisory hostile-environment reruns. |
 | `codeql.yml` | Scans the shipped Go, Rust, and JavaScript code. |
 | `docs.yml` | Checks spelling, links, contracts, and the man page. |
 | `fuzz.yml` | Runs extended Go and Rust fuzz tests. |
@@ -60,6 +60,18 @@ For an approved large adapter PR, use both required options:
 Normal PRs run the required deterministic lanes.
 The `Release asset ACL (Darwin)` lane runs on every PR and `main` push.
 It uses `macos-15` and checks the exact Go toolchain.
+
+The `Hostile environment` lanes run repository validation again on one hostile axis each.
+`WORKCELL_HOSTILE_ENV` selects the axis:
+
+- `tmpdir` puts `TMPDIR` in a directory whose name has a space, a literal `$`, a `--` token, and 80 characters of padding.
+- `workspace` copies the checkout to a bind source whose name has a space and a comma. The `--mount` record is CSV, so the comma must survive the encoder.
+- `root` runs the container as UID 0.
+- `uidmap` runs the container as a UID that owns none of the bind and has no record in the image.
+
+These shapes reproduce quoting, argument-boundary, mount-record, and `sun_path` defects before review.
+The lanes are advisory: they use `continue-on-error` and are not required checks.
+Run one axis on a host with `WORKCELL_HOSTILE_ENV=tmpdir ./scripts/ci/run-validate-in-validator.sh`.
 
 The `approved-heavy-ci` label enables these expensive PR lanes:
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -71,7 +71,15 @@ The `Hostile environment` lanes run repository validation again on one hostile a
 
 These shapes reproduce quoting, argument-boundary, mount-record, and `sun_path` defects before review.
 The lanes are advisory: they use `continue-on-error` and are not required checks.
-Run one axis on a host with `WORKCELL_HOSTILE_ENV=tmpdir ./scripts/ci/run-validate-in-validator.sh`.
+Run one axis on a host the same way the lane does, with Docker available:
+
+```bash
+export WORKCELL_VALIDATOR_IMAGE="workcell-validator:local"
+./scripts/ci/build-validator-image.sh
+WORKCELL_VALIDATE_REPO_PROFILE=repo-core \
+  WORKCELL_HOSTILE_ENV=tmpdir \
+  ./scripts/ci/run-validate-in-validator.sh
+```
 
 The `approved-heavy-ci` label enables these expensive PR lanes:
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -201,9 +201,10 @@ A new publisher requires a reviewed policy change.
 `ci.yml` and `docs.yml` run the validator as the caller UID and GID.
 They use separate writable home, cache, and temporary roots.
 The launcher creates an isolated home if the caller has no passwd entry.
-Each validator lane also mounts a synthesized `/etc/passwd` record for that UID.
+Each validator lane in `ci.yml` and `docs.yml` also mounts a synthesized `/etc/passwd` record for that UID, and `scripts/build-and-test.sh --docker` does the same.
 `scripts/ci/lib/validator-passwd.sh` writes the record.
 A UID with no record breaks each tool that resolves the invoking user, such as `ssh-keygen`.
+The `Validate repository` step in `release.yml` runs its own container and does not mount that record yet.
 
 The mirrored local jobs are under `scripts/ci/`.
 Workflow YAML controls events, permissions, runners, and hosted-only steps.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -60,6 +60,7 @@ For an approved large adapter PR, use both required options:
 Normal PRs run the required deterministic lanes.
 The `Release asset ACL (Darwin)` lane runs on every PR and `main` push.
 It uses `macos-15` and checks the exact Go toolchain.
+
 The `approved-heavy-ci` label enables these expensive PR lanes:
 
 - native amd64 and arm64 reproducible builds
@@ -188,6 +189,9 @@ A new publisher requires a reviewed policy change.
 `ci.yml` and `docs.yml` run the validator as the caller UID and GID.
 They use separate writable home, cache, and temporary roots.
 The launcher creates an isolated home if the caller has no passwd entry.
+Each validator lane also mounts a synthesized `/etc/passwd` record for that UID.
+`scripts/ci/lib/validator-passwd.sh` writes the record.
+A UID with no record breaks each tool that resolves the invoking user, such as `ssh-keygen`.
 
 The mirrored local jobs are under `scripts/ci/`.
 Workflow YAML controls events, permissions, runners, and hosted-only steps.

--- a/internal/aptbroker/client.go
+++ b/internal/aptbroker/client.go
@@ -58,6 +58,9 @@ func dialBroker(ctx context.Context, socketPath string) (*net.UnixConn, error) {
 	if socketPath == "" {
 		socketPath = DefaultSocketPath
 	}
+	if err := checkSocketPathLength(socketPath); err != nil {
+		return nil, err
+	}
 	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	if err != nil {
 		return nil, err

--- a/internal/aptbroker/protocol.go
+++ b/internal/aptbroker/protocol.go
@@ -23,7 +23,29 @@ const (
 	responseMagic    = "WCRS"
 	frameHeaderSize  = 9
 	responseBaseSize = 10
+
+	// AF_UNIX copies the pathname into the fixed sun_path field of struct
+	// sockaddr_un: 108 bytes on Linux and 104 on macOS, both counting the NUL
+	// terminator.  Past that, bind() and connect() fail with a bare EINVAL that
+	// reads as a kernel fault rather than as an over-long state root, which is
+	// how a long TMPDIR reaches this package.  The bound is the smaller of the
+	// two limits so the diagnostic is identical on every platform Workcell
+	// builds on; the 104..107-byte window that Linux alone would accept is
+	// rejected with the same actionable message instead of binding on one host
+	// and failing on another.
+	maxSocketPathLength = 103
 )
+
+// checkSocketPathLength rejects a pathname that cannot fit in sun_path before
+// it reaches bind() or connect(), so the caller is told which path was too long
+// and by how much.
+func checkSocketPathLength(path string) error {
+	if len(path) > maxSocketPathLength {
+		return fmt.Errorf("apt broker socket path is %d bytes, over the %d-byte AF_UNIX limit: %s",
+			len(path), maxSocketPathLength, path)
+	}
+	return nil
+}
 
 var allowedEnvironmentValues = map[string]map[string]struct{}{
 	"APT_LISTCHANGES_FRONTEND": {

--- a/internal/aptbroker/protocol_test.go
+++ b/internal/aptbroker/protocol_test.go
@@ -5,8 +5,10 @@ package aptbroker
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -248,4 +250,29 @@ func requestBodyWithDuplicateEnvironment(t *testing.T) []byte {
 		writeString(&body, "noninteractive")
 	}
 	return body.Bytes()
+}
+
+// A pathname past sun_path must be refused with a message naming the limit and
+// the offending length, not with the kernel's bare "invalid argument", and both
+// endpoints must refuse it before they touch the filesystem.  A long TMPDIR is
+// how an over-long path reaches this package, which is also why the suite's own
+// binds go through shortSocketDir.
+func TestSocketPathOverSunPathLimitIsRejectedWithTheLimit(t *testing.T) {
+	over := "/tmp/" + strings.Repeat("p", maxSocketPathLength) + "/socket"
+	atLimit := "/tmp/" + strings.Repeat("p", maxSocketPathLength-len("/tmp//socket")) + "/socket"
+	if len(atLimit) != maxSocketPathLength {
+		t.Fatalf("boundary fixture is %d bytes, want %d", len(atLimit), maxSocketPathLength)
+	}
+	want := fmt.Sprintf("apt broker socket path is %d bytes, over the %d-byte AF_UNIX limit: %s",
+		len(over), maxSocketPathLength, over)
+
+	if _, err := listenSocket(over, false); err == nil || err.Error() != want {
+		t.Fatalf("listenSocket error = %v, want %s", err, want)
+	}
+	if _, err := dialBroker(context.Background(), over); err == nil || err.Error() != want {
+		t.Fatalf("dialBroker error = %v, want %s", err, want)
+	}
+	if err := checkSocketPathLength(atLimit); err != nil {
+		t.Fatalf("path at the limit rejected: %v", err)
+	}
 }

--- a/internal/aptbroker/server.go
+++ b/internal/aptbroker/server.go
@@ -248,6 +248,9 @@ func closeConnectionOnCancel(ctx context.Context, connection *net.UnixConn, fini
 }
 
 func listenSocket(path string, requireRoot bool) (*net.UnixListener, error) {
+	if err := checkSocketPathLength(path); err != nil {
+		return nil, err
+	}
 	if err := validateSocketParent(filepath.Dir(path), requireRoot); err != nil {
 		return nil, err
 	}

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -557,7 +557,7 @@ func TestValidatorLanesMountSynthesizedPasswd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			lane := string(content)
+			lane := activeShellLines(string(content))
 			if !strings.Contains(lane, "scripts/ci/lib/validator-passwd.sh") {
 				t.Fatalf("%s must use the shared passwd synthesis library", rel)
 			}
@@ -573,56 +573,87 @@ func TestValidatorLanesMountSynthesizedPasswd(t *testing.T) {
 	}
 }
 
-// The hostile lane earns its runtime only while TMPDIR keeps every shape that
-// reproduced a finding by hand, so the derivation is executed here rather than
-// pattern-matched: a dropped backslash that lets bash expand $HOME, or a
-// shortened padding component, leaves the lane green for the wrong reason.
-func TestHostileTMPDIRKeepsTheShapesThatReproducedFindings(t *testing.T) {
+// The passwd artifact has to land inside the workspace the caller preflighted.
+// mkdir -p and mktemp both follow a symlinked tmp without complaint, which
+// would move the create, the mode change and the removal somewhere else, so the
+// library gates on the canonical path.  The symlinked case is its negative
+// fixture.
+func TestValidatorPasswdRefusesSymlinkedWorkspaceTmp(t *testing.T) {
 	t.Parallel()
 
-	root := repoRoot(t)
-	lane := filepath.Join(root, "scripts", "ci", "run-validate-in-validator.sh")
-	content, err := os.ReadFile(lane)
-	if err != nil {
-		t.Fatal(err)
-	}
-	derivation := ""
-	for _, line := range strings.Split(string(content), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), `validator_tmp="${validator_tmp}/`) {
-			derivation = strings.TrimSpace(line)
-			break
+	library := filepath.Join(repoRoot(t), "scripts", "ci", "lib", "validator-passwd.sh")
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "docker", "#!/bin/bash\nprintf 'root:x:0:0:root:/root:/bin/bash\\n'\n")
+	probe := writeExecutable(t, t.TempDir(), "probe", `#!/bin/bash
+set -euo pipefail
+PATH="$1:${PATH}"
+export PATH
+source "$2"
+workcell_ci_validator_passwd_file docker fixture-image 1000 1000 /home/fixture "$3"
+`)
+
+	for _, symlinked := range []bool{false, true} {
+		symlinked := symlinked
+		name := "plain tmp"
+		if symlinked {
+			name = "symlinked tmp"
 		}
-	}
-	if derivation == "" {
-		t.Fatal("run-validate-in-validator.sh no longer derives a hostile TMPDIR")
-	}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	script := `validator_tmp="/tmp/workcell-home-1000/.tmp"; ` + derivation + `; printf '%s' "${validator_tmp}"`
-	command := exec.Command("/bin/bash", "-c", script)
-	command.Env = append(os.Environ(), "HOME=/hostile-home-must-not-expand")
-	output, err := command.Output()
-	if err != nil {
-		t.Fatalf("hostile TMPDIR derivation failed: %v", err)
+			workspace := t.TempDir()
+			if symlinked {
+				if err := os.Symlink(t.TempDir(), filepath.Join(workspace, "tmp")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			output, err := exec.Command("/bin/bash", probe, binDir, library, workspace).CombinedOutput()
+			if symlinked {
+				if err == nil || !strings.Contains(string(output), "is not the canonical") {
+					t.Fatalf("symlinked tmp accepted: %v\n%s", err, output)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("plain tmp refused: %v\n%s", err, output)
+			}
+			canonical, err := filepath.EvalSymlinks(workspace)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.TrimSpace(string(output)); !strings.HasPrefix(got, filepath.Join(canonical, "tmp")+"/") {
+				t.Fatalf("passwd artifact = %q, want a file under %q", got, canonical)
+			}
+		})
 	}
-	hostile := string(output)
+}
 
-	if !strings.Contains(hostile, " ") {
-		t.Fatalf("hostile TMPDIR %q has no whitespace component", hostile)
+// activeShellLines drops whole-line comments so a lane cannot satisfy a check
+// with the statement it commented out.  A trailing comment is left alone: it
+// cannot carry a statement, and cutting at the first "#" would corrupt a
+// pathname or a parameter expansion that contains one.
+func activeShellLines(script string) string {
+	active := make([]string, 0, strings.Count(script, "\n")+1)
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		active = append(active, line)
 	}
-	if !strings.Contains(hostile, "$") {
-		t.Fatalf("hostile TMPDIR %q has no unexpanded dollar sign", hostile)
+	return strings.Join(active, "\n")
+}
+
+// The negative fixture for activeShellLines: a commented-out source statement
+// must not read as coverage.
+func TestActiveShellLinesDropsCommentedStatements(t *testing.T) {
+	t.Parallel()
+
+	commented := "  # source \"${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh\"\n#!/bin/bash\n"
+	if got := activeShellLines(commented); strings.Contains(got, "validator-passwd.sh") {
+		t.Fatalf("commented statement survived comment stripping: %q", got)
 	}
-	option, padded := false, false
-	for _, word := range strings.Fields(hostile) {
-		option = option || strings.HasPrefix(word, "--")
-	}
-	for _, component := range strings.Split(hostile, "/") {
-		padded = padded || len(component) >= 80
-	}
-	if !option {
-		t.Fatalf("hostile TMPDIR %q has no --prefixed token", hostile)
-	}
-	if !padded {
-		t.Fatalf("hostile TMPDIR %q has no ~80-character padding component", hostile)
+	live := "source \"${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh\" # keep the trailing comment\n"
+	if got := activeShellLines(live); !strings.Contains(got, "# keep the trailing comment") {
+		t.Fatalf("live statement lost its trailing comment: %q", got)
 	}
 }

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -755,6 +755,67 @@ func hasOptionToken(path string) bool {
 	return false
 }
 
+// activeShellLines drops whole-line comments, so a commented-out statement
+// cannot satisfy a check that the live one no longer does.  A trailing comment
+// is left alone: it cannot carry a statement, and cutting at the first "#"
+// would corrupt a pathname or a parameter expansion that contains one.
+func activeShellLines(script string) string {
+	active := make([]string, 0, strings.Count(script, "\n")+1)
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		active = append(active, line)
+	}
+	return strings.Join(active, "\n")
+}
+
+// hostileDerivation returns the one active assignment that derives an axis.
+// It refuses a script carrying a heredoc or here-string, because the same text
+// inside one would read as live code to a line matcher, and it refuses anything
+// other than exactly one match, so a copy left behind by an edit cannot stand in
+// for the statement the lane runs.  The `<<` guard is deliberately blunt: if a
+// lane ever needs one, this matcher needs a shell parser rather than a
+// loosened check.
+func hostileDerivation(script, prefix string) (string, error) {
+	active := activeShellLines(script)
+	if strings.Contains(active, "<<") {
+		return "", fmt.Errorf("script carries a heredoc, here-string or shift; the matcher needs a shell parser")
+	}
+	matches := []string{}
+	for _, line := range strings.Split(active, "\n") {
+		if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, prefix) {
+			matches = append(matches, trimmed)
+		}
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("want exactly one active %q assignment, got %d", prefix, len(matches))
+	}
+	return matches[0], nil
+}
+
+// The negative fixtures for hostileDerivation: the assignment inside a heredoc
+// is inert, and a duplicate leaves the matcher no single statement to run.
+func TestHostileDerivationRejectsInertAndAmbiguousText(t *testing.T) {
+	t.Parallel()
+
+	prefix := `validator_tmp="${validator_tmp}/`
+	live := prefix + `hostile"` + "\n"
+	for name, script := range map[string]string{
+		"heredoc":   "cat <<'EOF'\n" + live + "EOF\n",
+		"duplicate": live + live,
+		"absent":    "validator_tmp=\"/tmp\"\n",
+	} {
+		if _, err := hostileDerivation(script, prefix); err == nil {
+			t.Fatalf("%s script accepted as a derivation", name)
+		}
+	}
+	got, err := hostileDerivation(live, prefix)
+	if err != nil || got != strings.TrimSpace(live) {
+		t.Fatalf("live assignment = %q, %v", got, err)
+	}
+}
+
 // runHostileDerivation executes the single assignment the lane derives an axis
 // with, so the test reads the value bash produces instead of the source text.
 func runHostileDerivation(t *testing.T, prefix, preset, variable string) string {
@@ -765,18 +826,9 @@ func runHostileDerivation(t *testing.T, prefix, preset, variable string) string 
 	if err != nil {
 		t.Fatal(err)
 	}
-	derivation := ""
-	for _, line := range strings.Split(string(content), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
-			continue
-		}
-		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
-			derivation = strings.TrimSpace(line)
-			break
-		}
-	}
-	if derivation == "" {
-		t.Fatalf("run-validate-in-validator.sh no longer derives %s", variable)
+	derivation, err := hostileDerivation(string(content), prefix)
+	if err != nil {
+		t.Fatalf("run-validate-in-validator.sh no longer derives %s: %v", variable, err)
 	}
 	script := preset + "; " + derivation + `; printf '%s' "${` + variable + `}"`
 	command := exec.Command("/bin/bash", "-c", script)

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -528,3 +528,47 @@ func stringsFromNUL(data []byte) []string {
 	}
 	return result
 }
+
+// Every validator lane runs its workload as a uid the image has no /etc/passwd
+// record for, so a lane without the synthesized entry loses ssh-keygen, and
+// with it git's ssh signing and verification.  The synthesis lives in one
+// library precisely so a lane cannot half-adopt it: this test fails when a lane
+// stops sourcing it, calls it more than once, or drops the read-only mount.
+func TestValidatorLanesMountSynthesizedPasswd(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	validatorMounts := []string{
+		`workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd`,
+		`--mount "${validator_passwd_mount}"`,
+	}
+	for rel, mounts := range map[string][]string{
+		"scripts/ci/run-docs-in-validator.sh":     validatorMounts,
+		"scripts/ci/run-fuzz-in-validator.sh":     validatorMounts,
+		"scripts/ci/run-mutation-in-validator.sh": validatorMounts,
+		"scripts/ci/run-validate-in-validator.sh": validatorMounts,
+		"scripts/build-and-test.sh":               {`-v "${passwd_file}:/etc/passwd:ro"`},
+	} {
+		rel, mounts := rel, mounts
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			lane := string(content)
+			if !strings.Contains(lane, "scripts/ci/lib/validator-passwd.sh") {
+				t.Fatalf("%s must use the shared passwd synthesis library", rel)
+			}
+			if got := strings.Count(lane, "workcell_ci_validator_passwd_file"); got != 1 {
+				t.Fatalf("%s calls the passwd synthesis %d times, want 1", rel, got)
+			}
+			for _, mount := range mounts {
+				if !strings.Contains(lane, mount) {
+					t.Fatalf("%s must mount the synthesized passwd file: %s", rel, mount)
+				}
+			}
+		})
+	}
+}

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -632,6 +632,31 @@ workcell_ci_validator_passwd_file docker fixture-image 1000 1000 /home/fixture "
 	}
 }
 
+// A failing lookup must not read as "the image has no record for this uid".
+// Folding awk's error status into the absent case would append a second record
+// for a uid the image already carries, and glibc resolves to whichever record
+// comes first.
+func TestValidatorPasswdFailsClosedWhenTheLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	library := filepath.Join(repoRoot(t), "scripts", "ci", "lib", "validator-passwd.sh")
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "docker", "#!/bin/bash\nprintf 'root:x:0:0:root:/root:/bin/bash\\n'\n")
+	writeExecutable(t, binDir, "awk", "#!/bin/bash\necho 'awk: fixture read error' >&2\nexit 2\n")
+	probe := writeExecutable(t, t.TempDir(), "probe", `#!/bin/bash
+set -euo pipefail
+PATH="$1:${PATH}"
+export PATH
+source "$2"
+workcell_ci_validator_passwd_file docker fixture-image 1000 1000 /home/fixture "$3"
+`)
+
+	output, err := exec.Command("/bin/bash", probe, binDir, library, t.TempDir()).CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "Validator passwd lookup failed with status 2") {
+		t.Fatalf("failing lookup accepted: %v\n%s", err, output)
+	}
+}
+
 // The hostile lane earns its runtime only while each axis keeps the shapes that
 // reproduced a finding by hand, so the derivations are executed here rather
 // than pattern-matched: a dropped backslash that lets bash expand $HOME, a

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -771,27 +771,53 @@ func activeShellLines(script string) string {
 }
 
 // hostileDerivation returns the one active assignment that derives an axis.
-// It refuses a script carrying a heredoc or here-string, because the same text
-// inside one would read as live code to a line matcher, and it refuses anything
-// other than exactly one match, so a copy left behind by an edit cannot stand in
-// for the statement the lane runs.  The `<<` guard is deliberately blunt: if a
-// lane ever needs one, this matcher needs a shell parser rather than a
-// loosened check.
+// A line only counts when the script text before it leaves no quote open and
+// carries no heredoc, so the same text inside a multiline string or a heredoc
+// body is inert here as it is to bash.  Exactly one match is required as well,
+// so a copy left behind by an edit cannot stand in for the statement the lane
+// runs.  The `<<` guard is deliberately blunt: if a lane ever needs a heredoc,
+// this matcher needs a real shell parser rather than a loosened check.
 func hostileDerivation(script, prefix string) (string, error) {
 	active := activeShellLines(script)
 	if strings.Contains(active, "<<") {
 		return "", fmt.Errorf("script carries a heredoc, here-string or shift; the matcher needs a shell parser")
 	}
 	matches := []string{}
+	offset := 0
 	for _, line := range strings.Split(active, "\n") {
-		if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, prefix) {
+		if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, prefix) && !insideQuotedString(active[:offset]) {
 			matches = append(matches, trimmed)
 		}
+		offset += len(line) + 1
 	}
 	if len(matches) != 1 {
 		return "", fmt.Errorf("want exactly one active %q assignment, got %d", prefix, len(matches))
 	}
 	return matches[0], nil
+}
+
+// insideQuotedString reports whether the text leaves a single- or double-quoted
+// string open.  Bash takes a backslash literally inside single quotes, so the
+// escape only applies outside them.
+func insideQuotedString(text string) bool {
+	single, double := false, false
+	for index := 0; index < len(text); index++ {
+		switch text[index] {
+		case '\\':
+			if !single {
+				index++
+			}
+		case '\'':
+			if !double {
+				single = !single
+			}
+		case '"':
+			if !single {
+				double = !double
+			}
+		}
+	}
+	return single || double
 }
 
 // The negative fixtures for hostileDerivation: the assignment inside a heredoc
@@ -802,9 +828,10 @@ func TestHostileDerivationRejectsInertAndAmbiguousText(t *testing.T) {
 	prefix := `validator_tmp="${validator_tmp}/`
 	live := prefix + `hostile"` + "\n"
 	for name, script := range map[string]string{
-		"heredoc":   "cat <<'EOF'\n" + live + "EOF\n",
-		"duplicate": live + live,
-		"absent":    "validator_tmp=\"/tmp\"\n",
+		"heredoc":          "cat <<'EOF'\n" + live + "EOF\n",
+		"quoted multiline": "printf '%s' '\n" + live + "'\n",
+		"duplicate":        live + live,
+		"absent":           "validator_tmp=\"/tmp\"\n",
 	} {
 		if _, err := hostileDerivation(script, prefix); err == nil {
 			t.Fatalf("%s script accepted as a derivation", name)

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -657,6 +657,29 @@ workcell_ci_validator_passwd_file docker fixture-image 1000 1000 /home/fixture "
 	}
 }
 
+// The record is colon-delimited, and the dev-side home is derived from
+// ${TMPDIR}, where a colon is legal.  Writing one into the home field would
+// truncate it and shift every field after it, so the field is refused.
+func TestValidatorPasswdRefusesAColonInTheHomeField(t *testing.T) {
+	t.Parallel()
+
+	library := filepath.Join(repoRoot(t), "scripts", "ci", "lib", "validator-passwd.sh")
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "docker", "#!/bin/bash\nprintf 'root:x:0:0:root:/root:/bin/bash\\n'\n")
+	probe := writeExecutable(t, t.TempDir(), "probe", `#!/bin/bash
+set -euo pipefail
+PATH="$1:${PATH}"
+export PATH
+source "$2"
+workcell_ci_validator_passwd_file docker fixture-image 1000 1000 "/home/fixture:extra" "$3"
+`)
+
+	output, err := exec.Command("/bin/bash", probe, binDir, library, t.TempDir()).CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "not a usable passwd field") {
+		t.Fatalf("colon in the home field accepted: %v\n%s", err, output)
+	}
+}
+
 // The hostile lane earns its runtime only while each axis keeps the shapes that
 // reproduced a finding by hand, so the derivations are executed here rather
 // than pattern-matched: a dropped backslash that lets bash expand $HOME, a

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -534,22 +535,31 @@ func stringsFromNUL(data []byte) []string {
 // with it git's ssh signing and verification.  The synthesis lives in one
 // library precisely so a lane cannot half-adopt it: this test fails when a lane
 // stops sourcing it, calls it more than once, or drops the read-only mount.
+// Each requirement is an active statement, not a substring, so a commented-out
+// line or the same text quoted inside an echo does not read as coverage.
 func TestValidatorLanesMountSynthesizedPasswd(t *testing.T) {
 	t.Parallel()
 
 	root := repoRoot(t)
-	validatorMounts := []string{
-		`workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd`,
-		`--mount "${validator_passwd_mount}"`,
+	validatorStatements := []string{
+		`source "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"`,
+		`validator_passwd="$(workcell_ci_validator_passwd_file \`,
+		`validator_passwd_mount="$(workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd)"`,
+		`--mount "${validator_passwd_mount}" \`,
 	}
-	for rel, mounts := range map[string][]string{
-		"scripts/ci/run-docs-in-validator.sh":     validatorMounts,
-		"scripts/ci/run-fuzz-in-validator.sh":     validatorMounts,
-		"scripts/ci/run-mutation-in-validator.sh": validatorMounts,
-		"scripts/ci/run-validate-in-validator.sh": validatorMounts,
-		"scripts/build-and-test.sh":               {`-v "${passwd_file}:/etc/passwd:ro"`},
+	for rel, statements := range map[string][]string{
+		"scripts/ci/run-docs-in-validator.sh":     validatorStatements,
+		"scripts/ci/run-fuzz-in-validator.sh":     validatorStatements,
+		"scripts/ci/run-mutation-in-validator.sh": validatorStatements,
+		"scripts/ci/run-validate-in-validator.sh": validatorStatements,
+		"scripts/build-and-test.sh": {
+			`"WORKCELL_BUILD_AND_TEST_PASSWD_LIB=${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh" \`,
+			`source "${WORKCELL_BUILD_AND_TEST_PASSWD_LIB}"`,
+			`passwd_file="$(workcell_ci_validator_passwd_file docker "$1" \`,
+			`-v "${passwd_file}:/etc/passwd:ro" \`,
+		},
 	} {
-		rel, mounts := rel, mounts
+		rel, statements := rel, statements
 		t.Run(rel, func(t *testing.T) {
 			t.Parallel()
 
@@ -557,16 +567,10 @@ func TestValidatorLanesMountSynthesizedPasswd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			lane := activeShellLines(string(content))
-			if !strings.Contains(lane, "scripts/ci/lib/validator-passwd.sh") {
-				t.Fatalf("%s must use the shared passwd synthesis library", rel)
-			}
-			if got := strings.Count(lane, "workcell_ci_validator_passwd_file"); got != 1 {
-				t.Fatalf("%s calls the passwd synthesis %d times, want 1", rel, got)
-			}
-			for _, mount := range mounts {
-				if !strings.Contains(lane, mount) {
-					t.Fatalf("%s must mount the synthesized passwd file: %s", rel, mount)
+			lane := string(content)
+			for _, statement := range statements {
+				if countActiveStatements(lane, statement) != 1 {
+					t.Fatalf("%s must carry exactly one active statement: %s", rel, statement)
 				}
 			}
 		})
@@ -704,7 +708,10 @@ func runHostileDerivation(t *testing.T, prefix, preset, variable string) string 
 		t.Fatal(err)
 	}
 	derivation := ""
-	for _, line := range strings.Split(activeShellLines(string(content)), "\n") {
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
 		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
 			derivation = strings.TrimSpace(line)
 			break
@@ -723,32 +730,44 @@ func runHostileDerivation(t *testing.T, prefix, preset, variable string) string 
 	return string(output)
 }
 
-// activeShellLines drops whole-line comments so a lane cannot satisfy a check
-// with the statement it commented out.  A trailing comment is left alone: it
-// cannot carry a statement, and cutting at the first "#" would corrupt a
-// pathname or a parameter expansion that contains one.
-func activeShellLines(script string) string {
-	active := make([]string, 0, strings.Count(script, "\n")+1)
+// countActiveStatements counts the lines whose own statement is the wanted one.
+// Whole-line comments are dropped first, and the comparison is on the trimmed
+// line rather than on a substring of the file, so a commented-out statement, an
+// assignment that merely names it, or the same text quoted inside an echo does
+// not count.  A heredoc body is out of reach without a shell parser; the lanes
+// checked here contain none.
+func countActiveStatements(script, want string) int {
+	count := 0
 	for _, line := range strings.Split(script, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		active = append(active, line)
+		if trimmed == want {
+			count++
+		}
 	}
-	return strings.Join(active, "\n")
+	return count
 }
 
-// The negative fixture for activeShellLines: a commented-out source statement
-// must not read as coverage.
-func TestActiveShellLinesDropsCommentedStatements(t *testing.T) {
+// The negative fixtures for countActiveStatements: inert text that mentions the
+// statement must not read as coverage, and a live statement must still count
+// once whatever its indentation.
+func TestCountActiveStatementsIgnoresInertText(t *testing.T) {
 	t.Parallel()
 
-	commented := "  # source \"${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh\"\n#!/bin/bash\n"
-	if got := activeShellLines(commented); strings.Contains(got, "validator-passwd.sh") {
-		t.Fatalf("commented statement survived comment stripping: %q", got)
+	want := `source "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"`
+	for _, inert := range []string{
+		"  # " + want,
+		"echo " + strconv.Quote(want),
+		"lane_statement=" + strconv.Quote(want),
+		"if grep -Fq " + strconv.Quote(want) + " \"${lane}\"; then",
+	} {
+		if got := countActiveStatements(inert+"\n", want); got != 0 {
+			t.Fatalf("inert line %q counted %d times", inert, got)
+		}
 	}
-	live := "source \"${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh\" # keep the trailing comment\n"
-	if got := activeShellLines(live); !strings.Contains(got, "# keep the trailing comment") {
-		t.Fatalf("live statement lost its trailing comment: %q", got)
+	if got := countActiveStatements("  "+want+"\nunrelated\n", want); got != 1 {
+		t.Fatalf("live statement counted %d times, want 1", got)
 	}
 }

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -651,9 +651,19 @@ source "$2"
 workcell_ci_validator_passwd_file docker fixture-image 1000 1000 /home/fixture "$3"
 `)
 
-	output, err := exec.Command("/bin/bash", probe, binDir, library, t.TempDir()).CombinedOutput()
+	workspace := t.TempDir()
+	output, err := exec.Command("/bin/bash", probe, binDir, library, workspace).CombinedOutput()
 	if err == nil || !strings.Contains(string(output), "Validator passwd lookup failed with status 2") {
 		t.Fatalf("failing lookup accepted: %v\n%s", err, output)
+	}
+	// The caller only learns the pathname from the value the function prints, so
+	// a failure that left the file behind would leave it behind for good.
+	leftovers, err := filepath.Glob(filepath.Join(workspace, "tmp", "workcell-validator-passwd.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("failed synthesis left %v behind", leftovers)
 	}
 }
 

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -572,3 +572,57 @@ func TestValidatorLanesMountSynthesizedPasswd(t *testing.T) {
 		})
 	}
 }
+
+// The hostile lane earns its runtime only while TMPDIR keeps every shape that
+// reproduced a finding by hand, so the derivation is executed here rather than
+// pattern-matched: a dropped backslash that lets bash expand $HOME, or a
+// shortened padding component, leaves the lane green for the wrong reason.
+func TestHostileTMPDIRKeepsTheShapesThatReproducedFindings(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	lane := filepath.Join(root, "scripts", "ci", "run-validate-in-validator.sh")
+	content, err := os.ReadFile(lane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	derivation := ""
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), `validator_tmp="${validator_tmp}/`) {
+			derivation = strings.TrimSpace(line)
+			break
+		}
+	}
+	if derivation == "" {
+		t.Fatal("run-validate-in-validator.sh no longer derives a hostile TMPDIR")
+	}
+
+	script := `validator_tmp="/tmp/workcell-home-1000/.tmp"; ` + derivation + `; printf '%s' "${validator_tmp}"`
+	command := exec.Command("/bin/bash", "-c", script)
+	command.Env = append(os.Environ(), "HOME=/hostile-home-must-not-expand")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("hostile TMPDIR derivation failed: %v", err)
+	}
+	hostile := string(output)
+
+	if !strings.Contains(hostile, " ") {
+		t.Fatalf("hostile TMPDIR %q has no whitespace component", hostile)
+	}
+	if !strings.Contains(hostile, "$") {
+		t.Fatalf("hostile TMPDIR %q has no unexpanded dollar sign", hostile)
+	}
+	option, padded := false, false
+	for _, word := range strings.Fields(hostile) {
+		option = option || strings.HasPrefix(word, "--")
+	}
+	for _, component := range strings.Split(hostile, "/") {
+		padded = padded || len(component) >= 80
+	}
+	if !option {
+		t.Fatalf("hostile TMPDIR %q has no --prefixed token", hostile)
+	}
+	if !padded {
+		t.Fatalf("hostile TMPDIR %q has no ~80-character padding component", hostile)
+	}
+}

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -628,6 +628,101 @@ workcell_ci_validator_passwd_file docker fixture-image 1000 1000 /home/fixture "
 	}
 }
 
+// The hostile lane earns its runtime only while each axis keeps the shapes that
+// reproduced a finding by hand, so the derivations are executed here rather
+// than pattern-matched: a dropped backslash that lets bash expand $HOME, a
+// shortened padding component, or a comma quietly removed from the bind source
+// leaves the lane green for the wrong reason.
+func TestHostileAxesKeepTheShapesThatReproducedFindings(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := runHostileDerivation(t, `validator_tmp="${validator_tmp}/`, `validator_tmp="/tmp/workcell-home-1000/.tmp"`, "validator_tmp")
+	if !strings.Contains(tmpdir, " ") {
+		t.Fatalf("hostile TMPDIR %q has no whitespace component", tmpdir)
+	}
+	if !strings.Contains(tmpdir, "$") {
+		t.Fatalf("hostile TMPDIR %q has no unexpanded dollar sign", tmpdir)
+	}
+	if !hasOptionToken(tmpdir) {
+		t.Fatalf("hostile TMPDIR %q has no --prefixed token", tmpdir)
+	}
+	padded := false
+	for _, component := range strings.Split(tmpdir, "/") {
+		padded = padded || len(component) >= 80
+	}
+	if !padded {
+		t.Fatalf("hostile TMPDIR %q has no ~80-character padding component", tmpdir)
+	}
+
+	workspace := runHostileDerivation(t, `hostile_workspace="${hostile_root}/`, `hostile_root="/tmp/workcell-hostile.fixture"`, "hostile_workspace")
+	if !strings.Contains(workspace, " ") {
+		t.Fatalf("hostile workspace %q has no whitespace component", workspace)
+	}
+	if !strings.Contains(workspace, ",") {
+		t.Fatalf("hostile workspace %q has no comma, so it never exercises the CSV mount record", workspace)
+	}
+	if !hasOptionToken(workspace) {
+		t.Fatalf("hostile workspace %q has no --prefixed token", workspace)
+	}
+}
+
+// An unknown axis must fail closed.  A typo that fell through to the ordinary
+// validation would report a green advisory lane that tested nothing hostile.
+func TestHostileAxisRejectsAnUnknownValue(t *testing.T) {
+	t.Parallel()
+
+	lane := filepath.Join(repoRoot(t), "scripts", "ci", "run-validate-in-validator.sh")
+	command := exec.Command(lane)
+	command.Env = append(os.Environ(), "WORKCELL_HOSTILE_ENV=not-an-axis")
+	output, err := command.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+		t.Fatalf("unknown axis status = %v, want exit 2\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "Unsupported WORKCELL_HOSTILE_ENV: not-an-axis") {
+		t.Fatalf("unknown axis output = %q", output)
+	}
+}
+
+func hasOptionToken(path string) bool {
+	for _, word := range strings.Fields(path) {
+		if strings.HasPrefix(word, "--") {
+			return true
+		}
+	}
+	return false
+}
+
+// runHostileDerivation executes the single assignment the lane derives an axis
+// with, so the test reads the value bash produces instead of the source text.
+func runHostileDerivation(t *testing.T, prefix, preset, variable string) string {
+	t.Helper()
+
+	lane := filepath.Join(repoRoot(t), "scripts", "ci", "run-validate-in-validator.sh")
+	content, err := os.ReadFile(lane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	derivation := ""
+	for _, line := range strings.Split(activeShellLines(string(content)), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			derivation = strings.TrimSpace(line)
+			break
+		}
+	}
+	if derivation == "" {
+		t.Fatalf("run-validate-in-validator.sh no longer derives %s", variable)
+	}
+	script := preset + "; " + derivation + `; printf '%s' "${` + variable + `}"`
+	command := exec.Command("/bin/bash", "-c", script)
+	command.Env = append(os.Environ(), "HOME=/hostile-home-must-not-expand")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("%s derivation failed: %v", variable, err)
+	}
+	return string(output)
+}
+
 // activeShellLines drops whole-line comments so a lane cannot satisfy a check
 // with the statement it commented out.  A trailing comment is left alone: it
 // cannot carry a statement, and cutting at the first "#" would corrupt a

--- a/internal/testkit/validation_entrypoints_test.go
+++ b/internal/testkit/validation_entrypoints_test.go
@@ -1362,10 +1362,15 @@ func TestGitHubWorkflowsVerifyHostedInstallEvidence(t *testing.T) {
 				} `yaml:"run"`
 			} `yaml:"defaults"`
 			Jobs map[string]struct {
-				If              string     `yaml:"if"`
-				RunsOn          string     `yaml:"runs-on"`
-				Needs           yaml.Node  `yaml:"needs"`
-				ContinueOnError *yaml.Node `yaml:"continue-on-error"`
+				If     string    `yaml:"if"`
+				RunsOn string    `yaml:"runs-on"`
+				Needs  yaml.Node `yaml:"needs"`
+				// yaml.v3 refuses to decode a scalar into *yaml.Node, so a
+				// pointer here made the whole workflow unparseable as soon as any
+				// job or step set continue-on-error, and the assertions below
+				// vacuously true until then.  A value Node decodes and IsZero
+				// reports absence.
+				ContinueOnError yaml.Node `yaml:"continue-on-error"`
 				Defaults        struct {
 					Run struct {
 						Shell string `yaml:"shell"`
@@ -1380,11 +1385,11 @@ func TestGitHubWorkflowsVerifyHostedInstallEvidence(t *testing.T) {
 					} `yaml:"matrix"`
 				} `yaml:"strategy"`
 				Steps []struct {
-					Name            string     `yaml:"name"`
-					Run             string     `yaml:"run"`
-					If              string     `yaml:"if"`
-					ContinueOnError *yaml.Node `yaml:"continue-on-error"`
-					Shell           string     `yaml:"shell"`
+					Name            string    `yaml:"name"`
+					Run             string    `yaml:"run"`
+					If              string    `yaml:"if"`
+					ContinueOnError yaml.Node `yaml:"continue-on-error"`
+					Shell           string    `yaml:"shell"`
 				} `yaml:"steps"`
 			} `yaml:"jobs"`
 		}
@@ -1404,7 +1409,7 @@ func TestGitHubWorkflowsVerifyHostedInstallEvidence(t *testing.T) {
 		}
 		if installJob.If != wantJobIf ||
 			installJob.RunsOn != "${{ matrix.runner }}" ||
-			installJob.ContinueOnError != nil ||
+			!installJob.ContinueOnError.IsZero() ||
 			installJob.Defaults.Run.Shell != "" {
 			t.Fatalf("%s install-verification job metadata does not match the hosted evidence contract", workflowPath)
 		}
@@ -1428,7 +1433,7 @@ func TestGitHubWorkflowsVerifyHostedInstallEvidence(t *testing.T) {
 		installerStepCount := 0
 		for _, step := range installJob.Steps {
 			if step.Name == "Verify release bundle installer" {
-				if step.If != "" || step.ContinueOnError != nil || step.Shell != "" {
+				if step.If != "" || !step.ContinueOnError.IsZero() || step.Shell != "" {
 					t.Fatalf("%s release bundle installer step must use required default execution", workflowPath)
 				}
 				installerRun = step.Run

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -26,22 +26,22 @@
     "ci.yml/hostile-env[axis=root]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=root scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=root, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/hostile-env[axis=tmpdir]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=tmpdir scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=tmpdir, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/hostile-env[axis=uidmap]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=uidmap scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=uidmap, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/hostile-env[axis=workspace]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=workspace scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=workspace, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]": {
       "profiles": ["pr-parity"],

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -23,10 +23,25 @@
       "local_script": "scripts/container-smoke.sh",
       "local_order": 40
     },
-    "ci.yml/hostile-tmpdir": {
+    "ci.yml/hostile-env[axis=root]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory hostile-TMPDIR rerun of repository validation; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_TMPDIR=1 scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=root scripts/ci/run-validate-in-validator.sh"
+    },
+    "ci.yml/hostile-env[axis=tmpdir]": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=tmpdir scripts/ci/run-validate-in-validator.sh"
+    },
+    "ci.yml/hostile-env[axis=uidmap]": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=uidmap scripts/ci/run-validate-in-validator.sh"
+    },
+    "ci.yml/hostile-env[axis=workspace]": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=workspace scripts/ci/run-validate-in-validator.sh"
     },
     "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]": {
       "profiles": ["pr-parity"],

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -23,6 +23,11 @@
       "local_script": "scripts/container-smoke.sh",
       "local_order": 40
     },
+    "ci.yml/hostile-tmpdir": {
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory hostile-TMPDIR rerun of repository validation; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_TMPDIR=1 scripts/ci/run-validate-in-validator.sh"
+    },
     "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]": {
       "profiles": ["pr-parity"],
       "authority": "pr-parity",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -66,11 +66,14 @@
       "local_order": 40
     },
     {
-      "id": "ci.yml/hostile-tmpdir",
+      "id": "ci.yml/hostile-env[axis=root]",
       "workflow_path": ".github/workflows/ci.yml",
       "workflow_name": "CI",
-      "job_id": "hostile-tmpdir",
-      "job_name": "Hostile TMPDIR (advisory)",
+      "job_id": "hostile-env",
+      "job_name": "Hostile environment (root)",
+      "matrix": {
+        "axis": "root"
+      },
       "workflow_events": [
         "pull_request",
         "push",
@@ -78,7 +81,61 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory hostile-TMPDIR rerun of repository validation; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_TMPDIR=1 scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=root scripts/ci/run-validate-in-validator.sh"
+    },
+    {
+      "id": "ci.yml/hostile-env[axis=tmpdir]",
+      "workflow_path": ".github/workflows/ci.yml",
+      "workflow_name": "CI",
+      "job_id": "hostile-env",
+      "job_name": "Hostile environment (tmpdir)",
+      "matrix": {
+        "axis": "tmpdir"
+      },
+      "workflow_events": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=tmpdir scripts/ci/run-validate-in-validator.sh"
+    },
+    {
+      "id": "ci.yml/hostile-env[axis=uidmap]",
+      "workflow_path": ".github/workflows/ci.yml",
+      "workflow_name": "CI",
+      "job_id": "hostile-env",
+      "job_name": "Hostile environment (uidmap)",
+      "matrix": {
+        "axis": "uidmap"
+      },
+      "workflow_events": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=uidmap scripts/ci/run-validate-in-validator.sh"
+    },
+    {
+      "id": "ci.yml/hostile-env[axis=workspace]",
+      "workflow_path": ".github/workflows/ci.yml",
+      "workflow_name": "CI",
+      "job_id": "hostile-env",
+      "job_name": "Hostile environment (workspace)",
+      "matrix": {
+        "axis": "workspace"
+      },
+      "workflow_events": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=workspace scripts/ci/run-validate-in-validator.sh"
     },
     {
       "id": "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -66,6 +66,21 @@
       "local_order": 40
     },
     {
+      "id": "ci.yml/hostile-tmpdir",
+      "workflow_path": ".github/workflows/ci.yml",
+      "workflow_name": "CI",
+      "job_id": "hostile-tmpdir",
+      "job_name": "Hostile TMPDIR (advisory)",
+      "workflow_events": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "authority": "github-only",
+      "local_mode": "none",
+      "github_only_reason": "advisory hostile-TMPDIR rerun of repository validation; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_TMPDIR=1 scripts/ci/run-validate-in-validator.sh"
+    },
+    {
       "id": "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]",
       "workflow_path": ".github/workflows/ci.yml",
       "workflow_name": "CI",

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -81,7 +81,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=root scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=root, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/hostile-env[axis=tmpdir]",
@@ -99,7 +99,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=tmpdir scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=tmpdir, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/hostile-env[axis=uidmap]",
@@ -117,7 +117,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=uidmap scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=uidmap, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/hostile-env[axis=workspace]",
@@ -135,7 +135,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; a developer reproduces it on demand with WORKCELL_HOSTILE_ENV=workspace scripts/ci/run-validate-in-validator.sh"
+      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=workspace, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]",

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -98,6 +98,7 @@ run_validate_repo_in_validator_snapshot() {
     "WORKCELL_BUILD_AND_TEST_VALIDATOR_HOME=${validator_home}" \
     "WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE=${validator_cache}" \
     "WORKCELL_BUILD_AND_TEST_VALIDATOR_TMP=${validator_tmp}" \
+    "WORKCELL_BUILD_AND_TEST_PASSWD_LIB=${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh" \
     "${ROOT_DIR}/scripts/with-validation-snapshot.sh" \
     --repo "${ROOT_DIR}" \
     --mode worktree \
@@ -105,6 +106,17 @@ run_validate_repo_in_validator_snapshot() {
     -- \
     /bin/bash -p -c '
       workspace="$(pwd -P)"
+      # Same synthesized passwd entry the CI lanes mount: the workload runs as
+      # a uid the image has no /etc/passwd record for, and git shelling out to
+      # ssh-keygen for signing dies with "No user exists for uid <n>" without
+      # one.  The file lives in the disposable snapshot, which is already the
+      # bind source, so the Colima VM can see it.
+      source "${WORKCELL_BUILD_AND_TEST_PASSWD_LIB}"
+      passwd_file="$(workcell_ci_validator_passwd_file docker "$1" \
+        "${WORKCELL_BUILD_AND_TEST_VALIDATOR_UID}" \
+        "${WORKCELL_BUILD_AND_TEST_VALIDATOR_GID}" \
+        "${WORKCELL_BUILD_AND_TEST_VALIDATOR_HOME}" \
+        "${workspace}")"
       docker run --rm \
         --user "${WORKCELL_BUILD_AND_TEST_VALIDATOR_UID}:${WORKCELL_BUILD_AND_TEST_VALIDATOR_GID}" \
         --entrypoint /bin/bash \
@@ -115,6 +127,7 @@ run_validate_repo_in_validator_snapshot() {
         -e CARGO_TARGET_DIR="${WORKCELL_BUILD_AND_TEST_VALIDATOR_CACHE}/cargo-target" \
         -e TMPDIR="${WORKCELL_BUILD_AND_TEST_VALIDATOR_TMP}" \
         -v "${workspace}:/workspace" \
+        -v "${passwd_file}:/etc/passwd:ro" \
         -w /workspace \
         "$1" \
         -lc '"'"'
@@ -122,6 +135,7 @@ run_validate_repo_in_validator_snapshot() {
           mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"
           ./scripts/validate-repo.sh "$@"
         '"'"' bash "${@:2}"
+      rm -f "${passwd_file}"
       ./scripts/verify-invariants.sh
     ' bash "${image_tag}" "$@"
 }

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -116,7 +116,7 @@ run_validate_repo_in_validator_snapshot() {
         "${WORKCELL_BUILD_AND_TEST_VALIDATOR_UID}" \
         "${WORKCELL_BUILD_AND_TEST_VALIDATOR_GID}" \
         "${WORKCELL_BUILD_AND_TEST_VALIDATOR_HOME}" \
-        "${workspace}")"
+        "${workspace}")" || exit 1
       docker run --rm \
         --user "${WORKCELL_BUILD_AND_TEST_VALIDATOR_UID}:${WORKCELL_BUILD_AND_TEST_VALIDATOR_GID}" \
         --entrypoint /bin/bash \

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -50,11 +50,24 @@ workcell_ci_validator_passwd_file() {
   file="$(mktemp "${directory}/workcell-validator-passwd.XXXXXX")" || return
   "${docker_command}" run --rm --entrypoint /bin/bash "${image}" \
     -lc 'cat /etc/passwd' >"${file}" || return
-  if ! awk -F: -v uid="${uid}" '$3 == uid { found = 1 } END { exit !found }' \
-    "${file}"; then
-    printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
-      "${uid}" "${gid}" "${home}" >>"${file}"
-  fi
+  # "absent" gets its own exit status.  Folding every nonzero status into
+  # "absent" would let a missing or failing awk append a second record for a uid
+  # the image already has, and glibc would then resolve the uid to whichever
+  # record comes first.  An error here fails the lane instead.
+  local lookup=0
+  awk -F: -v uid="${uid}" '$3 == uid { found = 1 } END { exit found ? 0 : 10 }' \
+    "${file}" || lookup=$?
+  case "${lookup}" in
+    0) ;;
+    10)
+      printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
+        "${uid}" "${gid}" "${home}" >>"${file}"
+      ;;
+    *)
+      echo "Validator passwd lookup failed with status ${lookup}" >&2
+      return 1
+      ;;
+  esac
   # Owner-only whenever the workload runs as the uid that creates the file,
   # which is every lane except the remapped-uid axis.  There, rootful Docker
   # keeps the numeric owner across the bind, so an owner-only file would be

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -31,10 +31,23 @@ workcell_ci_validator_passwd_file() {
   local gid="$4"
   local home="$5"
   local workspace="$6"
+  local directory=""
   local file=""
 
-  mkdir -p "${workspace}/tmp" || return
-  file="$(mktemp "${workspace}/tmp/workcell-validator-passwd.XXXXXX")" || return
+  # Containment is decided on canonical paths.  A symlinked `tmp`, or a
+  # symlinked ancestor of it, would place the artifact, its mode change and its
+  # removal outside the workspace the caller preflighted, while `mkdir -p` and
+  # `mktemp` both follow it without complaint.  Bash cannot open and hold a
+  # parent descriptor, so the gate compares the resolved directory with the
+  # resolved workspace and refuses anything else.
+  workspace="$(cd "${workspace}" && pwd -P)" || return
+  directory="${workspace}/tmp"
+  mkdir -p "${directory}" || return
+  if [[ "$(cd "${directory}" && pwd -P)" != "${directory}" ]]; then
+    echo "Validator passwd directory is not the canonical ${directory}" >&2
+    return 1
+  fi
+  file="$(mktemp "${directory}/workcell-validator-passwd.XXXXXX")" || return
   "${docker_command}" run --rm --entrypoint /bin/bash "${image}" \
     -lc 'cat /etc/passwd' >"${file}" || return
   if ! awk -F: -v uid="${uid}" '$3 == uid { found = 1 } END { exit !found }' \
@@ -42,6 +55,10 @@ workcell_ci_validator_passwd_file() {
     printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
       "${uid}" "${gid}" "${home}" >>"${file}"
   fi
-  chmod 0444 "${file}" || return
+  # Owner-only: the container runs as the same uid the caller passes here, so
+  # glibc reads the bind-mounted copy as its owner and nothing else on the host
+  # needs it.  mktemp already created it 0600; 0400 also drops the write bit
+  # for the read-only mount.
+  chmod 0400 "${file}" || return
   printf '%s\n' "${file}"
 }

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -55,9 +55,15 @@ workcell_ci_validator_passwd_file() {
     echo "Validator home is not a usable passwd field: ${home}" >&2
     return 1
   fi
+  # Every failure after this point removes the file itself.  The caller only
+  # learns the pathname from the value this function prints, so a failure that
+  # returned early would leave an artifact its EXIT trap has no name for.
   file="$(mktemp "${directory}/workcell-validator-passwd.XXXXXX")" || return
   "${docker_command}" run --rm --entrypoint /bin/bash "${image}" \
-    -lc 'cat /etc/passwd' >"${file}" || return
+    -lc 'cat /etc/passwd' >"${file}" || {
+    rm -f "${file}"
+    return 1
+  }
   # "absent" gets its own exit status.  Folding every nonzero status into
   # "absent" would let a missing or failing awk append a second record for a uid
   # the image already has, and glibc would then resolve the uid to whichever
@@ -69,10 +75,14 @@ workcell_ci_validator_passwd_file() {
     0) ;;
     10)
       printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
-        "${uid}" "${gid}" "${home}" >>"${file}"
+        "${uid}" "${gid}" "${home}" >>"${file}" || {
+        rm -f "${file}"
+        return 1
+      }
       ;;
     *)
       echo "Validator passwd lookup failed with status ${lookup}" >&2
+      rm -f "${file}"
       return 1
       ;;
   esac
@@ -86,9 +96,15 @@ workcell_ci_validator_passwd_file() {
   # reports.  mktemp created the file 0600, so both modes also drop the write
   # bit the read-only mount does not need.
   if [[ "${uid}" == "$(id -u)" ]]; then
-    chmod 0400 "${file}" || return
+    chmod 0400 "${file}" || {
+      rm -f "${file}"
+      return 1
+    }
   else
-    chmod 0444 "${file}" || return
+    chmod 0444 "${file}" || {
+      rm -f "${file}"
+      return 1
+    }
   fi
   printf '%s\n' "${file}"
 }

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -47,6 +47,14 @@ workcell_ci_validator_passwd_file() {
     echo "Validator passwd directory is not the canonical ${directory}" >&2
     return 1
   fi
+  # The record is colon-delimited and newline-terminated, so a home carrying
+  # either character would truncate the home field and shift every field after
+  # it.  Both are legal in a Unix path, and the dev-side home comes from
+  # ${TMPDIR}, so the field is checked rather than assumed.
+  if [[ "${home}" == *:* || "${home}" == *$'\n'* ]]; then
+    echo "Validator home is not a usable passwd field: ${home}" >&2
+    return 1
+  fi
   file="$(mktemp "${directory}/workcell-validator-passwd.XXXXXX")" || return
   "${docker_command}" run --rm --entrypoint /bin/bash "${image}" \
     -lc 'cat /etc/passwd' >"${file}" || return

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -86,25 +86,20 @@ workcell_ci_validator_passwd_file() {
       return 1
       ;;
   esac
-  # Owner-only whenever the workload runs as the uid that creates the file,
-  # which is every lane except the remapped-uid axis.  There, rootful Docker
-  # keeps the numeric owner across the bind, so an owner-only file would be
-  # unreadable to the workload and the axis would fail on its own harness
-  # rather than on the repository.  Widening to world-readable for that case
-  # discloses nothing: the content is a copy of the image's own /etc/passwd
-  # plus one record naming a uid, gid and home that the container already
-  # reports.  mktemp created the file 0600, so both modes also drop the write
-  # bit the read-only mount does not need.
-  if [[ "${uid}" == "$(id -u)" ]]; then
-    chmod 0400 "${file}" || {
-      rm -f "${file}"
-      return 1
-    }
-  else
-    chmod 0444 "${file}" || {
-      rm -f "${file}"
-      return 1
-    }
-  fi
+  # World-readable, deliberately.  The file is a bind source, and the owner it
+  # presents inside the container depends on the daemon: a rootless or
+  # userns-remapped daemon maps the host owner to some other uid, and the
+  # remapped-uid axis changes the workload uid on purpose, so an owner-only mode
+  # would make /etc/passwd unreadable to the very process that needs it and the
+  # lane would fail on its own harness.  Nothing here is secret: the content is
+  # a copy of the image's own /etc/passwd plus one record naming a uid, gid and
+  # home the container already reports.  internal/host/validatorbind keeps its
+  # non-secret bind challenge readable for the same reason.  mktemp created the
+  # file 0600, so this also drops the write bit the read-only mount does not
+  # need.
+  chmod 0444 "${file}" || {
+    rm -f "${file}"
+    return 1
+  }
   printf '%s\n' "${file}"
 }

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S BASH_ENV= ENV= bash
+# shellcheck shell=bash
+# Shared /etc/passwd synthesis for validator-container lanes.
+#
+# Every lane runs the workload as the caller's uid to keep the bind-mounted
+# workspace writable, but that uid has no /etc/passwd entry, so glibc
+# getpwuid() fails and anything resolving the invoking user dies with "No user
+# exists for uid <n>".  ssh-keygen is one of those, and git shells out to it for
+# both `gpg.format = ssh` signing and verification, so the pre-push hook tests
+# cannot sign or verify a commit.  Give the container a passwd file carrying an
+# entry for the runtime uid, appended only when the image lacks one so an
+# existing uid keeps its own home.  The home field matches the HOME the caller
+# exports, so identity- and env-based home discovery agree on one path.
+#
+# The file is created under the workspace because that bind is preflighted by
+# the caller.  A host temporary directory is not always visible to the daemon:
+# on the documented macOS Colima path the daemon runs in a VM that does not
+# mount ${TMPDIR}, so the bind source would be missing.
+#
+# Usage:
+#   passwd_file="$(workcell_ci_validator_passwd_file \
+#     DOCKER IMAGE UID GID HOME WORKSPACE)"
+# DOCKER is the docker invocation to read the image's own /etc/passwd with:
+# the context-aware workcell_ci_docker wrapper in the CI lanes, plain docker in
+# scripts/build-and-test.sh.  The caller mounts the result read-only at
+# /etc/passwd and removes it when the run is done.
+workcell_ci_validator_passwd_file() {
+  local docker_command="$1"
+  local image="$2"
+  local uid="$3"
+  local gid="$4"
+  local home="$5"
+  local workspace="$6"
+  local file=""
+
+  mkdir -p "${workspace}/tmp" || return
+  file="$(mktemp "${workspace}/tmp/workcell-validator-passwd.XXXXXX")" || return
+  "${docker_command}" run --rm --entrypoint /bin/bash "${image}" \
+    -lc 'cat /etc/passwd' >"${file}" || return
+  if ! awk -F: -v uid="${uid}" '$3 == uid { found = 1 } END { exit !found }' \
+    "${file}"; then
+    printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
+      "${uid}" "${gid}" "${home}" >>"${file}"
+  fi
+  chmod 0444 "${file}" || return
+  printf '%s\n' "${file}"
+}

--- a/scripts/ci/lib/validator-passwd.sh
+++ b/scripts/ci/lib/validator-passwd.sh
@@ -55,10 +55,19 @@ workcell_ci_validator_passwd_file() {
     printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
       "${uid}" "${gid}" "${home}" >>"${file}"
   fi
-  # Owner-only: the container runs as the same uid the caller passes here, so
-  # glibc reads the bind-mounted copy as its owner and nothing else on the host
-  # needs it.  mktemp already created it 0600; 0400 also drops the write bit
-  # for the read-only mount.
-  chmod 0400 "${file}" || return
+  # Owner-only whenever the workload runs as the uid that creates the file,
+  # which is every lane except the remapped-uid axis.  There, rootful Docker
+  # keeps the numeric owner across the bind, so an owner-only file would be
+  # unreadable to the workload and the axis would fail on its own harness
+  # rather than on the repository.  Widening to world-readable for that case
+  # discloses nothing: the content is a copy of the image's own /etc/passwd
+  # plus one record naming a uid, gid and home that the container already
+  # reports.  mktemp created the file 0600, so both modes also drop the write
+  # bit the read-only mount does not need.
+  if [[ "${uid}" == "$(id -u)" ]]; then
+    chmod 0400 "${file}" || return
+  else
+    chmod 0444 "${file}" || return
+  fi
   printf '%s\n' "${file}"
 }

--- a/scripts/ci/run-docs-in-validator.sh
+++ b/scripts/ci/run-docs-in-validator.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
 source "${ROOT_DIR}/scripts/ci/lib/local-docker-parity.sh"
+source "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"
 VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-}"
 WORKSPACE="${WORKCELL_VALIDATOR_WORKSPACE:-${ROOT_DIR}}"
 
+validator_passwd=""
 cleanup() {
+  [[ -z "${validator_passwd}" ]] || rm -f "${validator_passwd}"
   cleanup_workcell_ci_docker
 }
 trap cleanup EXIT
@@ -33,6 +36,15 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+
+# Same synthesized passwd entry the validate lane mounts: the workload runs
+# as a uid the image has no /etc/passwd record for, and every tool that
+# resolves the invoking user fails without one.
+validator_passwd="$(workcell_ci_validator_passwd_file \
+  workcell_ci_docker "${VALIDATOR_IMAGE}" \
+  "${validator_uid}" "${validator_gid}" "${validator_home}" "${WORKSPACE}")"
+validator_passwd_mount="$(workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd)"
+
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
@@ -41,6 +53,7 @@ workcell_ci_docker run --rm \
   --user "${validator_uid}:${validator_gid}" \
   --entrypoint /bin/bash \
   --mount "${validator_workspace_mount}" \
+  --mount "${validator_passwd_mount}" \
   -w /workspace \
   -e HOME="${validator_home}" \
   -e XDG_CACHE_HOME="${validator_cache}" \

--- a/scripts/ci/run-fuzz-in-validator.sh
+++ b/scripts/ci/run-fuzz-in-validator.sh
@@ -10,11 +10,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
 source "${ROOT_DIR}/scripts/ci/lib/local-docker-parity.sh"
+source "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"
 VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-}"
 WORKSPACE="${WORKCELL_VALIDATOR_WORKSPACE:-${ROOT_DIR}}"
 FUZZTIME="${WORKCELL_FUZZTIME:-3m}"
 
+validator_passwd=""
 cleanup() {
+  [[ -z "${validator_passwd}" ]] || rm -f "${validator_passwd}"
   cleanup_workcell_ci_docker
 }
 trap cleanup EXIT
@@ -36,6 +39,15 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+
+# Same synthesized passwd entry the validate lane mounts: the workload runs
+# as a uid the image has no /etc/passwd record for, and every tool that
+# resolves the invoking user fails without one.
+validator_passwd="$(workcell_ci_validator_passwd_file \
+  workcell_ci_docker "${VALIDATOR_IMAGE}" \
+  "${validator_uid}" "${validator_gid}" "${validator_home}" "${WORKSPACE}")"
+validator_passwd_mount="$(workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd)"
+
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
@@ -50,6 +62,7 @@ workcell_ci_docker run --rm \
   -e TMPDIR="${validator_tmp}" \
   -e WORKCELL_FUZZTIME="${FUZZTIME}" \
   --mount "${validator_workspace_mount}" \
+  --mount "${validator_passwd_mount}" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-mutation-in-validator.sh
+++ b/scripts/ci/run-mutation-in-validator.sh
@@ -7,10 +7,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
 source "${ROOT_DIR}/scripts/ci/lib/local-docker-parity.sh"
+source "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"
 VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-}"
 WORKSPACE="${WORKCELL_VALIDATOR_WORKSPACE:-${ROOT_DIR}}"
 
+validator_passwd=""
 cleanup() {
+  [[ -z "${validator_passwd}" ]] || rm -f "${validator_passwd}"
   cleanup_workcell_ci_docker
 }
 trap cleanup EXIT
@@ -32,6 +35,15 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
+
+# Same synthesized passwd entry the validate lane mounts: the workload runs
+# as a uid the image has no /etc/passwd record for, and every tool that
+# resolves the invoking user fails without one.
+validator_passwd="$(workcell_ci_validator_passwd_file \
+  workcell_ci_docker "${VALIDATOR_IMAGE}" \
+  "${validator_uid}" "${validator_gid}" "${validator_home}" "${WORKSPACE}")"
+validator_passwd_mount="$(workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd)"
+
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"
 validator_workspace_mount="$(workcell_ci_workspace_mount_spec "${WORKSPACE}" false)"
 
@@ -46,6 +58,7 @@ workcell_ci_docker run --rm \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
   --mount "${validator_workspace_mount}" \
+  --mount "${validator_passwd_mount}" \
   -w /workspace \
   "${VALIDATOR_IMAGE}" \
   -lc '

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/trusted-docker-client.sh"
 source "${ROOT_DIR}/scripts/ci/lib/local-docker-parity.sh"
+source "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"
 VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-}"
 VALIDATE_PROFILE="${WORKCELL_VALIDATE_REPO_PROFILE:-release-preflight}"
 WORKSPACE="${WORKCELL_VALIDATOR_WORKSPACE:-${ROOT_DIR}}"
@@ -41,29 +42,9 @@ validator_tmp="${validator_home}/.tmp"
 
 setup_workcell_ci_docker
 
-# The workload runs as the caller's uid to keep the bind-mounted workspace
-# writable, but that uid has no /etc/passwd entry, so glibc getpwuid() fails
-# and anything resolving the invoking user dies with "No user exists for uid
-# <n>".  ssh-keygen is one of those, and git shells out to it for both
-# `gpg.format = ssh` signing and verification, so the pre-push hook tests
-# cannot sign or verify a commit.  Give the container a passwd file carrying
-# an entry for the runtime uid, appended only when the image lacks one so an
-# existing uid keeps its own home.  The home field matches HOME below, so
-# identity- and env-based home discovery agree on one path.
-# The file is created under the workspace because that bind is preflighted
-# below. A host temporary directory is not always visible to the daemon: on
-# the documented macOS Colima path the daemon runs in a VM that does not mount
-# ${TMPDIR}, so the bind source would be missing.
-mkdir -p "${WORKSPACE}/tmp"
-validator_passwd="$(mktemp "${WORKSPACE}/tmp/workcell-validator-passwd.XXXXXX")"
-workcell_ci_docker run --rm --entrypoint /bin/bash "${VALIDATOR_IMAGE}" \
-  -lc 'cat /etc/passwd' >"${validator_passwd}"
-if ! awk -F: -v uid="${validator_uid}" '$3 == uid { found = 1 } END { exit !found }' \
-  "${validator_passwd}"; then
-  printf 'workcell-ci:x:%s:%s:workcell ci:%s:/bin/bash\n' \
-    "${validator_uid}" "${validator_gid}" "${validator_home}" >>"${validator_passwd}"
-fi
-chmod 0444 "${validator_passwd}"
+validator_passwd="$(workcell_ci_validator_passwd_file \
+  workcell_ci_docker "${VALIDATOR_IMAGE}" \
+  "${validator_uid}" "${validator_gid}" "${validator_home}" "${WORKSPACE}")"
 validator_passwd_mount="$(workcell_ci_workspace_mount_spec "${validator_passwd}" true /etc/passwd)"
 
 require_workcell_ci_workspace_mount "${VALIDATOR_IMAGE}" "${WORKSPACE}"

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -9,13 +9,28 @@ VALIDATOR_IMAGE="${WORKCELL_VALIDATOR_IMAGE:-}"
 VALIDATE_PROFILE="${WORKCELL_VALIDATE_REPO_PROFILE:-release-preflight}"
 WORKSPACE="${WORKCELL_VALIDATOR_WORKSPACE:-${ROOT_DIR}}"
 SKIP_HEAVY_SHELLCHECK="${WORKCELL_SKIP_HEAVY_HOST_SHELLCHECK:-0}"
+# WORKCELL_HOSTILE_ENV names one hostile axis for the advisory lane in
+# .github/workflows/ci.yml.  Each axis is a shape that review has already
+# caught defects with, and each one runs the ordinary validation underneath, so
+# a failure is a defect in the repository rather than in the lane.
+HOSTILE_ENV="${WORKCELL_HOSTILE_ENV:-none}"
 
 validator_passwd=""
+hostile_root=""
 cleanup() {
   [[ -z "${validator_passwd}" ]] || rm -f "${validator_passwd}"
+  [[ -z "${hostile_root}" ]] || rm -rf "${hostile_root}"
   cleanup_workcell_ci_docker
 }
 trap cleanup EXIT
+
+case "${HOSTILE_ENV}" in
+  none | tmpdir | workspace | root | uidmap) ;;
+  *)
+    echo "Unsupported WORKCELL_HOSTILE_ENV: ${HOSTILE_ENV}" >&2
+    exit 2
+    ;;
+esac
 
 if [[ -z "${VALIDATOR_IMAGE}" ]]; then
   echo "WORKCELL_VALIDATOR_IMAGE is required" >&2
@@ -27,8 +42,35 @@ if [[ ! -d "${WORKSPACE}" ]]; then
 fi
 WORKSPACE="$(cd "${WORKSPACE}" && pwd -P)"
 
+if [[ "${HOSTILE_ENV}" == "workspace" ]]; then
+  # A bind source holding a space, a comma and a --prefixed token.  The comma
+  # is the one that matters most: the --mount record is CSV, so a source that
+  # carries one has to survive the encoder rather than split the record.  The
+  # copy is required because the checkout itself lives at a plain path.
+  hostile_root="$(mktemp -d "${TMPDIR:-/tmp}/workcell-hostile.XXXXXX")"
+  hostile_workspace="${hostile_root}/hostile ws,dir --workspace"
+  mkdir -p "${hostile_workspace}"
+  cp -a "${WORKSPACE}/." "${hostile_workspace}/"
+  WORKSPACE="$(cd "${hostile_workspace}" && pwd -P)"
+fi
+
 validator_uid="$(id -u)"
 validator_gid="$(id -g)"
+case "${HOSTILE_ENV}" in
+  root)
+    # The suite behaves differently as root, and review has already found
+    # assertions that only hold for an unprivileged uid: a chmod that root
+    # ignores, and a write-only file root can still read.
+    validator_uid=0
+    validator_gid=0
+    ;;
+  uidmap)
+    # A uid that owns none of the bind-mounted files and that the image has no
+    # passwd record for.  That is what a remapped-uid container looks like from
+    # inside, and it is where a readability assumption breaks.
+    validator_uid=$((validator_uid + 1))
+    ;;
+esac
 # GitHub-hosted runners are exclusive per-job, so the /tmp/workcell-home-<uid>
 # planted-symlink TOCTOU surface is not reachable here.  Keep the
 # predictable path for CI to preserve test-fixture stability across
@@ -39,14 +81,13 @@ validator_gid="$(id -g)"
 validator_home="/tmp/workcell-home-${validator_uid}"
 validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
-# WORKCELL_HOSTILE_TMPDIR=1 points TMPDIR at a directory whose name carries the
-# shapes that have broken this repository under review: a space, a literal `$`
-# that a re-expanding generator would substitute, a `--`-prefixed component that
-# a substring flag check mistakes for an option, and ~80 characters of padding
+# The tmpdir axis points TMPDIR at a directory whose name carries the shapes
+# that have broken this repository under review: a space, a literal `$` that a
+# re-expanding generator would substitute, a `--`-prefixed component that a
+# substring flag check mistakes for an option, and ~80 characters of padding
 # that pushes any AF_UNIX path derived from TMPDIR past sun_path.  Three review
-# findings were first reproduced by hand this way; the advisory
-# .github/workflows/ci.yml `hostile-tmpdir` lane runs it on every pull request.
-if [[ "${WORKCELL_HOSTILE_TMPDIR:-0}" == "1" ]]; then
+# findings were first reproduced by hand this way.
+if [[ "${HOSTILE_ENV}" == "tmpdir" ]]; then
   validator_tmp="${validator_tmp}/hostile \$HOME --hostname/$(printf 'p%.0s' {1..80})"
 fi
 

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -39,6 +39,16 @@ validator_gid="$(id -g)"
 validator_home="/tmp/workcell-home-${validator_uid}"
 validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
+# WORKCELL_HOSTILE_TMPDIR=1 points TMPDIR at a directory whose name carries the
+# shapes that have broken this repository under review: a space, a literal `$`
+# that a re-expanding generator would substitute, a `--`-prefixed component that
+# a substring flag check mistakes for an option, and ~80 characters of padding
+# that pushes any AF_UNIX path derived from TMPDIR past sun_path.  Three review
+# findings were first reproduced by hand this way; the advisory
+# .github/workflows/ci.yml `hostile-tmpdir` lane runs it on every pull request.
+if [[ "${WORKCELL_HOSTILE_TMPDIR:-0}" == "1" ]]; then
+  validator_tmp="${validator_tmp}/hostile \$HOME --hostname/$(printf 'p%.0s' {1..80})"
+fi
 
 setup_workcell_ci_docker
 

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -173,6 +173,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/ci/job-pr-shape.sh"
   "${ROOT_DIR}/scripts/ci/job-release-asset-acl.sh"
   "${ROOT_DIR}/scripts/ci/job-validate.sh"
+  "${ROOT_DIR}/scripts/ci/lib/validator-passwd.sh"
   "${ROOT_DIR}/scripts/ci/run-docs-in-validator.sh"
   "${ROOT_DIR}/scripts/ci/run-fuzz-in-validator.sh"
   "${ROOT_DIR}/scripts/ci/run-mutation-in-validator.sh"


### PR DESCRIPTION
## Summary

Counters review-finding class F (portability/flake: `sun_path` under a long TMPDIR, passwd-less uid) and reproduces classes B (shell quoting / env expansion in generated scripts) and E (flag-parsing completeness) before review instead of during it. Several findings on earlier PRs were each first reproduced by hand by running the suite under a hostile environment; this makes that a lane.

- **Advisory hostile-environment lane, four axes.** `WORKCELL_HOSTILE_ENV` selects one axis and `ci.yml` runs a matrix over all four:
  - `tmpdir` — TMPDIR whose name holds a space, a literal `$`, a `--`-prefixed token and 80 characters of padding.
  - `workspace` — the checkout is copied to a bind source named `hostile ws,dir --workspace`; the `--mount` record is CSV, so the comma has to survive the encoder.
  - `root` — the container runs as uid 0, where a chmod assertion and a write-only read assertion stop holding.
  - `uidmap` — the container runs as a uid that owns none of the bind and that the image has no passwd record for.

  An unknown axis exits 2, so a typo cannot report a green advisory lane that tested nothing. The jobs carry `continue-on-error` and are deliberately absent from `required_status_checks` in `policy/github-hosted-controls.toml`, so a red run reports without blocking a merge. They are gated on `validate` so the validator image layers are already in the shared buildx cache scope.
- **Production `sun_path` bound.** `internal/aptbroker` had the length check only in tests (`shortSocketDir`, `socketpair`). Both production endpoints — `listenSocket` and `dialBroker` — now reject an over-long pathname with the limit and the offending length named, instead of the kernel's bare `invalid argument`. The existing test workarounds are unchanged.
- **Passwd-synthesis parity.** The synthesized `/etc/passwd` entry lived only in `run-validate-in-validator.sh`. It moves to `scripts/ci/lib/validator-passwd.sh` and is now used by the docs, fuzz and mutation lanes and by `scripts/build-and-test.sh --docker`, which all ran as a uid the image has no record for and so lost `ssh-keygen`, and with it git's ssh signing and verification. The library gates on the canonical workspace path, keeps the artifact owner-only, and fails closed.
- **Enabling fix.** `validation_entrypoints_test.go` declared `continue-on-error` as `*yaml.Node`. yaml.v3 refuses to decode a scalar into a pointer node, so any job or step setting the key made the whole workflow unparseable, and the two assertions that read the field were unreachable. It is now a value node compared with `IsZero`.

The lane is advisory because three of the four axes are red today (see below). Open #675 does not resolve any of it: it touches only `internal/testkit/release_outputs_verify_test.go`, and none of the failures are in that file.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` — green.
- `bash -n`, `shellcheck -x`, `shfmt -ln=bash -i 2 -ci -d` on every touched script — clean.
- `./scripts/check-workflows.sh` (actionlint, zizmor, retention policy), `./scripts/verify-workflow-lanes.sh` with the regenerated `policy/workflow-lanes.json`, `./scripts/check-doc-links.sh`, `codespell` — pass.
- `./scripts/check-pr-shape.sh` — files=17 lines=889 areas=5.
- **Per-axis mechanics, verified end to end in a container against a local validator image.** `tmpdir`: `TMPDIR=/tmp/workcell-home-501/.tmp/hostile $HOME --hostname/pppp…` (80 chars) with `$HOME` unexpanded. `workspace`: the bind source is `…/hostile ws,dir --workspace` and the CSV mount record survives the preflight and the mount. `root`: `uid=0(root)`. `uidmap`: `uid=502(workcell-ci)` with the synthesized record and the workspace readable.
- **Per-axis results, hosted, on 7a2ab318.**
  - `workspace` — **pass** (8m22s). Full `repo-core` validation with the bind source named `hostile ws,dir --workspace`.
  - `tmpdir` — **fail** (5m46s). 20+ tests across `internal/host/c3certify`, `internal/host/validatorbind`, `internal/startupbench` and `internal/testkit`, matching the local run under the same TMPDIR shape (24 tests, 5 packages). The startupbench driver rejects its own generated values ("must name one executable path, not a shell fragment"); the pre-push hook, ci-plan collector, PR-shape, canonical build env and install-release tests break on the path. These are the class B/E defects the lane exists to surface.
  - `root` — **fail** (5m39s). Five `internal/testkit` `TestUpdateUpstreamPins*` tests.
  - `uidmap` — **fail** (5m22s). The same five, so that group is uid-sensitive rather than root-specific.

  The first matrix run built the validator image four times at once and two builds died with `curl` exit 22 on the pinned Debian snapshot; `max-parallel: 1` fixed that, and every axis now reports the repository rather than the lane's own infrastructure.
- Passwd synthesis: a container run resolves `uid=501(workcell-ci)` in the validate, docs, fuzz and mutation lanes, with `/etc/passwd` at `-r--------`.
- Signature check: every commit on this branch verifies (`%G? = G`), fifteen of fifteen.
- Review: fourteen Codex findings across six rounds; twelve fixed, one rebutted with the reason (no-follow parent), one rebutted as a non-existent commit object. All reacted to and answered in their threads.

## Follow-ups

- The `tmpdir` failures are left to a follow-up per package; the lane is non-blocking until they are cleared, then `continue-on-error` comes off and the jobs join `required_status_checks`.
- The matrix reruns validation four times on every pull request. If runner pressure bites before the failures are cleared, gating it behind the existing `approved-heavy-ci` label is a one-line change.
- Unrelated flake seen locally while running the full suite under load: `internal/host/c3certify` `TestKeepaliveHandlesSignals` ("keepalive did not report readiness"), which passes 3/3 in isolation.
