### PR TITLE
^F Add testkit flag-form and shell-quoting helpers, and close the gaps they expose

### DIFF
--- a/internal/host/validatorbind/validatorbind_test.go
+++ b/internal/host/validatorbind/validatorbind_test.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/omkhar/workcell/internal/testkit"
 )
 
 var errInvalidCleanupContext = errors.New("cleanup context is canceled or unbounded")
@@ -449,16 +451,16 @@ func blockingDockerFixture(t *testing.T) (string, string) {
 	path := filepath.Join(t.TempDir(), "docker")
 	commandLog := path + ".log"
 	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$@" >> %q
+printf '%%s\n' "$@" >> %s
 if [ "$1" = "--context" ]; then
 	shift 2
 fi
 if [ "$1" = "rm" ]; then
 	exit 0
 fi
-printf '%%s\n' %q >> %q
+printf '%%s\n' %s >> %s
 exec /bin/sleep 60
-`, commandLog, completedProbeLogMarker, commandLog)
+`, testkit.ShellQuote(commandLog), testkit.ShellQuote(completedProbeLogMarker), testkit.ShellQuote(commandLog))
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testkit/argv.go
+++ b/internal/testkit/argv.go
@@ -4,6 +4,7 @@
 package testkit
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -60,8 +61,29 @@ func CountFlagOccurrences(argv []string, flag, short string) int {
 	return count
 }
 
-// AssertRejectsLaterOverride fails t unless run rejects base with hostile
-// appended in every spelling FlagForms produces.
+// laterOverrideProblems reports each way run failed the later-override
+// contract, one description per problem and none when run holds the contract.
+//
+// The unmodified base is tried first. A base that is already rejected, because
+// it lacks another required option or because the runner cannot start, makes
+// every augmented invocation fail for that unrelated reason, and a last-wins
+// parser would then look as though it rejected every hostile form.
+func laterOverrideProblems(run func([]string) error, base []string, flag, short, hostile string) []string {
+	if err := run(base); err != nil {
+		return []string{fmt.Sprintf("base argv %q was rejected before any override was added, so no rejection below is evidence: %v", base, err)}
+	}
+	var problems []string
+	for _, form := range FlagForms(flag, short, hostile) {
+		argv := append(append([]string(nil), base...), form...)
+		if err := run(argv); err == nil {
+			problems = append(problems, fmt.Sprintf("argv %q accepted a later %s override; want a rejection", argv, strings.Join(form, " ")))
+		}
+	}
+	return problems
+}
+
+// AssertRejectsLaterOverride fails t unless run accepts base on its own and
+// rejects base with hostile appended in every spelling FlagForms produces.
 //
 // A last-wins parser is the danger. The trusted value in base stays visible to
 // an assertion that reads the first occurrence, while the process being driven
