### PR TITLE
Export the workflow shell-invocation parser and give it direct tests

### DIFF
--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -14,7 +14,10 @@ import (
 // third alternative captures, and it captures the delimiter it opens.
 var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
 
-var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
+// inlineComment consumes quoted words before it reads a comment, so that a #
+// inside an argument such as 'note: # here' cannot truncate the line. As in
+// bash, only an unquoted # at the start of a word opens a comment.
+var inlineComment = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|(?:^|\s)#.*$`)
 
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
@@ -40,7 +43,7 @@ func ShellInvocations(script, command string) [][]string {
 		if strings.HasSuffix(trimmed, "\\") {
 			continue
 		}
-		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
+		logical := strings.TrimSpace(stripComment(current.String()))
 		current.Reset()
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
@@ -57,4 +60,15 @@ func ShellInvocations(script, command string) [][]string {
 		}
 	}
 	return invocations
+}
+
+// stripComment removes an unquoted comment from one logical line. The pattern
+// keeps the quoted words it consumed and deletes only the comment.
+func stripComment(logical string) string {
+	return inlineComment.ReplaceAllStringFunc(logical, func(match string) string {
+		if strings.HasPrefix(match, "'") || strings.HasPrefix(match, `"`) {
+			return match
+		}
+		return ""
+	})
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -71,7 +71,7 @@ func ShellInvocations(script, command string) [][]string {
 // syntax where the shell reads text.
 func shellWords(line string) (words []string, heredocs []heredoc) {
 	var word strings.Builder
-	inWord, quote, pending, dashForm := false, byte(0), false, false
+	inWord, quote, pending, dashForm, substituted := false, byte(0), false, false, false
 	flush := func() {
 		if !inWord {
 			return
@@ -108,9 +108,16 @@ func shellWords(line string) (words []string, heredocs []heredoc) {
 			case character == '`' || (character == '$' && index+1 < len(line) && line[index+1] == '('):
 				// A command substitution resumes shell syntax inside the
 				// quotes. Where it closes is beyond a line reader, so syntax
-				// is read to the end of the line. That reads more heredocs and
-				// comments than bash, never fewer, so it can only drop an
-				// invocation, never invent one.
+				// is read to the end of the line. That finds every heredoc the
+				// line opens, and more, so a body is never read as commands.
+				//
+				// The words are a different answer, and reading syntax over
+				// text invents them: bash keeps the rest of the quoted
+				// argument in one word, while this reader splits it on an
+				// escaped space and hands the validator an option and value
+				// that no command received. The line's words are dropped
+				// instead, so it can lose an invocation, never invent one.
+				substituted = true
 				quote = 0
 				word.WriteByte(character)
 			default:
@@ -152,5 +159,8 @@ func shellWords(line string) (words []string, heredocs []heredoc) {
 		}
 	}
 	flush()
+	if substituted {
+		return nil, heredocs
+	}
 	return words, heredocs
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -4,20 +4,9 @@
 package metadatautil
 
 import (
-	"cmp"
-	"regexp"
+	"slices"
 	"strings"
 )
-
-// heredocPattern consumes quoted words before it reads a redirection, so that
-// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
-// third alternative captures, and it captures the delimiter it opens.
-var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
-
-// inlineComment consumes quoted words before it reads a comment, so that a #
-// inside an argument such as 'note: # here' cannot truncate the line. As in
-// bash, only an unquoted # at the start of a word opens a comment.
-var inlineComment = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|(?:^|\s)#.*$`)
 
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
@@ -25,6 +14,7 @@ var inlineComment = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|(?:^|\s)#.*$`)
 // one call cannot satisfy a two-call rule. A validator that must anchor on the
 // commands a script really runs uses this in place of a substring search.
 func ShellInvocations(script, command string) [][]string {
+	prefix := strings.Fields(command)
 	var invocations [][]string
 	var current strings.Builder
 	var heredocs []string
@@ -36,39 +26,95 @@ func ShellInvocations(script, command string) [][]string {
 			}
 			continue
 		}
-		if current.Len() > 0 {
-			current.WriteString(" ")
-		}
 		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
 		if strings.HasSuffix(trimmed, "\\") {
+			current.WriteString(" ")
 			continue
 		}
-		logical := strings.TrimSpace(stripComment(current.String()))
+		words, opened := shellWords(current.String())
 		current.Reset()
-		// Here-strings are blanked first so that a redirection such as
-		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten. A match
-		// with no capture is a consumed quoted word, not a redirection.
-		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
-				heredocs = append(heredocs, delimiter)
-			}
-		}
-		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
-			invocations = append(invocations, strings.Fields(rest))
+		heredocs = append(heredocs, opened...)
+		if len(words) >= len(prefix) && slices.Equal(words[:len(prefix)], prefix) {
+			invocations = append(invocations, words[len(prefix):])
 		}
 	}
 	return invocations
 }
 
-// stripComment removes an unquoted comment from one logical line. The pattern
-// keeps the quoted words it consumed and deletes only the comment.
-func stripComment(logical string) string {
-	return inlineComment.ReplaceAllStringFunc(logical, func(match string) string {
-		if strings.HasPrefix(match, "'") || strings.HasPrefix(match, `"`) {
-			return match
+// shellWords splits one logical line the way bash reads it. Quotes and
+// backslash escapes are removed, so a quoted argument stays one word and a
+// separator inside it is text rather than syntax; an unquoted # that starts a
+// word ends the line; and every heredoc the line opens returns as a delimiter,
+// in the order bash reads the bodies.
+//
+// One pass keeps the three answers consistent. A pattern per answer cannot:
+// each has to rediscover the quoting, and the one that gets it wrong reads
+// syntax where the shell reads text.
+func shellWords(line string) (words, heredocs []string) {
+	var word strings.Builder
+	inWord, quote, pending := false, byte(0), false
+	flush := func() {
+		if !inWord {
+			return
 		}
-		return ""
-	})
+		if pending {
+			heredocs = append(heredocs, word.String())
+			pending = false
+		} else {
+			words = append(words, word.String())
+		}
+		word.Reset()
+		inWord = false
+	}
+	for index := 0; index < len(line); index++ {
+		character := line[index]
+		switch {
+		case quote == '\'':
+			// A backslash is literal inside single quotes.
+			if character == '\'' {
+				quote = 0
+			} else {
+				word.WriteByte(character)
+			}
+		case quote == '"':
+			if character == '\\' && index+1 < len(line) {
+				index++
+				word.WriteByte(line[index])
+			} else if character == '"' {
+				quote = 0
+			} else {
+				word.WriteByte(character)
+			}
+		case character == '\\' && index+1 < len(line):
+			// An escaped quote is a literal character, not the start of a
+			// quoted span, so it cannot hide the syntax that follows it.
+			index++
+			word.WriteByte(line[index])
+			inWord = true
+		case character == '\'' || character == '"':
+			quote = character
+			inWord = true
+		case character == ' ' || character == '\t':
+			flush()
+		case character == '#' && !inWord:
+			return words, heredocs
+		case character == '<' && index+1 < len(line) && line[index+1] == '<':
+			flush()
+			index++
+			if index+1 < len(line) && line[index+1] == '<' {
+				// A here-string takes its text from the line, not from a body.
+				index++
+				break
+			}
+			if index+1 < len(line) && line[index+1] == '-' {
+				index++
+			}
+			pending = true
+		default:
+			word.WriteByte(character)
+			inWord = true
+		}
+	}
+	flush()
+	return words, heredocs
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+// heredoc is one body a script line opened. The dash form matters after the
+// opening line, because it alone lets the terminator carry leading tabs.
+type heredoc struct {
+	delimiter string
+	dashForm  bool
+}
+
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
 // included, and heredoc bodies, so that no decoy text counts as a command and
@@ -17,20 +24,32 @@ func ShellInvocations(script, command string) [][]string {
 	prefix := strings.Fields(command)
 	var invocations [][]string
 	var current strings.Builder
-	var heredocs []string
+	var heredocs []heredoc
 	for line := range strings.Lines(script) {
-		trimmed := strings.TrimSpace(line)
+		body := strings.TrimSuffix(line, "\n")
 		if len(heredocs) > 0 {
-			if trimmed == heredocs[0] {
+			// Bash compares the whole line against the delimiter, and only the
+			// dash form removes leading tabs first. A terminator that carries
+			// any other text, one space included, leaves the body open and
+			// keeps swallowing the commands below it.
+			terminator := body
+			if heredocs[0].dashForm {
+				terminator = strings.TrimLeft(terminator, "\t")
+			}
+			if terminator == heredocs[0].delimiter {
 				heredocs = heredocs[1:]
 			}
 			continue
 		}
-		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
-		if strings.HasSuffix(trimmed, "\\") {
-			current.WriteString(" ")
+		// A backslash continues the line only when it is not itself escaped,
+		// and bash then joins the two halves with nothing between them. A
+		// space after the backslash escapes the space instead, which ends the
+		// line and makes the next one a separate command.
+		if backslashes := len(body) - len(strings.TrimRight(body, `\`)); backslashes%2 == 1 {
+			current.WriteString(body[:len(body)-1])
 			continue
 		}
+		current.WriteString(body)
 		words, opened := shellWords(current.String())
 		current.Reset()
 		heredocs = append(heredocs, opened...)
@@ -50,16 +69,16 @@ func ShellInvocations(script, command string) [][]string {
 // One pass keeps the three answers consistent. A pattern per answer cannot:
 // each has to rediscover the quoting, and the one that gets it wrong reads
 // syntax where the shell reads text.
-func shellWords(line string) (words, heredocs []string) {
+func shellWords(line string) (words []string, heredocs []heredoc) {
 	var word strings.Builder
-	inWord, quote, pending := false, byte(0), false
+	inWord, quote, pending, dashForm := false, byte(0), false, false
 	flush := func() {
 		if !inWord {
 			return
 		}
 		if pending {
-			heredocs = append(heredocs, word.String())
-			pending = false
+			heredocs = append(heredocs, heredoc{delimiter: word.String(), dashForm: dashForm})
+			pending, dashForm = false, false
 		} else {
 			words = append(words, word.String())
 		}
@@ -120,6 +139,7 @@ func shellWords(line string) (words, heredocs []string) {
 			}
 			if index+1 < len(line) && line[index+1] == '-' {
 				index++
+				dashForm = true
 			}
 			pending = true
 		case pending && strings.IndexByte(";&|<>()", character) >= 0:

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -77,12 +77,24 @@ func shellWords(line string) (words, heredocs []string) {
 				word.WriteByte(character)
 			}
 		case quote == '"':
-			if character == '\\' && index+1 < len(line) {
+			switch {
+			case character == '\\' && index+1 < len(line) && strings.IndexByte("$`\"\\", line[index+1]) >= 0:
+				// A backslash escapes only these characters here. Before any
+				// other one it is a literal byte of the word, so a name such
+				// as "or\as" is not the command it resembles.
 				index++
 				word.WriteByte(line[index])
-			} else if character == '"' {
+			case character == '"':
 				quote = 0
-			} else {
+			case character == '`' || (character == '$' && index+1 < len(line) && line[index+1] == '('):
+				// A command substitution resumes shell syntax inside the
+				// quotes. Where it closes is beyond a line reader, so syntax
+				// is read to the end of the line. That reads more heredocs and
+				// comments than bash, never fewer, so it can only drop an
+				// invocation, never invent one.
+				quote = 0
+				word.WriteByte(character)
+			default:
 				word.WriteByte(character)
 			}
 		case character == '\\' && index+1 < len(line):

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -122,6 +122,10 @@ func shellWords(line string) (words, heredocs []string) {
 				index++
 			}
 			pending = true
+		case pending && strings.IndexByte(";&|<>()", character) >= 0:
+			// A delimiter word ends at an operator, as in cat <<EOF; echo
+			// ready, where bash reads the delimiter EOF and runs the echo.
+			flush()
 		default:
 			word.WriteByte(character)
 			inWord = true

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"cmp"
+	"regexp"
+	"strings"
+)
+
+// heredocPattern consumes quoted words before it reads a redirection, so that
+// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
+// third alternative captures, and it captures the delimiter it opens.
+var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+
+var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
+
+// ShellInvocations returns the arguments of each invocation of command in
+// script. It joins line continuations and drops comments, inline ones
+// included, and heredoc bodies, so that no decoy text counts as a command and
+// one call cannot satisfy a two-call rule. A validator that must anchor on the
+// commands a script really runs uses this in place of a substring search.
+func ShellInvocations(script, command string) [][]string {
+	var invocations [][]string
+	var current strings.Builder
+	var heredocs []string
+	for line := range strings.Lines(script) {
+		trimmed := strings.TrimSpace(line)
+		if len(heredocs) > 0 {
+			if trimmed == heredocs[0] {
+				heredocs = heredocs[1:]
+			}
+			continue
+		}
+		if current.Len() > 0 {
+			current.WriteString(" ")
+		}
+		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
+		if strings.HasSuffix(trimmed, "\\") {
+			continue
+		}
+		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
+		current.Reset()
+		// Here-strings are blanked first so that a redirection such as
+		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
+		// Every delimiter on the line opens a body, and bash reads them in the
+		// order they appear, so they are queued rather than overwritten. A match
+		// with no capture is a consumed quoted word, not a redirection.
+		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
+			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
+				heredocs = append(heredocs, delimiter)
+			}
+		}
+		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
+			invocations = append(invocations, strings.Fields(rest))
+		}
+	}
+	return invocations
+}

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -40,6 +40,16 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"one"}},
 		},
 		{
+			name:   "a hash inside single quotes is an argument, not a comment",
+			script: "oras cp 'note: # here' one\n",
+			want:   [][]string{{"'note:", "#", "here'", "one"}},
+		},
+		{
+			name:   "a hash inside double quotes is an argument, not a comment",
+			script: "oras cp \"note: # here\" one\n",
+			want:   [][]string{{"\"note:", "#", "here\"", "one"}},
+		},
+		{
 			name:   "a heredoc body with a quoted delimiter runs nothing",
 			script: "cat <<'PLAN'\noras cp one\nPLAN\noras cp two\n",
 			want:   [][]string{{"two"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -42,12 +42,27 @@ func TestShellInvocations(t *testing.T) {
 		{
 			name:   "a hash inside single quotes is an argument, not a comment",
 			script: "oras cp 'note: # here' one\n",
-			want:   [][]string{{"'note:", "#", "here'", "one"}},
+			want:   [][]string{{"note: # here", "one"}},
 		},
 		{
 			name:   "a hash inside double quotes is an argument, not a comment",
 			script: "oras cp \"note: # here\" one\n",
-			want:   [][]string{{"\"note:", "#", "here\"", "one"}},
+			want:   [][]string{{"note: # here", "one"}},
+		},
+		{
+			name:   "a hash inside a word is an argument, not a comment",
+			script: "oras cp a#b one\n",
+			want:   [][]string{{"a#b", "one"}},
+		},
+		{
+			name:   "a quoted argument stays one word, so an option inside it is text",
+			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
+			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},
+		},
+		{
+			name:   "an escaped quote does not open a span that hides a delimiter",
+			script: ": \\' <<PLAN ''\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
 		},
 		{
 			name:   "a heredoc body with a quoted delimiter runs nothing",

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestShellInvocations(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, script string
+		want         [][]string
+	}{
+		{
+			name:   "arguments of each invocation",
+			script: "oras cp one\noras cp two\n",
+			want:   [][]string{{"one"}, {"two"}},
+		},
+		{
+			name:   "a longer command name is not the requested command",
+			script: "oras cpx one\n",
+		},
+		{
+			name:   "continuations join into one invocation",
+			script: "oras cp \\\n  one \\\n  two\n",
+			want:   [][]string{{"one", "two"}},
+		},
+		{
+			name:   "a full-line comment runs nothing",
+			script: "# oras cp one\n",
+		},
+		{
+			name:   "an inline comment ends the invocation",
+			script: "oras cp one # oras cp two\n",
+			want:   [][]string{{"one"}},
+		},
+		{
+			name:   "a heredoc body with a quoted delimiter runs nothing",
+			script: "cat <<'PLAN'\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "an unquoted delimiter still opens a body, expansions included",
+			script: "cat <<PLAN\noras cp ${DECOY}\noras cp $(oras cp one)\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a tab-stripped delimiter closes the body it opened",
+			script: "cat <<-PLAN\n\toras cp one\n\tPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "two heredocs on one line each consume their own body",
+			script: "cat <<'NOTE' <<'PLAN'\noras cp one\nNOTE\noras cp two\nPLAN\noras cp three\n",
+			want:   [][]string{{"three"}},
+		},
+		{
+			name:   "a quoted word cannot open a delimiter",
+			script: ": <<'A' \"text <<B\"\nA\ncat <<'PLAN'\nB\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a here-string does not open a heredoc",
+			script: "cat <<<\"${PLAN}\"\noras cp one\n",
+			want:   [][]string{{"one"}},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got := metadatautil.ShellInvocations(testCase.script, "oras cp")
+			if !slices.EqualFunc(got, testCase.want, slices.Equal) {
+				t.Fatalf("ShellInvocations() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -55,6 +55,16 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"a#b", "one"}},
 		},
 		{
+			name:   "a backslash before an ordinary character stays literal in double quotes",
+			script: "\"or\\as\" cp one\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a command substitution inside double quotes opens its heredoc",
+			script: "printf '%s' \"$(cat <<PLAN\noras cp one\nPLAN\n)\"\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
 			name:   "a quoted argument stays one word, so an option inside it is text",
 			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
 			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -65,6 +65,11 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"two"}},
 		},
 		{
+			name:   "a delimiter word ends at an operator on the same line",
+			script: "cat <<EOF; oras cp one\nbody\nEOF\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
 			name:   "a quoted argument stays one word, so an option inside it is text",
 			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
 			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -100,6 +100,11 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"two"}},
 		},
 		{
+			name:   "a command substitution inside double quotes drops the line's words",
+			script: "oras cp --recursive --from-oci-layout \"$(printf x)\\ # --to-oci-layout dist/release-image:amd64 ignored\" || true\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
 			name:   "a delimiter word ends at an operator on the same line",
 			script: "cat <<EOF; oras cp one\nbody\nEOF\noras cp two\n",
 			want:   [][]string{{"two"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -31,6 +31,41 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"one", "two"}},
 		},
 		{
+			name:   "a continuation joins the halves with nothing between them",
+			script: "oras cp --to-oci-layout\\\ndist/release-image:amd64\n",
+			want:   [][]string{{"--to-oci-layoutdist/release-image:amd64"}},
+		},
+		{
+			name:   "a space after a backslash ends the line, so the next line is another command",
+			script: "oras cp one \\ \n--to-oci-layout dist/release-image:amd64\n",
+			want:   [][]string{{"one", " "}},
+		},
+		{
+			name:   "an escaped backslash ends the line, so the next line is another command",
+			script: "oras cp one \\\\\n--to-oci-layout dist/release-image:amd64\n",
+			want:   [][]string{{"one", "\\"}},
+		},
+		{
+			name:   "an indented terminator leaves a plain heredoc body open",
+			script: "cat <<PLAN\n  PLAN\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a tab-indented terminator leaves a plain heredoc body open",
+			script: "cat <<PLAN\n\tPLAN\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a space-indented terminator leaves a tab-stripped heredoc body open",
+			script: "cat <<-PLAN\n  PLAN\noras cp one\n\tPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a terminator with trailing text leaves the body open",
+			script: "cat <<PLAN\nPLAN \noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
 			name:   "a full-line comment runs nothing",
 			script: "# oras cp one\n",
 		},

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -248,6 +248,52 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind an indented terminator bash never reads as one",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          cat <<PLAN >/dev/null\n" +
+				"            PLAN\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind a space-indented terminator of a tab-stripped body",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          cat <<-PLAN >/dev/null\n" +
+				"            PLAN\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
+			name: "destinations moved onto a line a space after the backslash detaches",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          oras cp --recursive --from-oci-layout \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\ \n" +
+				"          --to-oci-layout dist/release-image:amd64 || true\n" +
+				"          oras cp --recursive --from-oci-layout \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\ \n" +
+				"          --to-oci-layout dist/release-image:arm64 || true",
+			want: "copy both platform images",
+		},
+		{
+			name: "destinations joined to their option by a continuation that inserts no space",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          oras cp --recursive --from-oci-layout \"dist/image-amd64/layout@${AMD64_DIGEST}\" --to-oci-layout\\\n" +
+				"          dist/release-image:amd64 || true\n" +
+				"          oras cp --recursive --from-oci-layout \"dist/image-arm64/layout@${ARM64_DIGEST}\" --to-oci-layout\\\n" +
+				"          dist/release-image:arm64 || true",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -207,6 +207,26 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "destinations moved inside a quoted argument the shell never reads as options",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          oras cp --recursive --from-oci-layout 'x --to-oci-layout dist/release-image:amd64 x' || true\n" +
+				"          oras cp --recursive --from-oci-layout 'x --to-oci-layout dist/release-image:arm64 x' || true",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind a delimiter an escaped quote appears to quote",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : \\' <<PLAN ''\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -235,6 +235,14 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "destinations exposed by a command substitution inside the quoted argument",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          oras cp --recursive --from-oci-layout \"$(printf x)\\ # --to-oci-layout dist/release-image:amd64 ignored\" || true\n" +
+				"          oras cp --recursive --from-oci-layout \"$(printf x)\\ # --to-oci-layout dist/release-image:arm64 ignored\" || true",
+			want: "copy both platform images",
+		},
+		{
 			name: "real commands moved into a heredoc a quoted command substitution opens",
 			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
 				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -179,6 +179,19 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands replaced by the second body of two heredocs",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          cat <<'NOTE' <<'PLAN' >/dev/null\n" +
+				"          NOTE\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -227,6 +227,27 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "copies renamed to a command bash never runs by a backslash in double quotes",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          \"or\\as\" cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64 || true\n" +
+				"          \"or\\as\" cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64 || true",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands moved into a heredoc a quoted command substitution opens",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          printf '%s' \"$(cat <<PLAN\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN\n" +
+				"          )\"",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -192,6 +192,21 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind a quoted delimiter that desynchronises the queue",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : <<'A' \"text <<B\"\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -215,12 +215,12 @@ var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 func commandArgs(script, command string) [][]string {
 	var invocations [][]string
 	var current strings.Builder
-	var heredoc string
+	var heredocs []string
 	for line := range strings.Lines(script) {
 		trimmed := strings.TrimSpace(line)
-		if heredoc != "" {
-			if trimmed == heredoc {
-				heredoc = ""
+		if len(heredocs) > 0 {
+			if trimmed == heredocs[0] {
+				heredocs = heredocs[1:]
 			}
 			continue
 		}
@@ -235,8 +235,10 @@ func commandArgs(script, command string) [][]string {
 		current.Reset()
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		if match := heredocPattern.FindStringSubmatch(strings.ReplaceAll(logical, "<<<", " ")); match != nil {
-			heredoc = cmp.Or(match[1], match[2], match[3])
+		// Every delimiter on the line opens a body, and bash reads them in the
+		// order they appear, so they are queued rather than overwritten.
+		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
+			heredocs = append(heredocs, cmp.Or(match[1], match[2], match[3]))
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -4,7 +4,6 @@
 package metadatautil
 
 import (
-	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -187,7 +186,7 @@ func validateReleaseAssembly(document workflowDocument) error {
 	steps := document.Jobs["release"].Steps
 	if !slices.ContainsFunc(steps, func(step workflowStep) bool {
 		var targets []string
-		for _, args := range commandArgs(step.Run, "oras cp --recursive --from-oci-layout") {
+		for _, args := range ShellInvocations(step.Run, "oras cp --recursive --from-oci-layout") {
 			if at := slices.Index(args, "--to-oci-layout"); at >= 0 && at+1 < len(args) {
 				targets = append(targets, args[at+1])
 			}
@@ -198,59 +197,11 @@ func validateReleaseAssembly(document workflowDocument) error {
 		return errors.New("release job must copy both platform images into the release OCI layout it indexes")
 	}
 	if !slices.ContainsFunc(steps, func(step workflowStep) bool {
-		return len(commandArgs(step.Run, "oras manifest index create --oci-layout")) > 0
+		return len(ShellInvocations(step.Run, "oras manifest index create --oci-layout")) > 0
 	}) {
 		return errors.New("release job must assemble the multi-arch index in an OCI layout")
 	}
 	return nil
-}
-
-// heredocPattern consumes quoted words before it reads a redirection, so that
-// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
-// third alternative captures, and it captures the delimiter it opens.
-var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
-
-var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
-
-// commandArgs returns the arguments of each invocation of command in script. It
-// joins continuations and drops comments, inline ones included, and heredoc bodies,
-// so no decoy text counts as a command and one call cannot satisfy a two-call rule.
-func commandArgs(script, command string) [][]string {
-	var invocations [][]string
-	var current strings.Builder
-	var heredocs []string
-	for line := range strings.Lines(script) {
-		trimmed := strings.TrimSpace(line)
-		if len(heredocs) > 0 {
-			if trimmed == heredocs[0] {
-				heredocs = heredocs[1:]
-			}
-			continue
-		}
-		if current.Len() > 0 {
-			current.WriteString(" ")
-		}
-		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
-		if strings.HasSuffix(trimmed, "\\") {
-			continue
-		}
-		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
-		current.Reset()
-		// Here-strings are blanked first so that a redirection such as
-		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten. A match
-		// with no capture is a consumed quoted word, not a redirection.
-		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
-				heredocs = append(heredocs, delimiter)
-			}
-		}
-		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
-			invocations = append(invocations, strings.Fields(rest))
-		}
-	}
-	return invocations
 }
 
 func validateUnprivilegedReleaseJobs(document workflowDocument) error {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -205,7 +205,10 @@ func validateReleaseAssembly(document workflowDocument) error {
 	return nil
 }
 
-var heredocPattern = regexp.MustCompile(`<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+// heredocPattern consumes quoted words before it reads a redirection, so that
+// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
+// third alternative captures, and it captures the delimiter it opens.
+var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
 
 var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 
@@ -236,9 +239,12 @@ func commandArgs(script, command string) [][]string {
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
 		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten.
+		// order they appear, so they are queued rather than overwritten. A match
+		// with no capture is a consumed quoted word, not a redirection.
 		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			heredocs = append(heredocs, cmp.Or(match[1], match[2], match[3]))
+			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
+				heredocs = append(heredocs, delimiter)
+			}
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))


### PR DESCRIPTION
## Summary

The workflow validators anchor on the commands a `run:` block really executes,
not on substrings of its text. The parser that does this (`commandArgs`) was
unexported, had two call sites, and had no direct test. Every edge it handles
was covered only by accident, through the release.yml decoy table.

This is unit (a) of the four-part plan against the two largest classes in the
Codex review corpus for PRs 600-685:

- **Class D, validator anchoring (25 findings, 15 confirmed).** Comments,
  inline comments, heredoc bodies, here-strings and prefix extension defeat a
  `strings.Contains` check. #672 alone produced nine of these, #680 two more.
  The parser is the counter. It could not be reused because it was unexported,
  so each new validator started again with a substring search and learned the
  lesson from the bot.
- **Class G, mutation gaps (22 findings).** A suite that survives a mutant of
  the thing it tests. No mutant in `policy/mutation-score-policy.json` touches
  `workflows.go`. The new tables are a direct mutation check of the parser.

Three changes:

1. `commandArgs` moves out of `internal/metadatautil/workflows.go` into a new
   file as the exported `metadatautil.ShellInvocations(script, command string)
   [][]string`. The two release-assembly call sites now call it.
2. A direct table test names the edges the parser handles, one per row:
   continuations, a full-line comment, an inline comment, a hash inside a word
   and inside each quote form, a quoted heredoc delimiter, an unquoted
   delimiter whose body holds expansions, a `<<-` delimiter closed by a
   tab-indented terminator, two heredocs opened on one line, a `<<` inside a
   quoted word, an escaped quote, a here-string, and a longer command name
   that is not the requested command.
3. The two regexes are replaced by `shellWords`, one pass that reads a logical
   line as shell words. This closes two bypasses of `validateReleaseAssembly`
   that the first review round found, both proved by a decoy fixture:

   - `strings.Fields` split a quoted argument, so
     `oras cp --recursive --from-oci-layout 'x --to-oci-layout dist/release-image:amd64 x' || true`
     gave the validator an exact option and target pair that bash passes as one
     inert word. Two such lines satisfied the both-platforms rule while the job
     copied neither image. **This bypass is older than this branch**: the same
     decoy passes against the parser on `main`.
   - `heredocPattern` started a quoted span at a backslash-escaped apostrophe,
     so `: \' <<PLAN ''` hid the `PLAN` delimiter and the heredoc body was read
     as commands. Confirmed against bash: the body is swallowed and never runs.

   One pass keeps the three answers consistent, where a pattern per answer has
   to rediscover the quoting and the one that gets it wrong reads syntax where
   the shell reads text. A quoted argument is one word, an escape is one
   literal character, an unquoted `#` that starts a word ends the line, and the
   command is matched word by word rather than by a text prefix.

### Dependency on #680

#680 (`fix/commandargs-multi-heredoc`) is open and fixes the multi-heredoc and
quoted-delimiter defects in the same parser. Its two commits are cherry-picked
here, so its two decoy fixtures ride along and keep passing against the
rewritten parser. If #680 merges first, this branch keeps only the export, the
tests and the word reader. Merge order does not matter; the content is the
same.

Units (b) shared evasion corpus and (c) registry parity check follow
separately. This PR adds no validator and changes no workflow.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./internal/metadatautil/ -count=1` (green, existing decoy tables included)
- `go test ./...` (green)
- `gofmt -l .` (clean)

Every new fixture was run against the commit before its fix and fails there,
so none restates behaviour that already held. The two bypass fixtures for the
quoted argument and the escaped quote were also run against `main`.

Mutation checks on `shellWords`, one per rule. Each mutant was applied, the
parser table and the release decoy table were run, and the file was restored:

| Mutant | Result |
| --- | --- |
| escape handling dropped | killed |
| quotes treated as ordinary characters | killed |
| `#` ends the line even inside a word | killed |
| command prefix not compared | killed |
| line continuation not joined | killed |
| here-string treated as a heredoc | killed |
| `<<-` dash not consumed | killed |
| heredoc delimiter not queued | killed |
| double-quote backslash escapes every character | killed |
| command substitution not recognised inside double quotes | killed |
| delimiter word not ended at an operator | killed |

Eleven mutants, eleven killed, no survivors.

## Review rounds

Three rounds. Five findings, all accepted, all fixed, each with its own test:

| Round | Finding | Severity | Fixture |
| --- | --- | --- | --- |
| 1 | `strings.Fields` split a quoted argument | P1 | decoy: destinations inside a quoted argument |
| 1 | a quoted span started at an escaped quote | P1 | decoy: delimiter an escaped quote appears to quote |
| 2 | a backslash was dropped before every character in double quotes | P1 | decoy: copies renamed by a backslash in double quotes |
| 2 | a heredoc in a quoted command substitution was missed | P1 | decoy: heredoc a quoted substitution opens |
| 3 | a delimiter word ran past an operator | P2 | unit: delimiter ends at an operator |

Severity fell across the rounds and round 3 raised no bypass. The head commit
`c2a5e01e` carries the round 3 fix and has not been through a further round.