@@ -69,11 +91,8 @@ func CountFlagOccurrences(argv []string, flag, short string) int {
 // behaviour that is safe under both readings.
 func AssertRejectsLaterOverride(t *testing.T, run func([]string) error, base []string, flag, short, hostile string) {
 	t.Helper()
-	for _, form := range FlagForms(flag, short, hostile) {
-		argv := append(append([]string(nil), base...), form...)
-		if err := run(argv); err == nil {
-			t.Errorf("argv %q accepted a later %s override; want a rejection", argv, strings.Join(form, " "))
-		}
+	for _, problem := range laterOverrideProblems(run, base, flag, short, hostile) {
+		t.Error(problem)
 	}
 }
 

--- a/internal/testkit/argv.go
+++ b/internal/testkit/argv.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"strings"
+	"testing"
+)
+
+// FlagForms returns every accepted spelling of one flag and its value:
+//
+//	--flag value    --flag=value    -s value    -s=value    -svalue
+//
+// flag and short are bare names, without leading dashes. An empty short
+// suppresses the three short forms.
+//
+// A test that asserts a security-sensitive flag must exercise all of them. A
+// hand-written assertion covers the long-space form only, so a parser that
+// splits the argument vector on whitespace and looks at the token after the
+// flag accepts every attached spelling unread.
+func FlagForms(flag, short, value string) [][]string {
+	forms := [][]string{
+		{"--" + flag, value},
+		{"--" + flag + "=" + value},
+	}
+	if short == "" {
+		return forms
+	}
+	return append(forms,
+		[]string{"-" + short, value},
+		[]string{"-" + short + "=" + value},
+		[]string{"-" + short + value},
+	)
+}
+
+// CountFlagOccurrences reports how many entries of argv spell flag or short,
+// in any form FlagForms produces.
+//
+// The comparison is per argv entry, never a substring scan of the flattened
+// argument string. A value that merely contains the flag text, such as a
+// temporary directory named ".../review--hostname-tmp", is not an occurrence,
+// and a `$*` substring test counts it as one. Callers assert exactly one
+// occurrence for a security-sensitive flag.
+//
+// ponytail: a short name is matched at entry position 1 only; a clustered
+// form such as "-vH value" is not counted. Widen when a caller needs it.
+func CountFlagOccurrences(argv []string, flag, short string) int {
+	long := "--" + flag
+	count := 0
+	for _, arg := range argv {
+		if arg == long || strings.HasPrefix(arg, long+"=") {
+			count++
+			continue
+		}
+		if short != "" && !strings.HasPrefix(arg, "--") && strings.HasPrefix(arg, "-"+short) {
+			count++
+		}
+	}
+	return count
+}
+
+// AssertRejectsLaterOverride fails t unless run rejects base with hostile
+// appended in every spelling FlagForms produces.
+//
+// A last-wins parser is the danger. The trusted value in base stays visible to
+// an assertion that reads the first occurrence, while the process being driven
+// uses the attacker's later one. Rejecting the duplicate outright is the only
+// behaviour that is safe under both readings.
+func AssertRejectsLaterOverride(t *testing.T, run func([]string) error, base []string, flag, short, hostile string) {
+	t.Helper()
+	for _, form := range FlagForms(flag, short, hostile) {
+		argv := append(append([]string(nil), base...), form...)
+		if err := run(argv); err == nil {
+			t.Errorf("argv %q accepted a later %s override; want a rejection", argv, strings.Join(form, " "))
+		}
+	}
+}
+
+// ShellQuote returns s as one POSIX shell word: single-quoted, with every
+// embedded single quote closed, escaped and reopened.
+//
+// Go's %q verb is not a substitute. It emits a Go literal, and the shell then
+// re-reads that literal under its own rules: a value holding $HOME, a backtick
+// or a $(...) passes through %q unchanged and the shell expands it. Single
+// quotes suppress every expansion, so this is safe for any byte sequence.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/testkit/argv.go
+++ b/internal/testkit/argv.go
@@ -68,6 +68,13 @@ func CountFlagOccurrences(argv []string, flag, short string) int {
 // it lacks another required option or because the runner cannot start, makes
 // every augmented invocation fail for that unrelated reason, and a last-wins
 // parser would then look as though it rejected every hostile form.
+//
+// The caller owns one precondition that this helper cannot check: hostile must
+// be a value the parser would accept were it not a duplicate. A value that is
+// independently invalid, an unresolvable host or a path that does not exist,
+// makes every augmented invocation fail on its own merits and restores the
+// same vacuous pass one level up. Pass a well-formed value of the same shape
+// as the one in base.
 func laterOverrideProblems(run func([]string) error, base []string, flag, short, hostile string) []string {
 	if err := run(base); err != nil {
 		return []string{fmt.Sprintf("base argv %q was rejected before any override was added, so no rejection below is evidence: %v", base, err)}

--- a/internal/testkit/argv_test.go
+++ b/internal/testkit/argv_test.go
@@ -75,6 +75,46 @@ func TestAssertRejectsLaterOverrideAcceptsAParserThatRejectsEveryForm(t *testing
 	AssertRejectsLaterOverride(t, run, []string{"--hostname", "trusted.example"}, "hostname", "H", "attacker.example")
 }
 
+// TestLaterOverrideProblemsRequiresAWorkingBaseline is the negative control for
+// a vacuous pass. A runner that fails for its own reasons rejects every hostile
+// form too, so without the baseline check a last-wins parser looks compliant.
+func TestLaterOverrideProblemsRequiresAWorkingBaseline(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"--hostname", "trusted.example"}
+	errSetup := errors.New("runner could not start")
+	alwaysFails := func([]string) error { return errSetup }
+
+	problems := laterOverrideProblems(alwaysFails, base, "hostname", "H", "attacker.example")
+	if len(problems) != 1 || !strings.Contains(problems[0], "before any override") {
+		t.Fatalf("laterOverrideProblems() with a failing baseline = %q, want one baseline problem", problems)
+	}
+
+	// The same runner without the baseline check reports nothing, which is the
+	// vacuous pass this guard removes.
+	silent := 0
+	for _, form := range FlagForms("hostname", "H", "attacker.example") {
+		if alwaysFails(append(append([]string(nil), base...), form...)) == nil {
+			silent++
+		}
+	}
+	if silent != 0 {
+		t.Fatalf("fixture no longer reproduces the vacuous pass: %d forms were accepted", silent)
+	}
+}
+
+// TestLaterOverrideProblemsReportsEveryAcceptedForm covers the other direction:
+// a last-wins parser over a working baseline is reported once per spelling.
+func TestLaterOverrideProblemsReportsEveryAcceptedForm(t *testing.T) {
+	t.Parallel()
+
+	lastWins := func([]string) error { return nil }
+	problems := laterOverrideProblems(lastWins, []string{"--hostname", "trusted.example"}, "hostname", "H", "attacker.example")
+	if len(problems) != 5 {
+		t.Fatalf("laterOverrideProblems() reported %d problems, want one per spelling: %q", len(problems), problems)
+	}
+}
+
 // TestCountFlagOccurrencesIgnoresAValueContainingTheFlag is the negative
 // control for the substring defect: a path holding the flag text must not be
 // counted as an occurrence, while the flattened-string scan the contract bans

--- a/internal/testkit/argv_test.go
+++ b/internal/testkit/argv_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// errDuplicateFlag is the rejection a strict parser reports.
+var errDuplicateFlag = errors.New("flag given more than once")
+
+// parseLongSpaceOnly is the parser a hand-written assertion actually proves:
+// it rejects a duplicate only in the "--flag value" spelling. Every other
+// spelling reaches the last-wins assignment. It is the negative control for
+// FlagForms.
+func parseLongSpaceOnly(argv []string, flag string) error {
+	seen := 0
+	for _, arg := range argv {
+		if arg == "--"+flag {
+			seen++
+		}
+	}
+	if seen > 1 {
+		return errDuplicateFlag
+	}
+	return nil
+}
+
+// parseEveryForm rejects a duplicate in every spelling, using the same
+// tokenised count the contract requires.
+func parseEveryForm(argv []string, flag, short string) error {
+	if CountFlagOccurrences(argv, flag, short) > 1 {
+		return errDuplicateFlag
+	}
+	return nil
+}
+
+// TestFlagFormsExposesTheSpellingsALongSpaceAssertionMisses proves the matrix
+// is not vacuous: against a parser that only knows "--flag value", four of the
+// five forms must slip through. A FlagForms that emitted five variations of
+// the long-space spelling would make this test fail.
+func TestFlagFormsExposesTheSpellingsALongSpaceAssertionMisses(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"--hostname", "trusted.example"}
+	escaped := 0
+	for _, form := range FlagForms("hostname", "H", "attacker.example") {
+		argv := append(append([]string(nil), base...), form...)
+		if parseLongSpaceOnly(argv, "hostname") == nil {
+			escaped++
+		}
+	}
+	if escaped != 4 {
+		t.Fatalf("long-space-only parser accepted %d of the attached spellings, want 4", escaped)
+	}
+}
+
+func TestFlagFormsOmitsShortSpellingsWhenThereIsNoShortName(t *testing.T) {
+	t.Parallel()
+
+	forms := FlagForms("assets-dir", "", "/tmp/assets")
+	if len(forms) != 2 {
+		t.Fatalf("FlagForms() with no short name = %q, want the two long spellings", forms)
+	}
+}
+
+func TestAssertRejectsLaterOverrideAcceptsAParserThatRejectsEveryForm(t *testing.T) {
+	t.Parallel()
+
+	run := func(argv []string) error { return parseEveryForm(argv, "hostname", "H") }
+	AssertRejectsLaterOverride(t, run, []string{"--hostname", "trusted.example"}, "hostname", "H", "attacker.example")
+}
+
+// TestCountFlagOccurrencesIgnoresAValueContainingTheFlag is the negative
+// control for the substring defect: a path holding the flag text must not be
+// counted as an occurrence, while the flattened-string scan the contract bans
+// does count it.
+func TestCountFlagOccurrencesIgnoresAValueContainingTheFlag(t *testing.T) {
+	t.Parallel()
+
+	argv := []string{"--assets-dir", "/tmp/review--hostname-tmp", "--hostname", "trusted.example"}
+	if got := CountFlagOccurrences(argv, "hostname", "H"); got != 1 {
+		t.Fatalf("CountFlagOccurrences() = %d, want 1", got)
+	}
+	if got := strings.Count(strings.Join(argv, " "), "--hostname"); got != 2 {
+		t.Fatalf("flattened-argument scan found %d matches; the fixture no longer reproduces the substring defect", got)
+	}
+}
+
+func TestCountFlagOccurrencesCountsEveryFormOnce(t *testing.T) {
+	t.Parallel()
+
+	for _, form := range FlagForms("hostname", "H", "attacker.example") {
+		if got := CountFlagOccurrences(form, "hostname", "H"); got != 1 {
+			t.Errorf("CountFlagOccurrences(%q) = %d, want 1", form, got)
+		}
+	}
+}
+
+// TestShellQuoteSurvivesShellReexpansion proves the quoting round-trips a
+// hostile value through Bash, and that Go's %q verb does not. The second half
+// is the negative control: if %q ever started surviving, the ban this package
+// enforces would be pointless.
+func TestShellQuoteSurvivesShellReexpansion(t *testing.T) {
+	t.Parallel()
+
+	hostile := "$HOME 'quoted' $(id) `id` \\n \"dq\" $((1+1))"
+
+	code, output := runBashProbe(t, "printf '%s' "+ShellQuote(hostile), nil)
+	if code != 0 {
+		t.Fatalf("quoted probe exit code = %d output=%q", code, output)
+	}
+	if output != hostile {
+		t.Fatalf("ShellQuote() round trip = %q, want %q", output, hostile)
+	}
+
+	code, naive := runBashProbe(t, "printf '%s' "+fmt.Sprintf("%q", hostile), nil)
+	if code == 0 && naive == hostile {
+		t.Fatal("the Go quoting verb survived the shell round trip; the fixture no longer reproduces the re-expansion defect")
+	}
+}

--- a/internal/testkit/release_outputs_verify_test.go
+++ b/internal/testkit/release_outputs_verify_test.go
@@ -23,8 +23,8 @@ import (
 func runReleaseOutputsInventoryGuard(t *testing.T, dir string) (int, string) {
 	t.Helper()
 	driver := filepath.Join(t.TempDir(), "release-outputs-inventory-driver.sh")
-	script := fmt.Sprintf("#!/bin/bash\nsource %q\ncosign() { return 0; }\nmain \"$@\"\n",
-		filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh"))
+	script := fmt.Sprintf("#!/bin/bash\nsource %s\ncosign() { return 0; }\nmain \"$@\"\n",
+		ShellQuote(filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh")))
 	if err := os.WriteFile(driver, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -79,14 +79,14 @@ func TestHomeControlPlaneRejectsManagedDirectoryTargets(t *testing.T) {
 					"  fi\n"+
 					"  builtin source \"$@\"\n"+
 					"}\n"+
-					"builtin source %q\n"+
-					"if workcell_target_is_allowed %q; then\n"+
+					"builtin source %s\n"+
+					"if workcell_target_is_allowed %s; then\n"+
 					"  printf 'allowed\\n'\n"+
 					"else\n"+
 					"  printf 'blocked\\n'\n"+
 					"fi\n",
-				scriptPath,
-				target,
+				ShellQuote(scriptPath),
+				ShellQuote(target),
 			)
 			code, output := runBashProbe(t, probe, nil)
 			if code != 0 {
@@ -120,14 +120,14 @@ func TestHomeControlPlaneRejectsTraversalTargets(t *testing.T) {
 					"  fi\n"+
 					"  builtin source \"$@\"\n"+
 					"}\n"+
-					"builtin source %q\n"+
-					"if workcell_target_is_allowed %q; then\n"+
+					"builtin source %s\n"+
+					"if workcell_target_is_allowed %s; then\n"+
 					"  printf 'allowed\\n'\n"+
 					"else\n"+
 					"  printf 'blocked\\n'\n"+
 					"fi\n",
-				scriptPath,
-				target,
+				ShellQuote(scriptPath),
+				ShellQuote(target),
 			)
 			code, output := runBashProbe(t, probe, nil)
 			if code != 0 {
@@ -148,7 +148,7 @@ func TestResolveWorkcellRealHomeRejectsWorkspaceOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 	scriptPath := filepath.Join(repoRoot(t), "scripts", "lib", "trusted-docker-client.sh")
-	probe := fmt.Sprintf("set -euo pipefail\nROOT_DIR=%q\nsource %q\nresolve_workcell_real_home\n", workspace, scriptPath)
+	probe := fmt.Sprintf("set -euo pipefail\nROOT_DIR=%s\nsource %s\nresolve_workcell_real_home\n", ShellQuote(workspace), ShellQuote(scriptPath))
 	code, output := runBashProbe(t, probe, map[string]string{
 		"HOME":                      t.TempDir(),
 		"WORKCELL_DOCKER_REAL_HOME": overrideHome,

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -20,23 +20,34 @@ const minTrackedGoFiles = 100
 // command at the start of a script line.
 var shellSourceMarker = regexp.MustCompile(`#!/|set -euo|\\n(builtin )?source |"(builtin )?source `)
 
-// goQuoteInShellLiteral reports the 1-based lines of goSource where a Bash
+// goQuoteInShellLiteral reports the 1-based lines of goSource where a shell
 // script literal interpolates a value with Go's %q verb. A marker opens the
-// block and the concatenated fragments that follow stay inside it, so a %q on
-// a later line of the same literal is reported too.
+// block and the following fragments of the same literal stay inside it, so a
+// %q on a later line is reported too.
+//
+// Both Go literal forms carry script text and both are tracked. Concatenated
+// interpreted fragments continue the block while each line opens with a double
+// quote. A raw literal has no such fragments: its body lines are plain script
+// text, so the block instead stays open until the closing backquote. A line
+// holding an odd number of backquotes opens or closes one.
 //
 // The scan is deliberately a line scan rather than a Go parse: the generator
 // sites are few, and a greppable rule stays readable to the shell reviewers it
 // serves.
 func goQuoteInShellLiteral(goSource string) []int {
 	var found []int
-	inShell := false
+	inShell, inRawLiteral := false, false
 	for i, line := range strings.Split(goSource, "\n") {
 		switch {
+		case inRawLiteral:
+			// The raw literal body continues; only its closing backquote ends it.
 		case shellSourceMarker.MatchString(line):
 			inShell = true
 		case !strings.HasPrefix(strings.TrimSpace(line), `"`):
 			inShell = false
+		}
+		if inShell && strings.Count(line, "`")%2 == 1 {
+			inRawLiteral = !inRawLiteral
 		}
 		if inShell && strings.Contains(line, "%q") {
 			found = append(found, i+1)
@@ -88,8 +99,34 @@ func TestGoQuoteInShellLiteralFindsTheGeneratorForms(t *testing.T) {
 		`}`,                                       // 8
 	}, "\n")
 
-	got := goQuoteInShellLiteral(source)
-	want := []int{2, 5, 6}
+	requireLines(t, goQuoteInShellLiteral(source), 2, 5, 6)
+}
+
+// TestGoQuoteInShellLiteralTracksRawLiterals covers the second Go literal form.
+// A raw literal's body lines are plain script text, so the double-quote rule
+// that continues a concatenated literal does not apply to them and the block
+// must stay open until the closing backquote instead.
+func TestGoQuoteInShellLiteralTracksRawLiterals(t *testing.T) {
+	t.Parallel()
+
+	const verb = "%" + "q"
+	const tick = "`"
+	source := strings.Join([]string{
+		`package p`,  // 1
+		`func c() {`, // 2
+		`	script := fmt.Sprintf(` + tick + `#!/bin/sh`, // 3: the marker opens a raw literal
+		`printf 'x' >> ` + verb,                        // 4: raw body, reported
+		`exec /bin/sleep 60`,                           // 5: raw body, no verb
+		tick + `, commandLog)`,                         // 6: the raw literal closes
+		`	t.Fatalf("output ` + verb + `", got)`,        // 7: prose, block already closed
+		`}`,                                            // 8
+	}, "\n")
+
+	requireLines(t, goQuoteInShellLiteral(source), 4)
+}
+
+func requireLines(t *testing.T, got []int, want ...int) {
+	t.Helper()
 	if len(got) != len(want) {
 		t.Fatalf("goQuoteInShellLiteral() = %v, want %v", got, want)
 	}

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -49,17 +49,20 @@ func hasGoQuoteDirective(text string) bool {
 	return false
 }
 
-// goQuoteInShellLiteral reports the 1-based lines of goSource where a shell
-// script literal interpolates a value with Go's q conversion.
+// goQuoteInShellLiteral reports the 1-based lines of goSource that build a
+// shell script literal interpolating a value with Go's q conversion.
 //
-// The scan tokenises rather than reading lines. A generated script is written
-// as string literals joined by +, so the marker that identifies the text as
-// shell and the directive that spoils it are usually in different fragments of
-// one expression; the fragments are therefore grouped and judged together.
-// Taking them from the tokeniser also means comments never reach the scan and
-// both literal forms decode the same way, which reading lines cannot do: a
-// trailing or block comment about shell syntax is not script text, and a raw
-// literal's body lines are.
+// The scan tokenises rather than reading lines, and judges a whole
+// concatenation rather than its fragments. A generated script is written as
+// string literals joined by +, so both the marker that identifies the text as
+// shell and the directive that spoils it are properties of the joined value:
+// "printf " + "%" + "q" is a real directive that no fragment contains, and
+// "%" + "%q" is an escaped percent that one fragment appears to contain.
+// Taking the tokens from go/scanner also keeps comments out of the scan and
+// decodes both literal forms alike, which reading lines cannot do: a trailing
+// or block comment about shell syntax is not script text, and a raw literal's
+// body lines are. Each group is reported at the line its first fragment
+// starts on.
 func goQuoteInShellLiteral(goSource string) []int {
 	fileSet := token.NewFileSet()
 	file := fileSet.AddFile("", fileSet.Base(), len(goSource))
@@ -67,12 +70,12 @@ func goQuoteInShellLiteral(goSource string) []int {
 	lexer.Init(file, []byte(goSource), nil, 0)
 
 	var found []int
-	group, directiveLines := "", []int(nil)
+	group, groupLine, open := "", 0, false
 	flush := func() {
-		if shellSourceMarker.MatchString(group) {
-			found = append(found, directiveLines...)
+		if open && shellSourceMarker.MatchString(group) && hasGoQuoteDirective(group) {
+			found = append(found, groupLine)
 		}
-		group, directiveLines = "", nil
+		group, groupLine, open = "", 0, false
 	}
 	for {
 		pos, tok, literal := lexer.Scan()
@@ -81,11 +84,10 @@ func goQuoteInShellLiteral(goSource string) []int {
 			flush()
 			return found
 		case token.STRING:
-			text := decodeGoLiteral(literal)
-			group += text
-			if hasGoQuoteDirective(text) {
-				directiveLines = append(directiveLines, fileSet.Position(pos).Line)
+			if !open {
+				groupLine, open = fileSet.Position(pos).Line, true
 			}
+			group += decodeGoLiteral(literal)
 		case token.ADD:
 			// A concatenation keeps the fragments of one literal together.
 		default:
@@ -133,9 +135,10 @@ func TestGeneratedShellScriptsDoNotUseGoQuoting(t *testing.T) {
 	}
 }
 
-// goQuoteFixture is Go source that carries every form the scan must judge.
-// The q conversions are assembled from pieces so this file does not report
-// itself, and every line is numbered against the fixture, not this file.
+// goQuoteFixture is Go source carrying every form the scan must judge. Each
+// generator is its own statement, so each reports at its own line. The q
+// conversions are assembled from pieces so this file does not report itself,
+// and the line numbers are the fixture's own.
 func goQuoteFixture() string {
 	q := "%" + "q"
 	pct := "%"
@@ -144,38 +147,42 @@ func goQuoteFixture() string {
 		`package p`,             // 1
 		``,                      // 2
 		`func concatenated() {`, // 3
-		`	_ = fmt.Sprintf("set -euo pipefail\n"+`, // 4: the marker fragment
-		`		"builtin source ` + q + `\n"+`,         // 5: reported
-		`		"cmd ` + q + `\n", one, two)`,          // 6: reported
-		`	t.Fatalf("output ` + q + `", got)`,      // 7: prose, a separate expression
+		`	_ = fmt.Sprintf("set -euo pipefail\n"+`, // 4: reported, the group starts here
+		`		"builtin source ` + q + `\n"+`,         // 5: same group
+		`		"cmd ` + q + `\n", one, two)`,          // 6: same group
+		`	t.Fatalf("output ` + q + `", got)`,      // 7: its own group, no marker
 		`}`,                                       // 8
 		``,                                        // 9
 		`func rawLiteral() {`,                     // 10
-		`	_ = fmt.Sprintf(` + tick + `#!/bin/sh`,  // 11: a raw literal opens on the marker
-		`printf 'x' >> ` + q,                      // 12: reported, same literal
+		`	_ = fmt.Sprintf(` + tick + `#!/bin/sh`,  // 11: reported, one token spans to 14
+		`printf 'x' >> ` + q,                      // 12
 		`exec /bin/sleep 60`,                      // 13
 		tick + `, commandLog)`,                    // 14
 		`}`,                                       // 15
 		``,                                        // 16
 		`func directiveForms() {`,                 // 17
-		`	_ = fmt.Sprintf("#!/bin/bash\n"+`,       // 18: the marker fragment
-		`		"indexed ` + pct + `[1]q\n"+`,          // 19: reported
-		`		"flagged ` + pct + `#q\n"+`,            // 20: reported
-		`		"padded ` + pct + `-8q\n"+`,            // 21: reported
-		`		"star ` + pct + `*q\n"+`,               // 22: reported
-		`		"star indexed ` + pct + `[2]*[1]q\n"+`, // 23: reported
-		`		"escaped then real ` + pct + pct + pct + `q\n"+`, // 24: reported
-		`		"literal ` + pct + pct + `q\n"+`,                 // 25: an escaped percent only
-		`		"safe ` + pct + `s\n", a, b, c)`,                 // 26: a different conversion
-		`}`,                                                 // 27
-		``,                                                  // 28
-		`func comments() {`,                                 // 29
-		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 30
-		`	_ = fmt.Sprintf("set -euo pipefail\n") /* ` + pct + `q */`,  // 31: inline comment
-		`	/*`, // 32
-		`	   #!/bin/bash ` + pct + `q in a block comment`, // 33
-		`	*/`, // 34
-		`}`,   // 35
+		`	_ = fmt.Sprintf("#!/bin/bash\nindexed ` + pct + `[1]q\n", a)`,                    // 18: reported
+		`	_ = fmt.Sprintf("#!/bin/bash\nflagged ` + pct + `#q\n", a)`,                      // 19: reported
+		`	_ = fmt.Sprintf("#!/bin/bash\npadded ` + pct + `-8q\n", a)`,                      // 20: reported
+		`	_ = fmt.Sprintf("#!/bin/bash\nstar ` + pct + `*q\n", w, a)`,                      // 21: reported
+		`	_ = fmt.Sprintf("#!/bin/bash\nstar indexed ` + pct + `[2]*[1]q\n", a, w)`,        // 22: reported
+		`	_ = fmt.Sprintf("#!/bin/bash\nescaped then real ` + pct + pct + pct + `q\n", a)`, // 23: reported
+		`	_ = fmt.Sprintf("#!/bin/bash\nliteral ` + pct + pct + `q\n")`,                    // 24: an escaped percent only
+		`	_ = fmt.Sprintf("#!/bin/bash\nsafe ` + pct + `s\n", a)`,                          // 25: a different conversion
+		`}`,                             // 26
+		``,                              // 27
+		`func splitAcrossFragments() {`, // 28
+		`	_ = fmt.Sprintf("#!/bin/bash\nprintf " + "` + pct + `" + "q\n", a)`,         // 29: reported, the joined value is a directive
+		`	_ = fmt.Sprintf("#!/bin/bash\nprintf " + "` + pct + `" + "` + pct + `q\n")`, // 30: the joined value is an escaped percent
+		`}`,                 // 31
+		``,                  // 32
+		`func comments() {`, // 33
+		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 34
+		`	_ = fmt.Sprintf("set -euo pipefail\n") /* ` + pct + `q */`,  // 35: trailing comment
+		`	/*`, // 36
+		`	   #!/bin/bash ` + pct + `q in a block comment`, // 37
+		`	*/`, // 38
+		`}`,   // 39
 	}, "\n")
 }
 
@@ -186,9 +193,10 @@ func TestGoQuoteInShellLiteralFindsEveryGeneratorForm(t *testing.T) {
 	t.Parallel()
 
 	requireLines(t, goQuoteInShellLiteral(goQuoteFixture()),
-		5, 6, // concatenated fragments after a marker fragment
-		11,                     // a raw literal, reported at the line its single token starts on
-		19, 20, 21, 22, 23, 24, // the directive spellings
+		4,                      // a concatenation whose marker and directives are in different fragments
+		11,                     // a raw literal, reported where its single token starts
+		18, 19, 20, 21, 22, 23, // the directive spellings
+		29, // a directive spelled across fragments
 	)
 }
 

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// minTrackedGoFiles is the inventory floor for the Go-source walk, so a walk
+// that returns nothing cannot pass the ban vacuously.
+const minTrackedGoFiles = 100
+
+// shellSourceMarker matches a Go string fragment that is Bash source text
+// rather than prose: an interpreter line, the house prologue, or a source
+// command at the start of a script line.
+var shellSourceMarker = regexp.MustCompile(`#!/|set -euo|\\n(builtin )?source |"(builtin )?source `)
+
+// goQuoteInShellLiteral reports the 1-based lines of goSource where a Bash
+// script literal interpolates a value with Go's %q verb. A marker opens the
+// block and the concatenated fragments that follow stay inside it, so a %q on
+// a later line of the same literal is reported too.
+//
+// The scan is deliberately a line scan rather than a Go parse: the generator
+// sites are few, and a greppable rule stays readable to the shell reviewers it
+// serves.
+func goQuoteInShellLiteral(goSource string) []int {
+	var found []int
+	inShell := false
+	for i, line := range strings.Split(goSource, "\n") {
+		switch {
+		case shellSourceMarker.MatchString(line):
+			inShell = true
+		case !strings.HasPrefix(strings.TrimSpace(line), `"`):
+			inShell = false
+		}
+		if inShell && strings.Contains(line, "%q") {
+			found = append(found, i+1)
+		}
+	}
+	return found
+}
+
+// TestGeneratedShellScriptsDoNotUseGoQuoting bans %q from the literals that
+// become Bash source. %q emits a Go literal; the shell re-reads it and expands
+// what it finds, so a value holding $HOME or $(...) escapes the quoting the
+// author believed they had applied.
+func TestGeneratedShellScriptsDoNotUseGoQuoting(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	scanned := 0
+	for _, rel := range trackedFiles(t, root) {
+		if !strings.HasSuffix(rel, ".go") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		scanned++
+		for _, line := range goQuoteInShellLiteral(string(content)) {
+			t.Errorf("%s:%d: a Bash script literal interpolates with %%q; use testkit.ShellQuote with %%s", rel, line)
+		}
+	}
+	if scanned < minTrackedGoFiles {
+		t.Fatalf("scanned %d Go files, want at least %d; the tracked-file walk did not complete", scanned, minTrackedGoFiles)
+	}
+}
+
+func TestGoQuoteInShellLiteralFindsTheGeneratorForms(t *testing.T) {
+	t.Parallel()
+
+	// The verb is assembled so that this fixture does not report its own file.
+	const verb = "%" + "q"
+	source := strings.Join([]string{
+		`package p`, // 1
+		`func a() { _ = fmt.Sprintf("#!/bin/bash\nx ` + verb + `\n") }`, // 2: marker and verb on one line
+		`func b() {`, // 3
+		`	_ = fmt.Sprintf("set -euo pipefail\n"+`, // 4: marker opens the block
+		`		"builtin source ` + verb + `\n"+`,      // 5: inside the block
+		`		"cmd ` + verb + `\n", one, two)`,       // 6: still inside the block
+		`	t.Fatalf("output ` + verb + `", got)`,   // 7: prose, block already closed
+		`}`,                                       // 8
+	}, "\n")
+
+	got := goQuoteInShellLiteral(source)
+	want := []int{2, 5, 6}
+	if len(got) != len(want) {
+		t.Fatalf("goQuoteInShellLiteral() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("goQuoteInShellLiteral() = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -4,7 +4,6 @@
 package testkit
 
 import (
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -25,12 +24,21 @@ var shellSourceMarker = regexp.MustCompile(`#!/|set -euo|\\n(builtin )?source |"
 // %q, %#q, %+q and %[1]q all apply the same shell-unsafe conversion.
 var goQuoteDirective = regexp.MustCompile(`%[-+# 0]*(\[\d+\])?\d*(\.\d+)?q`)
 
-// hasGoQuoteDirective reports whether line applies the q conversion. A doubled
-// percent sign is a literal percent rather than the start of a directive, so a
-// match that begins on the second sign of a pair does not count.
+// hasGoQuoteDirective reports whether line applies the q conversion.
+//
+// A doubled percent sign is a literal percent, so whether a match opens a real
+// directive is decided by the parity of the percent run that precedes it. An
+// even run is a sequence of complete escaped pairs and the match is a
+// directive; an odd run means this match's own percent closes the last pair.
+// %%q is therefore a literal, while %%%q is an escaped percent followed by a
+// real conversion.
 func hasGoQuoteDirective(line string) bool {
 	for _, match := range goQuoteDirective.FindAllStringIndex(line, -1) {
-		if match[0] > 0 && line[match[0]-1] == '%' {
+		run := 0
+		for i := match[0] - 1; i >= 0 && line[i] == '%'; i-- {
+			run++
+		}
+		if run%2 == 1 {
 			continue
 		}
 		return true
@@ -91,9 +99,12 @@ func TestGeneratedShellScriptsDoNotUseGoQuoting(t *testing.T) {
 		if !strings.HasSuffix(rel, ".go") {
 			continue
 		}
-		content, err := os.ReadFile(filepath.Join(root, rel))
+		// Read through the same no-follow descriptor discipline the Bash walk
+		// uses, so neither walk judges a file other than the one it named.
+		content, err := readTrackedFile(filepath.Join(root, rel))
 		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
+			t.Errorf("read %s: %v", rel, err)
+			continue
 		}
 		scanned++
 		for _, line := range goQuoteInShellLiteral(string(content)) {
@@ -161,12 +172,13 @@ func TestGoQuoteInShellLiteralReadsWholeFormatDirectives(t *testing.T) {
 		`		"flagged ` + pct + `#q\n"+`,                                // 4: reported
 		`		"padded ` + pct + `-8q\n"+`,                                // 5: reported
 		`		"literal ` + pct + pct + `q\n"+`,                           // 6: an escaped percent, not a directive
-		`		"safe ` + pct + `s\n", a, b, c, d)`,                        // 7: a different conversion
-		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 8: not script text
-		`}`, // 9
+		`		"escaped then real ` + pct + pct + pct + `q\n"+`,           // 7: a pair, then a directive
+		`		"safe ` + pct + `s\n", a, b, c, d)`,                        // 8: a different conversion
+		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 9: not script text
+		`}`, // 10
 	}, "\n")
 
-	requireLines(t, goQuoteInShellLiteral(source), 3, 4, 5)
+	requireLines(t, goQuoteInShellLiteral(source), 3, 4, 5, 7)
 }
 
 func requireLines(t *testing.T, got []int, want ...int) {

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -4,8 +4,11 @@
 package testkit
 
 import (
+	"go/scanner"
+	"go/token"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -14,76 +17,90 @@ import (
 // that returns nothing cannot pass the ban vacuously.
 const minTrackedGoFiles = 100
 
-// shellSourceMarker matches a Go string fragment that is Bash source text
+// shellSourceMarker matches a decoded string literal that is shell source text
 // rather than prose: an interpreter line, the house prologue, or a source
 // command at the start of a script line.
-var shellSourceMarker = regexp.MustCompile(`#!/|set -euo|\\n(builtin )?source |"(builtin )?source `)
+var shellSourceMarker = regexp.MustCompile(`#!/|set -euo|(^|\n)(builtin )?source `)
 
-// goQuoteDirective matches a complete fmt directive whose conversion is q, so
-// the indexed and flagged spellings are caught as well as the plain one:
-// %q, %#q, %+q and %[1]q all apply the same shell-unsafe conversion.
-var goQuoteDirective = regexp.MustCompile(`%[-+# 0]*(\[\d+\])?\d*(\.\d+)?q`)
+// goQuoteDirective matches a complete fmt directive whose conversion is q. All
+// of the spellings fmt accepts reach the same shell-unsafe conversion: flags
+// (%#q), a literal or starred width and precision (%-8q, %*q, %.2q), an
+// argument index on either (%[2]*[1]q), and a plain %q.
+var goQuoteDirective = regexp.MustCompile(`%[-+# 0]*(\d+|\*|\[\d+\]\*)?(\.(\d+|\*|\[\d+\]\*)?)?(\[\d+\])?q`)
 
-// hasGoQuoteDirective reports whether line applies the q conversion.
+// hasGoQuoteDirective reports whether text applies the q conversion.
 //
 // A doubled percent sign is a literal percent, so whether a match opens a real
 // directive is decided by the parity of the percent run that precedes it. An
 // even run is a sequence of complete escaped pairs and the match is a
 // directive; an odd run means this match's own percent closes the last pair.
-// %%q is therefore a literal, while %%%q is an escaped percent followed by a
-// real conversion.
-func hasGoQuoteDirective(line string) bool {
-	for _, match := range goQuoteDirective.FindAllStringIndex(line, -1) {
+// %%q is therefore a literal, while %%%q is an escaped percent then a real
+// conversion.
+func hasGoQuoteDirective(text string) bool {
+	for _, match := range goQuoteDirective.FindAllStringIndex(text, -1) {
 		run := 0
-		for i := match[0] - 1; i >= 0 && line[i] == '%'; i-- {
+		for i := match[0] - 1; i >= 0 && text[i] == '%'; i-- {
 			run++
 		}
-		if run%2 == 1 {
-			continue
+		if run%2 == 0 {
+			return true
 		}
-		return true
 	}
 	return false
 }
 
 // goQuoteInShellLiteral reports the 1-based lines of goSource where a shell
-// script literal interpolates a value with Go's %q verb. A marker opens the
-// block and the following fragments of the same literal stay inside it, so a
-// %q on a later line is reported too.
+// script literal interpolates a value with Go's q conversion.
 //
-// Both Go literal forms carry script text and both are tracked. Concatenated
-// interpreted fragments continue the block while each line opens with a double
-// quote. A raw literal has no such fragments: its body lines are plain script
-// text, so the block instead stays open until the closing backquote. A line
-// holding an odd number of backquotes opens or closes one.
-//
-// The scan is deliberately a line scan rather than a Go parse: the generator
-// sites are few, and a greppable rule stays readable to the shell reviewers it
-// serves.
+// The scan tokenises rather than reading lines. A generated script is written
+// as string literals joined by +, so the marker that identifies the text as
+// shell and the directive that spoils it are usually in different fragments of
+// one expression; the fragments are therefore grouped and judged together.
+// Taking them from the tokeniser also means comments never reach the scan and
+// both literal forms decode the same way, which reading lines cannot do: a
+// trailing or block comment about shell syntax is not script text, and a raw
+// literal's body lines are.
 func goQuoteInShellLiteral(goSource string) []int {
+	fileSet := token.NewFileSet()
+	file := fileSet.AddFile("", fileSet.Base(), len(goSource))
+	var lexer scanner.Scanner
+	lexer.Init(file, []byte(goSource), nil, 0)
+
 	var found []int
-	inShell, inRawLiteral := false, false
-	for i, line := range strings.Split(goSource, "\n") {
-		trimmed := strings.TrimSpace(line)
-		switch {
-		case inRawLiteral:
-			// The raw literal body continues; only its closing backquote ends it.
-		case strings.HasPrefix(trimmed, "//"):
-			// A comment discussing shell syntax is prose, not script text.
-			inShell = false
-		case shellSourceMarker.MatchString(line):
-			inShell = true
-		case !strings.HasPrefix(trimmed, `"`):
-			inShell = false
+	group, directiveLines := "", []int(nil)
+	flush := func() {
+		if shellSourceMarker.MatchString(group) {
+			found = append(found, directiveLines...)
 		}
-		if inShell && strings.Count(line, "`")%2 == 1 {
-			inRawLiteral = !inRawLiteral
-		}
-		if inShell && hasGoQuoteDirective(line) {
-			found = append(found, i+1)
+		group, directiveLines = "", nil
+	}
+	for {
+		pos, tok, literal := lexer.Scan()
+		switch tok {
+		case token.EOF:
+			flush()
+			return found
+		case token.STRING:
+			text := decodeGoLiteral(literal)
+			group += text
+			if hasGoQuoteDirective(text) {
+				directiveLines = append(directiveLines, fileSet.Position(pos).Line)
+			}
+		case token.ADD:
+			// A concatenation keeps the fragments of one literal together.
+		default:
+			flush()
 		}
 	}
-	return found
+}
+
+// decodeGoLiteral returns the text a Go string literal denotes. An unparsable
+// literal is returned as written, which can only over-report.
+func decodeGoLiteral(literal string) string {
+	if text, err := strconv.Unquote(literal); err == nil {
+		return text
+	}
+	return literal
 }
 
 // TestGeneratedShellScriptsDoNotUseGoQuoting bans %q from the literals that
@@ -116,69 +133,63 @@ func TestGeneratedShellScriptsDoNotUseGoQuoting(t *testing.T) {
 	}
 }
 
-func TestGoQuoteInShellLiteralFindsTheGeneratorForms(t *testing.T) {
-	t.Parallel()
-
-	// The verb is assembled so that this fixture does not report its own file.
-	const verb = "%" + "q"
-	source := strings.Join([]string{
-		`package p`, // 1
-		`func a() { _ = fmt.Sprintf("#!/bin/bash\nx ` + verb + `\n") }`, // 2: marker and verb on one line
-		`func b() {`, // 3
-		`	_ = fmt.Sprintf("set -euo pipefail\n"+`, // 4: marker opens the block
-		`		"builtin source ` + verb + `\n"+`,      // 5: inside the block
-		`		"cmd ` + verb + `\n", one, two)`,       // 6: still inside the block
-		`	t.Fatalf("output ` + verb + `", got)`,   // 7: prose, block already closed
+// goQuoteFixture is Go source that carries every form the scan must judge.
+// The q conversions are assembled from pieces so this file does not report
+// itself, and every line is numbered against the fixture, not this file.
+func goQuoteFixture() string {
+	q := "%" + "q"
+	pct := "%"
+	tick := "`"
+	return strings.Join([]string{
+		`package p`,             // 1
+		``,                      // 2
+		`func concatenated() {`, // 3
+		`	_ = fmt.Sprintf("set -euo pipefail\n"+`, // 4: the marker fragment
+		`		"builtin source ` + q + `\n"+`,         // 5: reported
+		`		"cmd ` + q + `\n", one, two)`,          // 6: reported
+		`	t.Fatalf("output ` + q + `", got)`,      // 7: prose, a separate expression
 		`}`,                                       // 8
+		``,                                        // 9
+		`func rawLiteral() {`,                     // 10
+		`	_ = fmt.Sprintf(` + tick + `#!/bin/sh`,  // 11: a raw literal opens on the marker
+		`printf 'x' >> ` + q,                      // 12: reported, same literal
+		`exec /bin/sleep 60`,                      // 13
+		tick + `, commandLog)`,                    // 14
+		`}`,                                       // 15
+		``,                                        // 16
+		`func directiveForms() {`,                 // 17
+		`	_ = fmt.Sprintf("#!/bin/bash\n"+`,       // 18: the marker fragment
+		`		"indexed ` + pct + `[1]q\n"+`,          // 19: reported
+		`		"flagged ` + pct + `#q\n"+`,            // 20: reported
+		`		"padded ` + pct + `-8q\n"+`,            // 21: reported
+		`		"star ` + pct + `*q\n"+`,               // 22: reported
+		`		"star indexed ` + pct + `[2]*[1]q\n"+`, // 23: reported
+		`		"escaped then real ` + pct + pct + pct + `q\n"+`, // 24: reported
+		`		"literal ` + pct + pct + `q\n"+`,                 // 25: an escaped percent only
+		`		"safe ` + pct + `s\n", a, b, c)`,                 // 26: a different conversion
+		`}`,                                                 // 27
+		``,                                                  // 28
+		`func comments() {`,                                 // 29
+		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 30
+		`	_ = fmt.Sprintf("set -euo pipefail\n") /* ` + pct + `q */`,  // 31: inline comment
+		`	/*`, // 32
+		`	   #!/bin/bash ` + pct + `q in a block comment`, // 33
+		`	*/`, // 34
+		`}`,   // 35
 	}, "\n")
-
-	requireLines(t, goQuoteInShellLiteral(source), 2, 5, 6)
 }
 
-// TestGoQuoteInShellLiteralTracksRawLiterals covers the second Go literal form.
-// A raw literal's body lines are plain script text, so the double-quote rule
-// that continues a concatenated literal does not apply to them and the block
-// must stay open until the closing backquote instead.
-func TestGoQuoteInShellLiteralTracksRawLiterals(t *testing.T) {
+// TestGoQuoteInShellLiteralFindsEveryGeneratorForm drives the whole fixture at
+// once. Every reported line is a real defect and every unreported line is a
+// form that only resembles one.
+func TestGoQuoteInShellLiteralFindsEveryGeneratorForm(t *testing.T) {
 	t.Parallel()
 
-	const verb = "%" + "q"
-	const tick = "`"
-	source := strings.Join([]string{
-		`package p`,  // 1
-		`func c() {`, // 2
-		`	script := fmt.Sprintf(` + tick + `#!/bin/sh`, // 3: the marker opens a raw literal
-		`printf 'x' >> ` + verb,                        // 4: raw body, reported
-		`exec /bin/sleep 60`,                           // 5: raw body, no verb
-		tick + `, commandLog)`,                         // 6: the raw literal closes
-		`	t.Fatalf("output ` + verb + `", got)`,        // 7: prose, block already closed
-		`}`,                                            // 8
-	}, "\n")
-
-	requireLines(t, goQuoteInShellLiteral(source), 4)
-}
-
-// TestGoQuoteInShellLiteralReadsWholeFormatDirectives covers the directive
-// spellings fmt accepts for the same q conversion, and the two forms that only
-// look like one: a doubled percent sign, and a comment about shell syntax.
-func TestGoQuoteInShellLiteralReadsWholeFormatDirectives(t *testing.T) {
-	t.Parallel()
-
-	const pct = "%"
-	source := strings.Join([]string{
-		`func d() {`,                                                  // 1
-		`	_ = fmt.Sprintf("#!/bin/bash\n"+`,                           // 2: marker opens the block
-		`		"indexed ` + pct + `[1]q\n"+`,                              // 3: reported
-		`		"flagged ` + pct + `#q\n"+`,                                // 4: reported
-		`		"padded ` + pct + `-8q\n"+`,                                // 5: reported
-		`		"literal ` + pct + pct + `q\n"+`,                           // 6: an escaped percent, not a directive
-		`		"escaped then real ` + pct + pct + pct + `q\n"+`,           // 7: a pair, then a directive
-		`		"safe ` + pct + `s\n", a, b, c, d)`,                        // 8: a different conversion
-		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 9: not script text
-		`}`, // 10
-	}, "\n")
-
-	requireLines(t, goQuoteInShellLiteral(source), 3, 4, 5, 7)
+	requireLines(t, goQuoteInShellLiteral(goQuoteFixture()),
+		5, 6, // concatenated fragments after a marker fragment
+		11,                     // a raw literal, reported at the line its single token starts on
+		19, 20, 21, 22, 23, 24, // the directive spellings
+	)
 }
 
 func requireLines(t *testing.T, got []int, want ...int) {

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -88,8 +88,9 @@ func goQuoteInShellLiteral(goSource string) []int {
 				groupLine, open = fileSet.Position(pos).Line, true
 			}
 			group += decodeGoLiteral(literal)
-		case token.ADD:
-			// A concatenation keeps the fragments of one literal together.
+		case token.ADD, token.LPAREN, token.RPAREN:
+			// A concatenation keeps the fragments of one literal together, and
+			// parentheses only group it: ("a") is the same value as "a".
 		default:
 			flush()
 		}
@@ -174,15 +175,19 @@ func goQuoteFixture() string {
 		`func splitAcrossFragments() {`, // 28
 		`	_ = fmt.Sprintf("#!/bin/bash\nprintf " + "` + pct + `" + "q\n", a)`,         // 29: reported, the joined value is a directive
 		`	_ = fmt.Sprintf("#!/bin/bash\nprintf " + "` + pct + `" + "` + pct + `q\n")`, // 30: the joined value is an escaped percent
-		`}`,                 // 31
-		``,                  // 32
-		`func comments() {`, // 33
-		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 34
-		`	_ = fmt.Sprintf("set -euo pipefail\n") /* ` + pct + `q */`,  // 35: trailing comment
-		`	/*`, // 36
-		`	   #!/bin/bash ` + pct + `q in a block comment`, // 37
-		`	*/`, // 38
-		`}`,   // 39
+		`}`,                      // 31
+		``,                       // 32
+		`func parenthesised() {`, // 33
+		`	_ = fmt.Sprintf("#!/bin/bash\n" + ("echo ` + q + `\n"), a)`, // 34: reported, parentheses only group
+		`}`,                 // 35
+		``,                  // 36
+		`func comments() {`, // 37
+		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 38
+		`	_ = fmt.Sprintf("set -euo pipefail\n") /* ` + pct + `q */`,  // 39: trailing comment
+		`	/*`, // 40
+		`	   #!/bin/bash ` + pct + `q in a block comment`, // 41
+		`	*/`, // 42
+		`}`,   // 43
 	}, "\n")
 }
 
@@ -197,6 +202,7 @@ func TestGoQuoteInShellLiteralFindsEveryGeneratorForm(t *testing.T) {
 		11,                     // a raw literal, reported where its single token starts
 		18, 19, 20, 21, 22, 23, // the directive spellings
 		29, // a directive spelled across fragments
+		34, // a fragment the source only parenthesises
 	)
 }
 

--- a/internal/testkit/shell_generator_quoting_test.go
+++ b/internal/testkit/shell_generator_quoting_test.go
@@ -20,6 +20,24 @@ const minTrackedGoFiles = 100
 // command at the start of a script line.
 var shellSourceMarker = regexp.MustCompile(`#!/|set -euo|\\n(builtin )?source |"(builtin )?source `)
 
+// goQuoteDirective matches a complete fmt directive whose conversion is q, so
+// the indexed and flagged spellings are caught as well as the plain one:
+// %q, %#q, %+q and %[1]q all apply the same shell-unsafe conversion.
+var goQuoteDirective = regexp.MustCompile(`%[-+# 0]*(\[\d+\])?\d*(\.\d+)?q`)
+
+// hasGoQuoteDirective reports whether line applies the q conversion. A doubled
+// percent sign is a literal percent rather than the start of a directive, so a
+// match that begins on the second sign of a pair does not count.
+func hasGoQuoteDirective(line string) bool {
+	for _, match := range goQuoteDirective.FindAllStringIndex(line, -1) {
+		if match[0] > 0 && line[match[0]-1] == '%' {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // goQuoteInShellLiteral reports the 1-based lines of goSource where a shell
 // script literal interpolates a value with Go's %q verb. A marker opens the
 // block and the following fragments of the same literal stay inside it, so a
@@ -38,18 +56,22 @@ func goQuoteInShellLiteral(goSource string) []int {
 	var found []int
 	inShell, inRawLiteral := false, false
 	for i, line := range strings.Split(goSource, "\n") {
+		trimmed := strings.TrimSpace(line)
 		switch {
 		case inRawLiteral:
 			// The raw literal body continues; only its closing backquote ends it.
+		case strings.HasPrefix(trimmed, "//"):
+			// A comment discussing shell syntax is prose, not script text.
+			inShell = false
 		case shellSourceMarker.MatchString(line):
 			inShell = true
-		case !strings.HasPrefix(strings.TrimSpace(line), `"`):
+		case !strings.HasPrefix(trimmed, `"`):
 			inShell = false
 		}
 		if inShell && strings.Count(line, "`")%2 == 1 {
 			inRawLiteral = !inRawLiteral
 		}
-		if inShell && strings.Contains(line, "%q") {
+		if inShell && hasGoQuoteDirective(line) {
 			found = append(found, i+1)
 		}
 	}
@@ -123,6 +145,28 @@ func TestGoQuoteInShellLiteralTracksRawLiterals(t *testing.T) {
 	}, "\n")
 
 	requireLines(t, goQuoteInShellLiteral(source), 4)
+}
+
+// TestGoQuoteInShellLiteralReadsWholeFormatDirectives covers the directive
+// spellings fmt accepts for the same q conversion, and the two forms that only
+// look like one: a doubled percent sign, and a comment about shell syntax.
+func TestGoQuoteInShellLiteralReadsWholeFormatDirectives(t *testing.T) {
+	t.Parallel()
+
+	const pct = "%"
+	source := strings.Join([]string{
+		`func d() {`,                                                  // 1
+		`	_ = fmt.Sprintf("#!/bin/bash\n"+`,                           // 2: marker opens the block
+		`		"indexed ` + pct + `[1]q\n"+`,                              // 3: reported
+		`		"flagged ` + pct + `#q\n"+`,                                // 4: reported
+		`		"padded ` + pct + `-8q\n"+`,                                // 5: reported
+		`		"literal ` + pct + pct + `q\n"+`,                           // 6: an escaped percent, not a directive
+		`		"safe ` + pct + `s\n", a, b, c, d)`,                        // 7: a different conversion
+		`	// A comment naming #!/bin/bash and ` + pct + `q is prose.`, // 8: not script text
+		`}`, // 9
+	}, "\n")
+
+	requireLines(t, goQuoteInShellLiteral(source), 3, 4, 5)
 }
 
 func requireLines(t *testing.T, got []int, want ...int) {

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -68,13 +68,21 @@ var shebangQuoteStripper = strings.NewReplacer("'", "", `"`, "", `\`, "")
 // isBashCandidate reports whether an interpreter line runs Bash and so must
 // hold the startup-file property.
 //
-// The quotes are stripped before the interpreter is read because env -S
-// processes them first: a line spelled with a quoted interpreter still runs
-// Bash, and a filter over the raw text would skip that file unjudged rather
-// than reject it.
+// A filter that misreads a line makes the walk skip a file rather than reject
+// it, which no later check can recover. It is therefore deliberately
+// over-inclusive: quotes are removed first because env -S removes them, and a
+// line carrying a substitution is treated as a candidate because its
+// interpreter is only decided at run time. Anything wrongly included is
+// rejected by the reviewed-form set, which is the safe direction.
 func isBashCandidate(shebang string) bool {
-	return strings.HasPrefix(shebang, "#!") &&
-		strings.Contains(shebangQuoteStripper.Replace(shebang), "bash")
+	if !strings.HasPrefix(shebang, "#!") {
+		return false
+	}
+	stripped := shebangQuoteStripper.Replace(shebang)
+	// A dollar sign means env -S will substitute from the environment, so the
+	// interpreter is not decidable from the source text. Such a line is judged
+	// rather than skipped, and the reviewed-form set then rejects it.
+	return strings.Contains(stripped, "bash") || strings.Contains(stripped, "$")
 }
 
 // hardenedShebangs is the exact set of interpreter lines a tracked Bash script
@@ -188,6 +196,7 @@ func TestIsBashCandidateSeesThroughQuoting(t *testing.T) {
 		{"plain", "#!/bin/bash -p", true},
 		{"env prefix", "#!/usr/bin/env -S BASH_ENV= ENV= bash", true},
 		{"quoted interpreter", "#!/usr/bin/env -S ba'sh'", true},
+		{"dynamic interpreter", "#!/usr/bin/env -S ${SHELL}", true},
 		{"double quoted interpreter", `#!/usr/bin/env -S ba"sh"`, true},
 		{"other interpreter", "#!/bin/sh", false},
 		{"not a shebang", "package p", false},
@@ -200,8 +209,10 @@ func TestIsBashCandidateSeesThroughQuoting(t *testing.T) {
 			}
 		})
 	}
-	if shebangNeutralizesStartupFiles("#!/usr/bin/env -S ba'sh'") {
-		t.Fatal("a quoted interpreter was accepted as a hardened form")
+	for _, hidden := range []string{"#!/usr/bin/env -S ba'sh'", "#!/usr/bin/env -S ${SHELL}"} {
+		if shebangNeutralizesStartupFiles(hidden) {
+			t.Fatalf("%q was accepted as a hardened form", hidden)
+		}
 	}
 }
 

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -61,6 +61,22 @@ func readTrackedFile(path string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
+// shebangQuoteStripper removes the quote characters env -S processes, so a
+// candidate cannot hide its interpreter behind them.
+var shebangQuoteStripper = strings.NewReplacer("'", "", `"`, "", `\`, "")
+
+// isBashCandidate reports whether an interpreter line runs Bash and so must
+// hold the startup-file property.
+//
+// The quotes are stripped before the interpreter is read because env -S
+// processes them first: a line spelled with a quoted interpreter still runs
+// Bash, and a filter over the raw text would skip that file unjudged rather
+// than reject it.
+func isBashCandidate(shebang string) bool {
+	return strings.HasPrefix(shebang, "#!") &&
+		strings.Contains(shebangQuoteStripper.Replace(shebang), "bash")
+}
+
 // hardenedShebangs is the exact set of interpreter lines a tracked Bash script
 // may use. Each one stops Bash from reading a caller-controlled startup file:
 // Bash sources $BASH_ENV, and $ENV in POSIX mode, before the script's first
@@ -105,7 +121,10 @@ func TestTrackedBashScriptsNeutralizeStartupFiles(t *testing.T) {
 			continue
 		}
 		shebang, _, _ := strings.Cut(string(content), "\n")
-		if !strings.HasPrefix(shebang, "#!") || !strings.Contains(shebang, "bash") {
+		// Quotes are removed by env -S before the interpreter is resolved, so
+		// they are removed here too. Otherwise a line spelled ba'sh' would not
+		// look like a Bash candidate and the file would be skipped unjudged.
+		if !isBashCandidate(shebang) {
 			continue
 		}
 		checked++
@@ -155,6 +174,37 @@ func TestReadTrackedFileRefusesASymlinkedPath(t *testing.T) {
 // point of an exact-match set: each of those was empirically shown to run an
 // inherited BASH_ENV, and a predicate that parsed the command line accepted
 // several of them.
+// TestIsBashCandidateSeesThroughQuoting proves the walk cannot be made to skip
+// a Bash script. A quoted interpreter still runs Bash, so it must reach the
+// judgement and be rejected there rather than be filtered out before it.
+func TestIsBashCandidateSeesThroughQuoting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		shebang string
+		want    bool
+	}{
+		{"plain", "#!/bin/bash -p", true},
+		{"env prefix", "#!/usr/bin/env -S BASH_ENV= ENV= bash", true},
+		{"quoted interpreter", "#!/usr/bin/env -S ba'sh'", true},
+		{"double quoted interpreter", `#!/usr/bin/env -S ba"sh"`, true},
+		{"other interpreter", "#!/bin/sh", false},
+		{"not a shebang", "package p", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isBashCandidate(test.shebang); got != test.want {
+				t.Fatalf("isBashCandidate(%q) = %t, want %t", test.shebang, got, test.want)
+			}
+		})
+	}
+	if shebangNeutralizesStartupFiles("#!/usr/bin/env -S ba'sh'") {
+		t.Fatal("a quoted interpreter was accepted as a hardened form")
+	}
+}
+
 func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -88,6 +88,10 @@ func shebangNeutralizesStartupFiles(shebang string) bool {
 		return false
 	}
 	for _, arg := range fields[command+1:] {
+		if arg == "--" {
+			// Bash stops reading options here; anything after is the operand.
+			break
+		}
 		if arg == "-p" {
 			return true
 		}
@@ -191,8 +195,11 @@ func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
 		// env(1) passes everything after the command name to that command, so
 		// these two are Bash arguments and an inherited BASH_ENV still runs.
 		{"cleared after the command", "#!/usr/bin/env -S bash BASH_ENV= ENV=", false},
-		// -p is a Bash option, so it counts only after the command name.
+		// -p is a Bash option, so it counts only after the command name, and
+		// only before the -- that ends Bash option parsing.
 		{"privileged before the command", "#!/usr/bin/env -S -p bash", false},
+		{"privileged after the option terminator", "#!/usr/bin/env -S bash -- -p", false},
+		{"privileged before the option terminator", "#!/usr/bin/env -S bash -p --", true},
 		{"absolute interpreter after assignments", "#!/usr/bin/env -S BASH_ENV= ENV= /bin/bash", true},
 	}
 	for _, test := range tests {

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -69,9 +69,21 @@ func TestTrackedBashScriptsNeutralizeStartupFiles(t *testing.T) {
 	root := repoRoot(t)
 	checked := 0
 	for _, rel := range trackedFiles(t, root) {
-		content, err := os.ReadFile(filepath.Join(root, rel))
+		path := filepath.Join(root, rel)
+		info, err := os.Lstat(path)
 		if err != nil {
-			// Tracked symlinks and gitlinks have no readable body.
+			t.Errorf("stat %s: %v", rel, err)
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			// A tracked symlink or submodule gitlink holds no script body.
+			continue
+		}
+		// A regular tracked file that cannot be read is a candidate this walk
+		// failed to judge, not one it cleared.
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", rel, err)
 			continue
 		}
 		shebang, _, _ := strings.Cut(string(content), "\n")

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// minTrackedBashScripts is the inventory floor for the shebang walk. A
+// tracked-file walk that returns nothing, or that stops early, otherwise
+// passes vacuously. The count on this tree is well above this floor; raise
+// the floor only with the tree.
+const minTrackedBashScripts = 100
+
+// trackedFiles returns every tracked path in the repository, relative to root.
+func trackedFiles(t *testing.T, root string) []string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", root, "ls-files", "-z").Output()
+	if err != nil {
+		t.Fatalf("git ls-files: %v", err)
+	}
+	var paths []string
+	for _, path := range strings.Split(string(out), "\x00") {
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	if len(paths) == 0 {
+		t.Fatal("git ls-files reported no tracked files")
+	}
+	return paths
+}
+
+// shebangNeutralizesStartupFiles reports whether a Bash shebang line stops the
+// interpreter from reading a caller-controlled startup file. Bash sources
+// $BASH_ENV, and $ENV in POSIX mode, before the script's first line, so a
+// script whose shebang leaves those names alone runs the caller's code first.
+//
+// Two spellings close that, and this repository uses both: privileged mode
+// (-p), under which Bash ignores both variables outright, and an env(1) prefix
+// that clears both names for the interpreter.
+func shebangNeutralizesStartupFiles(shebang string) bool {
+	clearedBashEnv, clearedEnv := false, false
+	for _, field := range strings.Fields(shebang) {
+		switch field {
+		case "-p":
+			return true
+		case "BASH_ENV=":
+			clearedBashEnv = true
+		case "ENV=":
+			clearedEnv = true
+		}
+	}
+	return clearedBashEnv && clearedEnv
+}
+
+// TestTrackedBashScriptsNeutralizeStartupFiles extends the single-script
+// shebang assertion in internal/metadatautil to every tracked Bash script. The
+// per-script check pins one reviewed file; the startup-file property is
+// required of all of them.
+func TestTrackedBashScriptsNeutralizeStartupFiles(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	checked := 0
+	for _, rel := range trackedFiles(t, root) {
+		content, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			// Tracked symlinks and gitlinks have no readable body.
+			continue
+		}
+		shebang, _, _ := strings.Cut(string(content), "\n")
+		if !strings.HasPrefix(shebang, "#!") || !strings.Contains(shebang, "bash") {
+			continue
+		}
+		checked++
+		if !shebangNeutralizesStartupFiles(shebang) {
+			t.Errorf("%s starts with %s; every tracked Bash script must clear BASH_ENV and ENV, either with the env(1) prefix form or with `#!/bin/bash -p`", rel, shebang)
+		}
+	}
+	if checked < minTrackedBashScripts {
+		t.Fatalf("scanned %d Bash scripts, want at least %d; the tracked-file walk did not complete", checked, minTrackedBashScripts)
+	}
+}
+
+func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		shebang string
+		want    bool
+	}{
+		{"cleared env prefix", "#!/usr/bin/env -S BASH_ENV= ENV= bash", true},
+		{"privileged", "#!/bin/bash -p", true},
+		{"cleared prefix and privileged", "#!/usr/bin/env -S BASH_ENV= ENV= LC_ALL=C bash -p", true},
+		{"bare", "#!/bin/bash", false},
+		{"bare env", "#!/usr/bin/env bash", false},
+		{"BASH_ENV cleared only", "#!/usr/bin/env -S BASH_ENV= bash", false},
+		{"ENV cleared only", "#!/usr/bin/env -S ENV= bash", false},
+		{"assigned not cleared", "#!/usr/bin/env -S BASH_ENV=/tmp/rc ENV=/tmp/rc bash", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shebangNeutralizesStartupFiles(test.shebang); got != test.want {
+				t.Fatalf("shebangNeutralizesStartupFiles(%q) = %t, want %t", test.shebang, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -61,63 +61,30 @@ func readTrackedFile(path string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
-// shebangNeutralizesStartupFiles reports whether a Bash shebang line stops the
-// interpreter from reading a caller-controlled startup file. Bash sources
-// $BASH_ENV, and $ENV in POSIX mode, before the script's first line, so a
-// script whose shebang leaves those names alone runs the caller's code first.
+// hardenedShebangs is the exact set of interpreter lines a tracked Bash script
+// may use. Each one stops Bash from reading a caller-controlled startup file:
+// Bash sources $BASH_ENV, and $ENV in POSIX mode, before the script's first
+// line, and each form here either runs Bash privileged (-p), under which both
+// variables are ignored, or clears both names with an env(1) prefix.
 //
-// Two spellings close that, and this repository uses both: privileged mode
-// (-p), under which Bash ignores both variables outright, and an env(1) prefix
-// that clears both names for the interpreter.
-//
-// Position decides which spelling a token belongs to. env(1) takes assignments
-// before the command name and passes everything after it to that command, so
-// "env -S bash BASH_ENV= ENV=" hands Bash two arguments and leaves an inherited
-// BASH_ENV in force. Bash in turn reads options only until -- or until its
-// script operand, so "bash -- -p" and "bash /dev/null -p" are not privileged.
-// A later assignment of the same name also wins, so the final value of each
-// name decides, not whether a cleared spelling appeared anywhere.
+// This is an exact-match set and not a parser. A Bash and env(1) command line
+// carries more grammar than the property needs -- quoting inside -S, option
+// arity, an option terminator, a script operand, repeated assignments where
+// the last wins -- and each of those is a way for a line to read as hardened
+// while behaving otherwise. Matching whole reviewed lines has no such grammar
+// to work around. Adding a form is a deliberate edit here, which is the review
+// the property deserves.
+var hardenedShebangs = map[string]bool{
+	"#!/bin/bash -p":                        true,
+	"#!/usr/bin/env -S BASH_ENV= ENV= bash": true,
+	"#!/usr/bin/env -S -i PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin BASH_ENV= ENV= /bin/bash": true,
+	"#!/usr/bin/env -S -uPOSIXLY_CORRECT -uPOSIX_PEDANTIC BASH_ENV= ENV= SHELLOPTS= BASHOPTS= BASH_COMPAT= BASH_XTRACEFD= FUNCNEST= LC_ALL=C bash -p":                                                      true,
+}
+
+// shebangNeutralizesStartupFiles reports whether a Bash interpreter line is one
+// of the reviewed hardened forms.
 func shebangNeutralizesStartupFiles(shebang string) bool {
-	fields := strings.Fields(shebang)
-	command := -1
-	for i, field := range fields {
-		if field == "bash" || strings.HasSuffix(field, "/bash") {
-			command = i
-			break
-		}
-	}
-	if command < 0 {
-		return false
-	}
-	for _, arg := range fields[command+1:] {
-		if arg == "-p" {
-			return true
-		}
-		if arg == "--" || !strings.HasPrefix(arg, "-") {
-			// The option terminator, or the script operand: Bash reads no
-			// further options after either.
-			break
-		}
-	}
-	if command == 0 {
-		// The interpreter line names Bash directly and carried no -p, so there
-		// is no room before it for an assignment.
-		return false
-	}
-	bashEnv, env := "unset", "unset"
-	for _, assignment := range fields[1:command] {
-		name, value, isAssignment := strings.Cut(assignment, "=")
-		if !isAssignment {
-			continue
-		}
-		switch name {
-		case "BASH_ENV":
-			bashEnv = value
-		case "ENV":
-			env = value
-		}
-	}
-	return bashEnv == "" && env == ""
+	return hardenedShebangs[shebang]
 }
 
 // TestTrackedBashScriptsNeutralizeStartupFiles extends the single-script
@@ -183,6 +150,11 @@ func TestReadTrackedFileRefusesASymlinkedPath(t *testing.T) {
 	}
 }
 
+// TestShebangNeutralizesStartupFilesRejectsUnhardenedForms covers the reviewed
+// forms and the lines that read as hardened but are not. The last group is the
+// point of an exact-match set: each of those was empirically shown to run an
+// inherited BASH_ENV, and a predicate that parsed the command line accepted
+// several of them.
 func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
 	t.Parallel()
 
@@ -191,28 +163,31 @@ func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
 		shebang string
 		want    bool
 	}{
-		{"cleared env prefix", "#!/usr/bin/env -S BASH_ENV= ENV= bash", true},
+		{"env prefix", "#!/usr/bin/env -S BASH_ENV= ENV= bash", true},
 		{"privileged", "#!/bin/bash -p", true},
-		{"cleared prefix and privileged", "#!/usr/bin/env -S BASH_ENV= ENV= LC_ALL=C bash -p", true},
+
 		{"bare", "#!/bin/bash", false},
 		{"bare env", "#!/usr/bin/env bash", false},
 		{"BASH_ENV cleared only", "#!/usr/bin/env -S BASH_ENV= bash", false},
 		{"ENV cleared only", "#!/usr/bin/env -S ENV= bash", false},
 		{"assigned not cleared", "#!/usr/bin/env -S BASH_ENV=/tmp/rc ENV=/tmp/rc bash", false},
-		// env(1) passes everything after the command name to that command, so
-		// these two are Bash arguments and an inherited BASH_ENV still runs.
+
+		// Each of these runs an inherited BASH_ENV. env(1) passes everything
+		// after the command name to that command; Bash reads options only
+		// until -- or its script operand, and --rcfile consumes the next
+		// argument; a repeated assignment is won by the last one; and -S
+		// removes quotes, so a quoted name is the same name.
 		{"cleared after the command", "#!/usr/bin/env -S bash BASH_ENV= ENV=", false},
-		// -p is a Bash option, so it counts only after the command name, and
-		// only before the -- that ends Bash option parsing.
 		{"privileged before the command", "#!/usr/bin/env -S -p bash", false},
 		{"privileged after the option terminator", "#!/usr/bin/env -S bash -- -p", false},
-		{"privileged before the option terminator", "#!/usr/bin/env -S bash -p --", true},
-		// Bash reads no further options once its script operand appears.
 		{"privileged after the script operand", "#!/usr/bin/env -S bash /dev/null -p", false},
-		// A later assignment of the same name wins, so the final value decides.
+		{"privileged consumed by an option", "#!/usr/bin/env -S bash --rcfile -p", false},
 		{"cleared then reassigned", "#!/usr/bin/env -S BASH_ENV= ENV= BASH_ENV=/tmp/rc bash", false},
-		{"assigned then cleared", "#!/usr/bin/env -S BASH_ENV=/tmp/rc ENV= BASH_ENV= bash", true},
-		{"absolute interpreter after assignments", "#!/usr/bin/env -S BASH_ENV= ENV= /bin/bash", true},
+		{"cleared then reassigned through quotes", "#!/usr/bin/env -S BASH_ENV= ENV= BASH_'ENV'=/tmp/rc bash", false},
+
+		// Safe in themselves, but not reviewed lines. An equivalent form is
+		// rejected until it is added to the set on purpose.
+		{"unlisted equivalent", "#!/usr/bin/env -S BASH_ENV= ENV= LC_ALL=C bash -p", false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -70,11 +70,13 @@ func readTrackedFile(path string) ([]byte, error) {
 // (-p), under which Bash ignores both variables outright, and an env(1) prefix
 // that clears both names for the interpreter.
 //
-// Position decides which spelling a token belongs to. env(1) takes its
-// assignments before the command name and passes everything after it to that
-// command, so "env -S bash BASH_ENV= ENV=" hands Bash two arguments and leaves
-// an inherited BASH_ENV in force. Assignments are therefore read only before
-// the interpreter, and -p only after it.
+// Position decides which spelling a token belongs to. env(1) takes assignments
+// before the command name and passes everything after it to that command, so
+// "env -S bash BASH_ENV= ENV=" hands Bash two arguments and leaves an inherited
+// BASH_ENV in force. Bash in turn reads options only until -- or until its
+// script operand, so "bash -- -p" and "bash /dev/null -p" are not privileged.
+// A later assignment of the same name also wins, so the final value of each
+// name decides, not whether a cleared spelling appeared anywhere.
 func shebangNeutralizesStartupFiles(shebang string) bool {
 	fields := strings.Fields(shebang)
 	command := -1
@@ -88,12 +90,13 @@ func shebangNeutralizesStartupFiles(shebang string) bool {
 		return false
 	}
 	for _, arg := range fields[command+1:] {
-		if arg == "--" {
-			// Bash stops reading options here; anything after is the operand.
-			break
-		}
 		if arg == "-p" {
 			return true
+		}
+		if arg == "--" || !strings.HasPrefix(arg, "-") {
+			// The option terminator, or the script operand: Bash reads no
+			// further options after either.
+			break
 		}
 	}
 	if command == 0 {
@@ -101,16 +104,20 @@ func shebangNeutralizesStartupFiles(shebang string) bool {
 		// is no room before it for an assignment.
 		return false
 	}
-	clearedBashEnv, clearedEnv := false, false
+	bashEnv, env := "unset", "unset"
 	for _, assignment := range fields[1:command] {
-		switch assignment {
-		case "BASH_ENV=":
-			clearedBashEnv = true
-		case "ENV=":
-			clearedEnv = true
+		name, value, isAssignment := strings.Cut(assignment, "=")
+		if !isAssignment {
+			continue
+		}
+		switch name {
+		case "BASH_ENV":
+			bashEnv = value
+		case "ENV":
+			env = value
 		}
 	}
-	return clearedBashEnv && clearedEnv
+	return bashEnv == "" && env == ""
 }
 
 // TestTrackedBashScriptsNeutralizeStartupFiles extends the single-script
@@ -200,6 +207,11 @@ func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
 		{"privileged before the command", "#!/usr/bin/env -S -p bash", false},
 		{"privileged after the option terminator", "#!/usr/bin/env -S bash -- -p", false},
 		{"privileged before the option terminator", "#!/usr/bin/env -S bash -p --", true},
+		// Bash reads no further options once its script operand appears.
+		{"privileged after the script operand", "#!/usr/bin/env -S bash /dev/null -p", false},
+		// A later assignment of the same name wins, so the final value decides.
+		{"cleared then reassigned", "#!/usr/bin/env -S BASH_ENV= ENV= BASH_ENV=/tmp/rc bash", false},
+		{"assigned then cleared", "#!/usr/bin/env -S BASH_ENV=/tmp/rc ENV= BASH_ENV= bash", true},
 		{"absolute interpreter after assignments", "#!/usr/bin/env -S BASH_ENV= ENV= /bin/bash", true},
 	}
 	for _, test := range tests {

--- a/internal/testkit/tracked_shebangs_test.go
+++ b/internal/testkit/tracked_shebangs_test.go
@@ -4,10 +4,13 @@
 package testkit
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -36,6 +39,28 @@ func trackedFiles(t *testing.T, root string) []string {
 	return paths
 }
 
+// readTrackedFile returns the contents of one tracked path, judged through the
+// descriptor it reads. Opening with O_NOFOLLOW and taking the mode from the
+// open file, rather than from an earlier stat of the pathname, means a swap of
+// the final component between the check and the read cannot redirect the walk
+// to another file. This tree tracks only regular files, so a symlink or a
+// directory here is a failure rather than a case to skip.
+func readTrackedFile(path string) ([]byte, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("tracked path is %s, not a regular file", info.Mode().Type())
+	}
+	return io.ReadAll(file)
+}
+
 // shebangNeutralizesStartupFiles reports whether a Bash shebang line stops the
 // interpreter from reading a caller-controlled startup file. Bash sources
 // $BASH_ENV, and $ENV in POSIX mode, before the script's first line, so a
@@ -44,12 +69,37 @@ func trackedFiles(t *testing.T, root string) []string {
 // Two spellings close that, and this repository uses both: privileged mode
 // (-p), under which Bash ignores both variables outright, and an env(1) prefix
 // that clears both names for the interpreter.
+//
+// Position decides which spelling a token belongs to. env(1) takes its
+// assignments before the command name and passes everything after it to that
+// command, so "env -S bash BASH_ENV= ENV=" hands Bash two arguments and leaves
+// an inherited BASH_ENV in force. Assignments are therefore read only before
+// the interpreter, and -p only after it.
 func shebangNeutralizesStartupFiles(shebang string) bool {
-	clearedBashEnv, clearedEnv := false, false
-	for _, field := range strings.Fields(shebang) {
-		switch field {
-		case "-p":
+	fields := strings.Fields(shebang)
+	command := -1
+	for i, field := range fields {
+		if field == "bash" || strings.HasSuffix(field, "/bash") {
+			command = i
+			break
+		}
+	}
+	if command < 0 {
+		return false
+	}
+	for _, arg := range fields[command+1:] {
+		if arg == "-p" {
 			return true
+		}
+	}
+	if command == 0 {
+		// The interpreter line names Bash directly and carried no -p, so there
+		// is no room before it for an assignment.
+		return false
+	}
+	clearedBashEnv, clearedEnv := false, false
+	for _, assignment := range fields[1:command] {
+		switch assignment {
 		case "BASH_ENV=":
 			clearedBashEnv = true
 		case "ENV=":
@@ -69,20 +119,10 @@ func TestTrackedBashScriptsNeutralizeStartupFiles(t *testing.T) {
 	root := repoRoot(t)
 	checked := 0
 	for _, rel := range trackedFiles(t, root) {
-		path := filepath.Join(root, rel)
-		info, err := os.Lstat(path)
+		content, err := readTrackedFile(filepath.Join(root, rel))
 		if err != nil {
-			t.Errorf("stat %s: %v", rel, err)
-			continue
-		}
-		if !info.Mode().IsRegular() {
-			// A tracked symlink or submodule gitlink holds no script body.
-			continue
-		}
-		// A regular tracked file that cannot be read is a candidate this walk
-		// failed to judge, not one it cleared.
-		content, err := os.ReadFile(path)
-		if err != nil {
+			// A candidate this walk could not judge is not a candidate it
+			// cleared. Reporting it keeps the walk fail-closed.
 			t.Errorf("read %s: %v", rel, err)
 			continue
 		}
@@ -97,6 +137,38 @@ func TestTrackedBashScriptsNeutralizeStartupFiles(t *testing.T) {
 	}
 	if checked < minTrackedBashScripts {
 		t.Fatalf("scanned %d Bash scripts, want at least %d; the tracked-file walk did not complete", checked, minTrackedBashScripts)
+	}
+}
+
+// TestReadTrackedFileRefusesASymlinkedPath proves the no-follow discipline:
+// the walk reads the file the path names, never a target that path was pointed
+// at. Without O_NOFOLLOW the symlink below would deliver the decoy body and the
+// walk would judge the wrong file.
+func TestReadTrackedFileRefusesASymlinkedPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.sh")
+	decoy := filepath.Join(dir, "decoy.sh")
+	link := filepath.Join(dir, "link.sh")
+	if err := os.WriteFile(real, []byte("#!/bin/bash -p\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(decoy, []byte("#!/bin/bash\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(decoy, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if content, err := readTrackedFile(real); err != nil || !strings.HasPrefix(string(content), "#!/bin/bash -p") {
+		t.Fatalf("readTrackedFile() on a regular file = %q, %v", content, err)
+	}
+	if content, err := readTrackedFile(link); err == nil {
+		t.Fatalf("readTrackedFile() followed a symlink and returned %q", content)
+	}
+	if content, err := readTrackedFile(dir); err == nil {
+		t.Fatalf("readTrackedFile() accepted a directory and returned %q", content)
 	}
 }
 
@@ -116,6 +188,12 @@ func TestShebangNeutralizesStartupFilesRejectsUnhardenedForms(t *testing.T) {
 		{"BASH_ENV cleared only", "#!/usr/bin/env -S BASH_ENV= bash", false},
 		{"ENV cleared only", "#!/usr/bin/env -S ENV= bash", false},
 		{"assigned not cleared", "#!/usr/bin/env -S BASH_ENV=/tmp/rc ENV=/tmp/rc bash", false},
+		// env(1) passes everything after the command name to that command, so
+		// these two are Bash arguments and an inherited BASH_ENV still runs.
+		{"cleared after the command", "#!/usr/bin/env -S bash BASH_ENV= ENV=", false},
+		// -p is a Bash option, so it counts only after the command name.
+		{"privileged before the command", "#!/usr/bin/env -S -p bash", false},
+		{"absolute interpreter after assignments", "#!/usr/bin/env -S BASH_ENV= ENV= /bin/bash", true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh
+++ b/verify/invariants/harnesses/git-probes/snapshot-kind-probe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 if [[ -d kind ]]; then
   printf 'kind=dir\n'

--- a/verify/invariants/harnesses/git-probes/snapshot-probe.sh
+++ b/verify/invariants/harnesses/git-probes/snapshot-probe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 printf 'tracked=%s\n' "$(cat tracked.txt)"
 if [[ -e untracked.txt ]]; then

--- a/verify/invariants/harnesses/install-deps/brew.sh
+++ b/verify/invariants/harnesses/install-deps/brew.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 if [[ "${1:-}" != "install" ]]; then
   echo "Expected only brew install during installer dependency bootstrap" >&2

--- a/verify/invariants/harnesses/install-deps/sysctl.sh
+++ b/verify/invariants/harnesses/install-deps/sysctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 if [[ "${1:-}" == "-in" ]] && [[ "${2:-}" == "hw.optional.arm64" ]]; then
   printf '1\n'

--- a/verify/invariants/harnesses/install-deps/uname.sh
+++ b/verify/invariants/harnesses/install-deps/uname.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S BASH_ENV= ENV= bash
 set -euo pipefail
 case "${1:-}" in
   -s)


### PR DESCRIPTION
## Summary

Two deterministic counters from the Codex review-history mining of PRs 600-685,
plus the defects each one found on `main`.

**S6 - flag-form matrix helper (`internal/testkit/argv.go`).** Counters class E,
flag-parsing completeness: 13 mined findings, 11 accepted, concentrated in #675
(9) and #684 (4). Every one of them says the same thing - the assertion covered
`--flag value` and the parser accepted `--flag=value`, `-s value`, `-s=value` or
`-svalue` unread.

- `FlagForms(flag, short, value)` returns all five spellings.
- `AssertRejectsLaterOverride` drives a caller through every spelling, so a
  last-wins parser cannot keep the trusted first value in view while the driven
  process uses the attacker's later one.
- `CountFlagOccurrences` compares whole argument-vector entries. This is the
  tokenised half of the contract. The `--hostname` finding in #675 fired because
  a temporary directory named `.../review--hostname-tmp` matched a substring scan
  of the flattened argument string; the tokenised count does not match it.

**S7 - generated-shell quoting and shebang completeness.** Counters class B,
shell quoting and environment expansion in generated scripts: 13 mined findings,
all 13 accepted, concentrated in #647 (11).

- `ShellQuote` wraps a value as one POSIX shell word. The Go quoting verb emits a
  Go literal that the shell re-reads and expands, which is the #647 defect.
- A ban keeps the generators that way. It scans each tracked Go file for the Go
  quoting verb inside a Bash source literal. Four sites violated it on `main` and
  are converted here: the release-output driver and three security-boundary
  probes.
- Five harness scripts under `verify/invariants/harnesses/` used a bare
  `#!/bin/bash`, so a caller that set `BASH_ENV` or `ENV` ran its own code before
  the script's first line. The single-script shebang assertion in
  `internal/metadatautil` pinned one reviewed file; the walk added here requires
  the property of all 139 tracked Bash scripts.

Both walks fail closed on a short inventory, in the house form the class C
findings established: a walk that returns nothing must not pass vacuously.

### Deferred, with a reason

- The S6 retrofit of the flag assertions in
  `internal/testkit/release_outputs_verify_test.go` waits for #675, which is open
  and rewrites that file. It is about five lines once #675 merges.
- The S7 reuse of the `internal/host/validatorbind` CSV `MountSpec` encoder in
  `scripts/ci/run-validate-in-validator.sh` waits for the hostile-TMPDIR change,
  which owns that file.

## Testing

- `go build ./...`
- `go vet ./internal/testkit/ ./internal/metadatautil/`
- `go test ./internal/testkit/ ./internal/metadatautil/ -count=1` - both pass.
- `./scripts/check-pr-shape.sh` - files=11 lines=463 areas=2.
- `shellcheck -x verify/invariants/harnesses/**/*.sh` - clean.

Negative controls, mutation style:

- Restore the bare shebang on one harness script. The walk reports it and fails.
- Restore the Go quoting verb at a generator site. The ban reports the exact file
  and line and fails.
- `TestFlagFormsExposesTheSpellingsALongSpaceAssertionMisses` drives the matrix
  against a parser that only knows `--flag value` and requires that exactly four
  of the five spellings escape it. A matrix of five long-space variations would
  fail this test.
- `TestCountFlagOccurrencesIgnoresAValueContainingTheFlag` asserts the tokenised
  count is 1 and that the banned flattened-string scan finds 2 on the same
  argument vector.
- `TestShellQuoteSurvivesShellReexpansion` round-trips `$HOME`, `$(id)`, a
  backtick and a quote through Bash, and requires that the Go quoting verb does
  not survive the same round trip.

Differential injection probe for the shebang change, run under `env -i` with
`BASH_ENV` pointed at an attacker file:

```
=== bare (state on main) ===      === hardened (this branch) ===
INJECTED                          Darwin
Darwin
```

Both harness groups were replayed in their real invocation shapes before the
push: the `install-deps` mocks under the restricted `env -i` PATH that
`verify-invariants.sh` builds for them, and the git probe through
`scripts/with-validation-snapshot.sh --mode index`. Both behave as they do on
`main`.


## Review rounds

Six Codex rounds, seventeen findings. One P1, in round 1, fixed; every other
finding was P2 and all were accepted. Each fix carries a mutation control that
fails without it, and each claimed bypass was reproduced locally before being
fixed.

Two of the rounds changed the design rather than patching it, both after the
same seam produced a finding three rounds running:

- The quoting scan read lines, so Go's literal and comment boundaries were
  inferred. It now takes string tokens from `go/scanner` and judges the joined
  value of a concatenation, which is what `fmt` sees. That closed the raw
  literal, full-line comment, trailing and block comment, split-directive and
  parenthesised-fragment findings together.
- The shebang check parsed the interpreter line, and six separate readings of
  Bash and `env` grammar turned out to be wrong: assignments after the command,
  `-p` past `--`, `-p` past the script operand, `-p` consumed by `--rcfile`, a
  repeated assignment won by the last, and quote removal inside `-S`. Probes
  under `env -i` ran an injected startup file for five of them. The parser is
  replaced by exact matching against the reviewed interpreter lines, so there is
  no grammar left to work around.

The most consequential finding was against the shipped helper rather than a
check: `AssertRejectsLaterOverride` treated any error as a rejection, so a base
that was already invalid made a last-wins parser pass vacuously. The baseline
must now succeed first.

### Known residual

Both walks decide that a literal is shell from its text, never from where the
value goes. That misses a markerless fragment such as
`fmt.Sprintf("printf '%s' %q", value)`, and would falsely report a Bash script
that uses `printf %q` if it also carried a marker in the same expression.
Closing either direction needs the literal traced to its sink, which belongs to
the shared exported shell parser unit. This check is the greppable interim that
unit's plan calls for: a ratchet over the sites that exist, not a proof that no
other site can exist. No such site exists in the tree today.

The tracked-file reads open each path once with `O_NOFOLLOW` and judge that
descriptor. A per-component walk from a repository descriptor is deliberately
not added: reaching the residual needs write access to the checkout, and anyone
holding it can edit the tracked file directly and be judged on what they wrote.
