### PR TITLE
^f Add a loader invocation-form fixture matrix

### DIFF
--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -145,6 +145,13 @@ const FORMS: &[Form] = &[
     // where the option's value belongs: if the walk reads that value as the
     // exec target it reaches an option of unknown arity and refuses, so the
     // absence of a refusal is the proof that the value was consumed.
+    //
+    // The opposite error needs the opposite placement. An attached value is
+    // already in its option's token, so a walk that also consumes the next
+    // argument steps over the exec target and refuses nothing. A row for an
+    // attached form therefore puts UNKNOWN_OPTION in the exec-target position
+    // and demands a refusal: the refusal is the proof that the walk stopped
+    // there rather than past it.
     form(
         "bare exec target",
         Execve(LOADER, &["ld", TARGET], GUARDED_ENV),
@@ -194,9 +201,25 @@ const FORMS: &[Form] = &[
         ANY,
     ),
     form(
+        "--argv0=value consumes no further argument",
+        Execve(LOADER, &["ld", "--argv0=x", UNKNOWN_OPTION], GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
         "--inhibit-rpath= empty attached value",
         Execve(LOADER, &["ld", "--inhibit-rpath=", TARGET], GUARDED_ENV),
         NotRefused,
+        ANY,
+    ),
+    form(
+        "--inhibit-rpath= empty attached value consumes no further argument",
+        Execve(
+            LOADER,
+            &["ld", "--inhibit-rpath=", UNKNOWN_OPTION],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
         ANY,
     ),
     form(

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//! Loader invocation-form fixture matrix for the exec guard.
+//!
+//! Every defect in the loader/exec bypass class had one shape: the guard's
+//! argument walk missed a syntactic form of an invocation it already judged in
+//! another form. Each fix was proven one form at a time. This file makes the
+//! coverage a table instead: one row per invocation form, each row naming the
+//! classification the guard must reach, driven through the guard's own
+//! exported entry points rather than through its private helpers.
+//!
+//! A row states the message the guard must print, or that no form-specific
+//! refusal may fire. The cleared-environment first hop is accepted in the
+//! second case: a child environment without the approved preload is refused by
+//! the fail-closed default, which is not a statement about the form under test.
+//!
+//! Rows the guards on this branch cannot answer are recorded as pending with a
+//! reason rather than asserted green. `scripts/container-smoke.sh` replays the
+//! same forms against the real loader inside the runtime image, where the
+//! mutable exec roots and the protected runtime signatures exist.
+
+use Call::{Execve, ExecveNullEnv, Execveat, Execvp};
+use Expect::{NotRefused, Pending, Refused};
+use libc::c_int;
+use std::ffi::{CString, OsString};
+use std::fs::{self, File};
+use std::io::Read;
+use std::os::fd::FromRawFd;
+use std::path::{Path, PathBuf};
+use std::ptr;
+
+const MUTABLE_NATIVE: &str = "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile.\n";
+const LOADER_ENV: &str = "Workcell blocked unsafe dynamic-loader environment for native execution on the strict profile.\n";
+const PROTECTED_RUNTIME: &str =
+    "Workcell blocked direct protected runtime execution outside approved wrappers.\n";
+const MISSING_GUARD: &str = "Workcell blocked child execution without the approved exec guard preload on the strict profile.\n";
+const RELATIVE_SEARCH_PATH: &str =
+    "Workcell rejected a command found only through a relative PATH entry.\n";
+const OVERSIZED_INPUT: &str = "Workcell rejected oversized exec arguments.\n";
+
+/// The refusals that answer the form under test. `MISSING_GUARD` is absent on
+/// purpose: it is the fail-closed default for an unguarded child, not a
+/// judgement about the invocation form.
+const FORM_SPECIFIC_REFUSALS: &[&str] = &[
+    MUTABLE_NATIVE,
+    LOADER_ENV,
+    PROTECTED_RUNTIME,
+    RELATIVE_SEARCH_PATH,
+    OVERSIZED_INPUT,
+];
+
+/// Matches `ALLOWED_LD_PRELOAD` in `src/lib.rs`. Rows that are not about the
+/// child environment carry exactly this entry, so the fail-closed default
+/// never masks the classification the row is about.
+const GUARD_PRELOAD: &str = "LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so";
+const GUARDED_ENV: &[&str] = &[GUARD_PRELOAD];
+
+/// The fixture directory. `{fixture}` expands to it in every row.
+const FIXTURE: &str = "{fixture}";
+/// A pathname whose basename marks it as the dynamic loader, so the guard walks
+/// the argument vector the way the loader would.
+const LOADER_NAME: &str = "ld-linux-form-fixture.so.2";
+const LOADER: &str = "{fixture}/ld-linux-form-fixture.so.2";
+/// An option of unknown arity. The guard cannot locate the exec target past it,
+/// so reaching it must refuse. Placing it where a value belongs turns "the
+/// option's value was read as the exec target" into an observable refusal.
+const UNKNOWN_OPTION: &str = "--workcell-not-a-real-option";
+/// A regular file that is not an ELF and carries no shebang: the ENOEXEC
+/// fallback target, and an exec target outside every mutable root.
+const TARGET: &str = "{fixture}/not-an-exec-target";
+const TARGET_ARGV: &[&str] = &["target"];
+/// A bare name for the PATH-search rows. No search root holds it.
+const PROBE: &str = "workcell-loader-form-probe";
+/// Bytes past `MAX_EXEC_PATH_SEGMENT_BYTES` in `src/lib.rs`.
+const OVERLONG_SEGMENT_BYTES: usize = 128 * 1024 + 1;
+
+const EQUALS_SIGN_PENDING: &str = "the split-at-equals defect is only observable when the truncated prefix resolves inside a mutable exec root; container smoke covers it";
+const ENV_CLUSTER_PENDING: &str = "the cluster is classified only when the shebang scan reaches a protected runtime, whose stat signatures exist in the runtime image; container smoke covers it";
+const RAW_SYSCALL_PENDING: &str = "the built cdylib exports workcell_syscall_shim, not syscall, so a raw-syscall row observes nothing and would report a false pass";
+
+enum Call {
+    /// `execve(path, argv, envp)` with an explicit child environment.
+    Execve(
+        &'static str,
+        &'static [&'static str],
+        &'static [&'static str],
+    ),
+    /// `execve(path, argv, NULL)`. A NULL envp gives the child an empty
+    /// environment, which no other row can ask about.
+    ExecveNullEnv(&'static str),
+    /// `execveat(dirfd, name, argv, envp, 0)` with `name` relative to the
+    /// fixture directory, so the target is the descriptor the kernel resolves.
+    Execveat(
+        &'static str,
+        &'static [&'static str],
+        &'static [&'static str],
+    ),
+    /// `execvp(file, argv)` with `PATH` set to this value. The search reads the
+    /// caller's own `PATH`, never the child environment.
+    Execvp(&'static str, &'static str),
+}
+
+enum Expect {
+    /// The guard must print this message.
+    Refused(&'static str),
+    /// No form-specific refusal may fire.
+    NotRefused,
+    /// Not answerable on this branch. Recorded, not asserted.
+    Pending(&'static str),
+}
+
+struct Form {
+    name: &'static str,
+    call: Call,
+    expect: Expect,
+    /// The loader-environment and descriptor classifiers are Linux-only.
+    linux_only: bool,
+}
+
+/// Table constructor, so a row reads as one line of matrix rather than four.
+const fn form(name: &'static str, call: Call, expect: Expect, linux_only: bool) -> Form {
+    Form {
+        name,
+        call,
+        expect,
+        linux_only,
+    }
+}
+
+/// `linux_only` values, named for the table.
+const ANY: bool = false;
+const LINUX: bool = true;
+
+const FORMS: &[Form] = &[
+    // The loader argument walk. A row that must not refuse puts UNKNOWN_OPTION
+    // where the option's value belongs: if the walk reads that value as the
+    // exec target it reaches an option of unknown arity and refuses, so the
+    // absence of a refusal is the proof that the value was consumed.
+    form(
+        "bare exec target",
+        Execve(LOADER, &["ld", TARGET], GUARDED_ENV),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "option of unknown arity refuses rather than skips",
+        Execve(LOADER, &["ld", UNKNOWN_OPTION, TARGET], GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "option abbreviation is not a known option",
+        Execve(LOADER, &["ld", "--argv", TARGET], GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "valueless option before an unknown option still refuses",
+        Execve(
+            LOADER,
+            &["ld", "--list-tunables", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--argv0 separate value is not the exec target",
+        Execve(
+            LOADER,
+            &["ld", "--argv0", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "--argv0=value attached form",
+        Execve(
+            LOADER,
+            &["ld", "--argv0=--workcell-not-a-real-option", TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "--inhibit-rpath= empty attached value",
+        Execve(LOADER, &["ld", "--inhibit-rpath=", TARGET], GUARDED_ENV),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "--inhibit-rpath separate value",
+        Execve(
+            LOADER,
+            &["ld", "--inhibit-rpath", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "--glibc-hwcaps-mask separate value",
+        Execve(
+            LOADER,
+            &["ld", "--glibc-hwcaps-mask", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "valueless option leaves the next argument as the target",
+        Execve(LOADER, &["ld", "--inhibit-cache", TARGET], GUARDED_ENV),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "-- ends option parsing",
+        Execve(LOADER, &["ld", "--", TARGET], GUARDED_ENV),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "--library-path is refused rather than read, colon separators",
+        Execve(
+            LOADER,
+            &["ld", "--library-path", "/usr/lib:/state/lib", TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--library-path attached value, semicolon separators",
+        Execve(
+            LOADER,
+            &["ld", "--library-path=/usr/lib;/state/lib", TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--preload is refused rather than expanded",
+        Execve(
+            LOADER,
+            &["ld", "--preload", "$ORIGIN/../evil.so", TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--audit= empty attached value is still refused",
+        Execve(LOADER, &["ld", "--audit=", TARGET], GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "arguments after the exec target belong to the target",
+        Execve(
+            LOADER,
+            &["ld", TARGET, "--preload", "/state/evil.so"],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "exec target containing an equals sign is not truncated",
+        Execve(
+            LOADER,
+            &["ld", "{fixture}/not-an-exec-target=x"],
+            GUARDED_ENV,
+        ),
+        Pending(EQUALS_SIGN_PENDING),
+        ANY,
+    ),
+    // The loader environment on a native exec target.
+    form(
+        "LD_LIBRARY_PATH colon separators",
+        Execve(
+            TARGET,
+            TARGET_ARGV,
+            &[GUARD_PRELOAD, "LD_LIBRARY_PATH=/usr/lib:/state/lib"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "LD_LIBRARY_PATH semicolon separators",
+        Execve(
+            TARGET,
+            TARGET_ARGV,
+            &[GUARD_PRELOAD, "LD_LIBRARY_PATH=/usr/lib;/state/lib"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "LD_PRELOAD space separator beside the approved guard",
+        Execve(
+            TARGET,
+            TARGET_ARGV,
+            &["LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so /state/evil.so"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "LD_PRELOAD colon separator beside the approved guard",
+        Execve(
+            TARGET,
+            TARGET_ARGV,
+            &["LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so:/state/evil.so"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "LD_PRELOAD newline separator beside the approved guard",
+        Execve(
+            TARGET,
+            TARGET_ARGV,
+            &["LD_PRELOAD=/usr/local/lib/libworkcell_exec_guard.so\n/state/evil.so"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "ENOEXEC fallback target: every regular file is loader interpreted",
+        Execve(
+            TARGET,
+            TARGET_ARGV,
+            &[GUARD_PRELOAD, "LD_AUDIT=/state/evil.so"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "a directory target cannot reach the loader",
+        Execve(
+            FIXTURE,
+            TARGET_ARGV,
+            &[GUARD_PRELOAD, "LD_AUDIT=/state/evil.so"],
+        ),
+        NotRefused,
+        LINUX,
+    ),
+    form(
+        "null environ is an empty child environment",
+        ExecveNullEnv(FIXTURE),
+        Refused(MISSING_GUARD),
+        LINUX,
+    ),
+    // Descriptor-relative resolution.
+    form(
+        "execveat resolves a dirfd-relative loader name",
+        Execveat(LOADER_NAME, &["ld", UNKNOWN_OPTION, TARGET], GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        LINUX,
+    ),
+    form(
+        "execveat dirfd-relative loader skips a value-taking option's value",
+        Execveat(
+            LOADER_NAME,
+            &["ld", "--argv0", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        LINUX,
+    ),
+    // PATH resolution, read from the caller's own environment.
+    form(
+        "relative PATH entry is refused rather than searched",
+        Execvp(PROBE, "relative/dir:/nonexistent-workcell-search-root"),
+        Refused(RELATIVE_SEARCH_PATH),
+        ANY,
+    ),
+    form(
+        "chdir before PATH resolution: a dot entry is relative too",
+        Execvp(PROBE, ".:/nonexistent-workcell-search-root"),
+        Refused(RELATIVE_SEARCH_PATH),
+        ANY,
+    ),
+    form(
+        "overlong PATH component",
+        Execvp(PROBE, "{overlong}"),
+        Refused(OVERSIZED_INPUT),
+        ANY,
+    ),
+    form(
+        "empty name is not searched",
+        Execvp("", "/nonexistent-workcell-search-root"),
+        NotRefused,
+        ANY,
+    ),
+    // Forms this lane cannot answer. Recorded, never asserted green.
+    form(
+        "env(1) short-option cluster ahead of a protected runtime",
+        Execve("/usr/bin/env", &["env", "-iS", "codex"], GUARDED_ENV),
+        Pending(ENV_CLUSTER_PENDING),
+        ANY,
+    ),
+    form(
+        "raw syscall(SYS_execve) entry",
+        Execve(LOADER, &["ld", UNKNOWN_OPTION, TARGET], GUARDED_ENV),
+        Pending(RAW_SYSCALL_PENDING),
+        ANY,
+    ),
+];
+
+/// Keeps a pending row from being added without being counted.
+const PENDING_FORMS: usize = 3;
+
+#[test]
+fn loader_invocation_forms_reach_the_stated_classification() {
+    let fixture = prepare_fixture();
+
+    // Believe the matrix only after it observes a form the guard is known to
+    // refuse. Without this, a harness that reaches nothing reports every row as
+    // unrefused and the whole table passes for the wrong reason.
+    let control = Execve(LOADER, &["ld", UNKNOWN_OPTION, TARGET], GUARDED_ENV);
+    let observed = run(&control, &fixture);
+    assert!(
+        observed.contains(MUTABLE_NATIVE),
+        "harness control: the guard must refuse an unknown loader option, saw {observed:?}"
+    );
+
+    let mut pending = 0usize;
+    for form in FORMS {
+        if let Pending(reason) = form.expect {
+            println!("pending form {}: {reason}", form.name);
+            pending += 1;
+            continue;
+        }
+        if form.linux_only && !cfg!(target_os = "linux") {
+            println!("skipping Linux-only form {}", form.name);
+            continue;
+        }
+
+        let stderr = run(&form.call, &fixture);
+        match form.expect {
+            Refused(message) => assert!(
+                stderr.contains(message),
+                "form {}: expected {message:?}, saw {stderr:?}",
+                form.name
+            ),
+            NotRefused => {
+                if let Some(refusal) = FORM_SPECIFIC_REFUSALS
+                    .iter()
+                    .find(|message| stderr.contains(**message))
+                {
+                    panic!(
+                        "form {}: expected no form-specific refusal, saw {refusal:?}",
+                        form.name
+                    );
+                }
+            }
+            Pending(_) => unreachable!("pending rows are skipped above"),
+        }
+    }
+
+    assert_eq!(
+        pending, PENDING_FORMS,
+        "a pending row was added or removed without updating PENDING_FORMS"
+    );
+    fs::remove_dir_all(&fixture).expect("remove the fixture directory");
+}
+
+fn prepare_fixture() -> PathBuf {
+    let fixture =
+        std::env::temp_dir().join(format!("workcell-loader-forms-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&fixture);
+    fs::create_dir_all(&fixture).expect("create the fixture directory");
+    fs::write(fixture.join("ld-linux-form-fixture.so.2"), []).expect("write the loader fixture");
+    fs::write(
+        fixture.join("not-an-exec-target"),
+        "neither an ELF nor a shebang\n",
+    )
+    .expect("write the exec target fixture");
+    fixture
+}
+
+fn expand(value: &str, fixture: &Path) -> String {
+    let value = if value.contains("{overlong}") {
+        value.replace(
+            "{overlong}",
+            &format!("/{}", "a".repeat(OVERLONG_SEGMENT_BYTES)),
+        )
+    } else {
+        value.to_owned()
+    };
+    value.replace("{fixture}", &fixture.display().to_string())
+}
+
+fn c_string(value: &str, fixture: &Path) -> CString {
+    CString::new(expand(value, fixture)).expect("fixture strings carry no interior NUL")
+}
+
+fn c_strings(values: &[&str], fixture: &Path) -> Vec<CString> {
+    values
+        .iter()
+        .map(|value| c_string(value, fixture))
+        .collect()
+}
+
+fn c_pointers(values: &[CString]) -> Vec<*const libc::c_char> {
+    values
+        .iter()
+        .map(|value| value.as_ptr())
+        .chain(std::iter::once(ptr::null()))
+        .collect()
+}
+
+fn run(call: &Call, fixture: &Path) -> String {
+    match call {
+        Execve(path, argv, env) => {
+            let path = c_string(path, fixture);
+            let argv = c_strings(argv, fixture);
+            let env = c_strings(env, fixture);
+            let argv = c_pointers(&argv);
+            let env = c_pointers(&env);
+            capture_stderr(|| {
+                // SAFETY: path is a live NUL-terminated CString; argv and env are live NULL-terminated pointer arrays that outlive the call.
+                unsafe {
+                    workcell_exec_guard::execve(path.as_ptr(), argv.as_ptr(), env.as_ptr());
+                }
+            })
+        }
+        ExecveNullEnv(path) => {
+            let path = c_string(path, fixture);
+            let argv = c_strings(TARGET_ARGV, fixture);
+            let argv = c_pointers(&argv);
+            capture_stderr(|| {
+                // SAFETY: path is a live NUL-terminated CString; argv is a live NULL-terminated pointer array; a NULL envp is the documented empty-environment form.
+                unsafe {
+                    workcell_exec_guard::execve(path.as_ptr(), argv.as_ptr(), ptr::null());
+                }
+            })
+        }
+        Execveat(name, argv, env) => {
+            let directory = c_string(FIXTURE, fixture);
+            // SAFETY: directory is a live NUL-terminated CString; open only reads it.
+            let dirfd = unsafe {
+                libc::open(
+                    directory.as_ptr(),
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+                )
+            };
+            assert!(dirfd >= 0, "open the fixture directory");
+            let name = c_string(name, fixture);
+            let argv = c_strings(argv, fixture);
+            let env = c_strings(env, fixture);
+            let argv = c_pointers(&argv);
+            let env = c_pointers(&env);
+            let stderr = capture_stderr(|| {
+                // SAFETY: dirfd is an open directory descriptor; name, argv and env are live and NULL-terminated for the call.
+                unsafe {
+                    workcell_exec_guard::execveat(
+                        dirfd,
+                        name.as_ptr(),
+                        argv.as_ptr(),
+                        env.as_ptr(),
+                        0,
+                    );
+                }
+            });
+            // SAFETY: dirfd was opened above, is still open, and is closed once.
+            unsafe { libc::close(dirfd) };
+            stderr
+        }
+        Execvp(file, path_value) => {
+            let previous = std::env::var_os("PATH");
+            set_path(Some(expand(path_value, fixture).into()));
+            let file = c_string(file, fixture);
+            let argv = c_strings(&["probe"], fixture);
+            let argv = c_pointers(&argv);
+            let stderr = capture_stderr(|| {
+                // SAFETY: file is a live NUL-terminated CString; argv is a live NULL-terminated pointer array that outlives the call.
+                unsafe {
+                    workcell_exec_guard::execvp(file.as_ptr(), argv.as_ptr());
+                }
+            });
+            set_path(previous);
+            stderr
+        }
+    }
+}
+
+/// The PATH-search rows have to change the caller's own `PATH`: `execvp`
+/// searches the caller environment, never the child one.
+fn set_path(value: Option<OsString>) {
+    // SAFETY: .cargo/config.toml forces RUST_TEST_THREADS=1 for this crate, so no other thread reads or writes the environment while this runs.
+    unsafe {
+        match value {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+}
+
+/// The guard reports every refusal by writing to file descriptor 2 and returns
+/// -1, so the message is the only thing that says which classification fired.
+fn capture_stderr(body: impl FnOnce()) -> String {
+    let mut pipe_fds = [0 as c_int; 2];
+    // SAFETY: pipe_fds is a live two-element array; pipe writes both descriptors and nothing else.
+    let created = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+    assert_eq!(created, 0, "create a pipe");
+    // SAFETY: STDERR_FILENO is open; dup returns a new descriptor owned here.
+    let saved = unsafe { libc::dup(libc::STDERR_FILENO) };
+    assert!(saved >= 0, "duplicate stderr");
+    // SAFETY: both descriptors are open and owned here.
+    let redirected = unsafe { libc::dup2(pipe_fds[1], libc::STDERR_FILENO) };
+    assert!(redirected >= 0, "redirect stderr");
+
+    body();
+
+    // SAFETY: saved and the write end are open descriptors owned here, each closed once.
+    unsafe {
+        libc::dup2(saved, libc::STDERR_FILENO);
+        libc::close(saved);
+        libc::close(pipe_fds[1]);
+    }
+    // SAFETY: the read end is open, owned here, and handed to File exactly once.
+    let mut read_end = unsafe { File::from_raw_fd(pipe_fds[0]) };
+    let mut captured = String::new();
+    read_end
+        .read_to_string(&mut captured)
+        .expect("read the captured stderr");
+    captured
+}

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -243,9 +243,93 @@ const FORMS: &[Form] = &[
         ANY,
     ),
     form(
+        "--glibc-hwcaps-prepend separate value",
+        Execve(
+            LOADER,
+            &["ld", "--glibc-hwcaps-prepend", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
+        "--hwcap-mask separate value",
+        Execve(
+            LOADER,
+            &["ld", "--hwcap-mask", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        NotRefused,
+        ANY,
+    ),
+    form(
         "valueless option leaves the next argument as the target",
         Execve(LOADER, &["ld", "--inhibit-cache", TARGET], GUARDED_ENV),
         NotRefused,
+        ANY,
+    ),
+    // One row per remaining valueless option. Each puts UNKNOWN_OPTION where a
+    // value would sit: a walk that reads it as this option's value skips it and
+    // refuses nothing, so the refusal is the proof that the option consumed
+    // nothing.
+    form(
+        "--list consumes no value",
+        Execve(
+            LOADER,
+            &["ld", "--list", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--list-diagnostics consumes no value",
+        Execve(
+            LOADER,
+            &["ld", "--list-diagnostics", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--verify consumes no value",
+        Execve(
+            LOADER,
+            &["ld", "--verify", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--inhibit-cache consumes no value",
+        Execve(
+            LOADER,
+            &["ld", "--inhibit-cache", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--help consumes no value",
+        Execve(
+            LOADER,
+            &["ld", "--help", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
+        ANY,
+    ),
+    form(
+        "--version consumes no value",
+        Execve(
+            LOADER,
+            &["ld", "--version", UNKNOWN_OPTION, TARGET],
+            GUARDED_ENV,
+        ),
+        Refused(MUTABLE_NATIVE),
         ANY,
     ),
     form(

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -28,7 +28,7 @@ use std::ffi::{CString, OsString};
 use std::fs::{self, File};
 use std::io::Read;
 use std::os::fd::FromRawFd;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::ptr;
 
@@ -596,11 +596,24 @@ fn loader_invocation_forms_reach_the_stated_classification() {
     fs::remove_dir_all(&fixture).expect("remove the fixture directory");
 }
 
+/// The fixture directory holds files the rows execute, in a directory every
+/// user can write. A name another user can predict is a check/use gap: it can
+/// be pre-created, and the writes below would then land through symlinks that
+/// user planted. The name carries 128 bits from the kernel, and the directory
+/// is created exclusively and owner-only, so it is this process's alone and no
+/// other user can place an entry inside it for a write to follow.
 fn prepare_fixture() -> PathBuf {
-    let fixture =
-        std::env::temp_dir().join(format!("workcell-loader-forms-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&fixture);
-    fs::create_dir_all(&fixture).expect("create the fixture directory");
+    let mut random = [0u8; 16];
+    File::open("/dev/urandom")
+        .expect("open the kernel random source")
+        .read_exact(&mut random)
+        .expect("read the fixture directory name");
+    let name: String = random.iter().map(|byte| format!("{byte:02x}")).collect();
+    let fixture = std::env::temp_dir().join(format!("workcell-loader-forms-{name}"));
+    fs::DirBuilder::new()
+        .mode(0o700)
+        .create(&fixture)
+        .expect("create the fixture directory exclusively");
     fs::write(fixture.join("ld-linux-form-fixture.so.2"), []).expect("write the loader fixture");
     fs::write(
         fixture.join("not-an-exec-target"),

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -28,6 +28,7 @@ use std::ffi::{CString, OsString};
 use std::fs::{self, File};
 use std::io::Read;
 use std::os::fd::FromRawFd;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::ptr;
 
@@ -73,6 +74,10 @@ const TARGET: &str = "{fixture}/not-an-exec-target";
 const TARGET_ARGV: &[&str] = &["target"];
 /// A bare name for the PATH-search rows. No search root holds it.
 const PROBE: &str = "workcell-loader-form-probe";
+/// An executable regular file that is neither an ELF nor a shebang. execve
+/// answers ENOEXEC for it, and glibc's execvp runs /bin/sh from inside libc,
+/// which does not re-enter the guard, so the guard must classify it first.
+const ENOEXEC_TARGET: &str = "enoexec-fallback-target";
 /// Bytes past `MAX_EXEC_PATH_SEGMENT_BYTES` in `src/lib.rs`.
 const OVERLONG_SEGMENT_BYTES: usize = 128 * 1024 + 1;
 
@@ -97,9 +102,11 @@ enum Call {
         &'static [&'static str],
         &'static [&'static str],
     ),
-    /// `execvp(file, argv)` with `PATH` set to this value. The search reads the
-    /// caller's own `PATH`, never the child environment.
-    Execvp(&'static str, &'static str),
+    /// `execvp(file, argv)` with `PATH` and one more variable set on the
+    /// caller. `execvp` reads the caller's own environment for both the search
+    /// and the loader-override check, never the child environment. An empty
+    /// third field sets no extra variable.
+    Execvp(&'static str, &'static str, &'static str),
 }
 
 enum Expect {
@@ -332,11 +339,21 @@ const FORMS: &[Form] = &[
         LINUX,
     ),
     form(
-        "ENOEXEC fallback target: every regular file is loader interpreted",
+        "a non-ELF regular file target is loader interpreted",
         Execve(
             TARGET,
             TARGET_ARGV,
             &[GUARD_PRELOAD, "LD_AUDIT=/state/evil.so"],
+        ),
+        Refused(LOADER_ENV),
+        LINUX,
+    ),
+    form(
+        "ENOEXEC fallback target found through the execvp search",
+        Execvp(
+            ENOEXEC_TARGET,
+            FIXTURE,
+            "LD_LIBRARY_PATH=/usr/lib:/state/lib",
         ),
         Refused(LOADER_ENV),
         LINUX,
@@ -377,25 +394,25 @@ const FORMS: &[Form] = &[
     // PATH resolution, read from the caller's own environment.
     form(
         "relative PATH entry is refused rather than searched",
-        Execvp(PROBE, "relative/dir:/nonexistent-workcell-search-root"),
+        Execvp(PROBE, "relative/dir:/nonexistent-workcell-search-root", ""),
         Refused(RELATIVE_SEARCH_PATH),
         ANY,
     ),
     form(
         "chdir before PATH resolution: a dot entry is relative too",
-        Execvp(PROBE, ".:/nonexistent-workcell-search-root"),
+        Execvp(PROBE, ".:/nonexistent-workcell-search-root", ""),
         Refused(RELATIVE_SEARCH_PATH),
         ANY,
     ),
     form(
         "overlong PATH component",
-        Execvp(PROBE, "{overlong}"),
+        Execvp(PROBE, "{overlong}", ""),
         Refused(OVERSIZED_INPUT),
         ANY,
     ),
     form(
         "empty name is not searched",
-        Execvp("", "/nonexistent-workcell-search-root"),
+        Execvp("", "/nonexistent-workcell-search-root", ""),
         NotRefused,
         ANY,
     ),
@@ -483,6 +500,11 @@ fn prepare_fixture() -> PathBuf {
         "neither an ELF nor a shebang\n",
     )
     .expect("write the exec target fixture");
+    let enoexec = fixture.join(ENOEXEC_TARGET);
+    fs::write(&enoexec, "neither an ELF nor a shebang\n").expect("write the ENOEXEC fixture");
+    // The PATH search only yields a candidate that answers X_OK.
+    fs::set_permissions(&enoexec, fs::Permissions::from_mode(0o755))
+        .expect("make the ENOEXEC fixture executable");
     fixture
 }
 
@@ -574,9 +596,14 @@ fn run(call: &Call, fixture: &Path) -> String {
             unsafe { libc::close(dirfd) };
             stderr
         }
-        Execvp(file, path_value) => {
-            let previous = std::env::var_os("PATH");
-            set_path(Some(expand(path_value, fixture).into()));
+        Execvp(file, path_value, extra_env) => {
+            let (extra_key, extra_value) = extra_env.split_once('=').unwrap_or(("", ""));
+            let restore = [
+                ("PATH", std::env::var_os("PATH")),
+                (extra_key, std::env::var_os(extra_key)),
+            ];
+            set_env("PATH", Some(expand(path_value, fixture).into()));
+            set_env(extra_key, Some(extra_value.into()));
             let file = c_string(file, fixture);
             let argv = c_strings(&["probe"], fixture);
             let argv = c_pointers(&argv);
@@ -586,20 +613,26 @@ fn run(call: &Call, fixture: &Path) -> String {
                     workcell_exec_guard::execvp(file.as_ptr(), argv.as_ptr());
                 }
             });
-            set_path(previous);
+            for (key, value) in restore {
+                set_env(key, value);
+            }
             stderr
         }
     }
 }
 
-/// The PATH-search rows have to change the caller's own `PATH`: `execvp`
-/// searches the caller environment, never the child one.
-fn set_path(value: Option<OsString>) {
+/// The search rows have to change the caller's own environment: `execvp` reads
+/// the caller's `PATH` and the caller's loader variables, never the child ones.
+/// An empty key is the no-extra-variable case and is ignored.
+fn set_env(key: &str, value: Option<OsString>) {
+    if key.is_empty() {
+        return;
+    }
     // SAFETY: .cargo/config.toml forces RUST_TEST_THREADS=1 for this crate, so no other thread reads or writes the environment while this runs.
     unsafe {
         match value {
-            Some(value) => std::env::set_var("PATH", value),
-            None => std::env::remove_var("PATH"),
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
         }
     }
 }

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -15,10 +15,11 @@
 //! second case: a child environment without the approved preload is refused by
 //! the fail-closed default, which is not a statement about the form under test.
 //!
-//! Rows the guards on this branch cannot answer are recorded as pending with a
-//! reason rather than asserted green. `scripts/container-smoke.sh` replays the
-//! same forms against the real loader inside the runtime image, where the
-//! mutable exec roots and the protected runtime signatures exist.
+//! Rows this lane cannot answer are recorded as pending with a reason rather
+//! than asserted green. `scripts/container-smoke.sh` replays the loader
+//! argument forms against the real loader inside the runtime image, where the
+//! mutable exec roots and the protected runtime signatures exist. Each pending
+//! reason names the lane that holds the form, or states that no lane holds it.
 
 use Call::{Execve, ExecveNullEnv, Execveat, Execvp};
 use Expect::{NotRefused, Pending, Refused};
@@ -75,9 +76,9 @@ const PROBE: &str = "workcell-loader-form-probe";
 /// Bytes past `MAX_EXEC_PATH_SEGMENT_BYTES` in `src/lib.rs`.
 const OVERLONG_SEGMENT_BYTES: usize = 128 * 1024 + 1;
 
-const EQUALS_SIGN_PENDING: &str = "the split-at-equals defect is only observable when the truncated prefix resolves inside a mutable exec root; container smoke covers it";
-const ENV_CLUSTER_PENDING: &str = "the cluster is classified only when the shebang scan reaches a protected runtime, whose stat signatures exist in the runtime image; container smoke covers it";
-const RAW_SYSCALL_PENDING: &str = "the built cdylib exports workcell_syscall_shim, not syscall, so a raw-syscall row observes nothing and would report a false pass";
+const EQUALS_SIGN_PENDING: &str = "the split-at-equals defect is only observable when the truncated prefix resolves inside a mutable exec root; the container smoke row target-with-equals-sign holds it";
+const ENV_CLUSTER_PENDING: &str = "the cluster is classified only when the shebang scan reaches a protected runtime, whose stat signatures exist in the runtime image; the container smoke fixture .workcell-env-cluster-node-shebang holds it";
+const RAW_SYSCALL_PENDING: &str = "no lane holds this form: the built cdylib exports workcell_syscall_shim and does not export syscall, so nothing interposes a raw syscall(SYS_execve, ...) and a row over it would report a false pass; the missing export is pre-existing on main and is recorded for the trampoline unit of the series";
 
 enum Call {
     /// `execve(path, argv, envp)` with an explicit child environment.

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3836,9 +3836,11 @@ EOF
   # against the exported guard entry points; these rows put the /state native
   # payload in the exec-target position, which only the runtime image has. The
   # approved preload stays in the child environment here, so a refused row
-  # reports its own reason rather than the missing-preload default. An exit
-  # status is not the property under test: the loader answers a form it accepts
-  # in its own way, so an unrefused row is proved by the absence of the message.
+  # reports its own reason rather than the missing-preload default. Every row
+  # states its own result: a refused row wants the block message, a row the
+  # loader accepts wants status 0 from /bin/true, and a row the loader itself
+  # rejects wants the loader's own text and no block message.
+  loader_form_block_message="Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile."
   loader_form_refused() {
     local label="$1"
     shift
@@ -3846,17 +3848,33 @@ EOF
       echo "expected loader invocation form ${label} to be refused" >&2
       exit 1
     fi
-    grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." "/tmp/loader-form-${label}.out"
+    grep -q "${loader_form_block_message}" "/tmp/loader-form-${label}.out"
   }
-  loader_form_not_refused() {
+  loader_form_reaches_target() {
     local label="$1"
     shift
-    "$LOADER" "$@" >"/tmp/loader-form-${label}.out" 2>&1 || true
-    if grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." "/tmp/loader-form-${label}.out"; then
-      echo "expected loader invocation form ${label} to locate its exec target past the option" >&2
+    if ! "$LOADER" "$@" >"/tmp/loader-form-${label}.out" 2>&1; then
+      echo "expected loader invocation form ${label} to run its exec target" >&2
       cat "/tmp/loader-form-${label}.out" >&2
       exit 1
     fi
+  }
+  # The loader rejects some spellings the guard must still pass through. The
+  # loader's own text proves the guard let the form reach it.
+  loader_form_loader_rejects() {
+    local label="$1"
+    local pattern="$2"
+    shift 2
+    if "$LOADER" "$@" >"/tmp/loader-form-${label}.out" 2>&1; then
+      echo "expected the loader to reject invocation form ${label}" >&2
+      exit 1
+    fi
+    if grep -q "${loader_form_block_message}" "/tmp/loader-form-${label}.out"; then
+      echo "expected loader invocation form ${label} to reach the loader unrefused" >&2
+      cat "/tmp/loader-form-${label}.out" >&2
+      exit 1
+    fi
+    grep -q "${pattern}" "/tmp/loader-form-${label}.out"
   }
   # Control row: believe the matrix only after it observes a known refusal.
   loader_form_refused control "$EXEC_TMP/workcell-state-native"
@@ -3866,13 +3884,15 @@ EOF
   loader_form_refused end-of-options -- "$EXEC_TMP/workcell-state-native"
   loader_form_refused library-path-semicolons "--library-path=/usr/lib;/state/lib" /bin/true
   loader_form_refused preload-origin-expansion --preload '$ORIGIN/../evil.so' /bin/true
-  loader_form_not_refused argv0-separate-value --argv0 "$EXEC_TMP/workcell-state-native" /bin/true
-  loader_form_not_refused argv0-attached-value "--argv0=$EXEC_TMP/workcell-state-native" /bin/true
-  loader_form_not_refused inhibit-rpath-empty-value --inhibit-rpath= /bin/true
-  loader_form_not_refused hwcaps-mask-separate-value --glibc-hwcaps-mask "$EXEC_TMP/workcell-state-native" /bin/true
+  loader_form_reaches_target argv0-separate-value --argv0 "$EXEC_TMP/workcell-state-native" /bin/true
+  loader_form_reaches_target hwcaps-mask-separate-value --glibc-hwcaps-mask "$EXEC_TMP/workcell-state-native" /bin/true
+  loader_form_reaches_target valueless-option-then-target --inhibit-cache /bin/true
+  loader_form_loader_rejects argv0-attached-value "unrecognized option" "--argv0=$EXEC_TMP/workcell-state-native" /bin/true
+  loader_form_loader_rejects inhibit-rpath-empty-value "unrecognized option" --inhibit-rpath= /bin/true
   # The split-at-equals defect the Rust table records as pending: the truncated
-  # prefix is a mutable native payload, so only this lane can observe it.
-  loader_form_not_refused target-with-equals-sign "$EXEC_TMP/workcell-state-native=x"
+  # prefix is a mutable native payload, so only this lane can observe it. The
+  # loader reports the whole name, which proves it was not truncated either.
+  loader_form_loader_rejects target-with-equals-sign "workcell-state-native=x" "$EXEC_TMP/workcell-state-native=x"
   if WORKCELL_MODE=breakglass "$EXEC_TMP/workcell-state-native" >/tmp/state-native-workcell-mode-bypass.out 2>&1; then
     echo "expected strict profile to ignore caller-supplied WORKCELL_MODE for mutable native execution" >&2
     exit 1

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -4105,6 +4105,18 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-node-shebang.out
+  # The short options cluster into one token, so -iS reaches both -i, which
+  # drops the guard preload, and -S, which re-splits the rest of the line.
+  cat >"${workspace_exec_scratch}/.workcell-env-cluster-node-shebang" <<EOF
+#!/usr/bin/env -iS /usr/local/libexec/workcell/real/node
+console.log("workcell env cluster shebang bypass");
+EOF
+  chmod 0700 "${workspace_exec_scratch}/.workcell-env-cluster-node-shebang"
+  if "${workspace_exec_scratch}/.workcell-env-cluster-node-shebang" >/tmp/workspace-env-cluster-node-shebang.out 2>&1; then
+    echo "expected strict profile to reject env -iS shebang execution of the real Node payload" >&2
+    exit 1
+  fi
+  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-cluster-node-shebang.out
   cat >"${workspace_exec_scratch}/.workcell-env-loader-node-shebang" <<EOF
 #!/usr/bin/env -S ${LOADER} /usr/local/libexec/workcell/real/node
 console.log("workcell env loader shebang bypass");

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3831,6 +3831,48 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." /tmp/state-native-loader.out
+  # Loader invocation-form matrix, replayed against the real loader. The Rust
+  # table in runtime/container/rust/tests/loader_forms.rs states the same forms
+  # against the exported guard entry points; these rows put the /state native
+  # payload in the exec-target position, which only the runtime image has. The
+  # approved preload stays in the child environment here, so a refused row
+  # reports its own reason rather than the missing-preload default. An exit
+  # status is not the property under test: the loader answers a form it accepts
+  # in its own way, so an unrefused row is proved by the absence of the message.
+  loader_form_refused() {
+    local label="$1"
+    shift
+    if "$LOADER" "$@" >"/tmp/loader-form-${label}.out" 2>&1; then
+      echo "expected loader invocation form ${label} to be refused" >&2
+      exit 1
+    fi
+    grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." "/tmp/loader-form-${label}.out"
+  }
+  loader_form_not_refused() {
+    local label="$1"
+    shift
+    "$LOADER" "$@" >"/tmp/loader-form-${label}.out" 2>&1 || true
+    if grep -q "Workcell blocked direct native executable launch from mutable workspace/state paths on the strict profile." "/tmp/loader-form-${label}.out"; then
+      echo "expected loader invocation form ${label} to locate its exec target past the option" >&2
+      cat "/tmp/loader-form-${label}.out" >&2
+      exit 1
+    fi
+  }
+  # Control row: believe the matrix only after it observes a known refusal.
+  loader_form_refused control "$EXEC_TMP/workcell-state-native"
+  loader_form_refused unknown-arity-option --workcell-not-a-real-option "$EXEC_TMP/workcell-state-native"
+  loader_form_refused option-abbreviation --argv "$EXEC_TMP/workcell-state-native"
+  loader_form_refused valueless-then-target --inhibit-cache "$EXEC_TMP/workcell-state-native"
+  loader_form_refused end-of-options -- "$EXEC_TMP/workcell-state-native"
+  loader_form_refused library-path-semicolons "--library-path=/usr/lib;/state/lib" /bin/true
+  loader_form_refused preload-origin-expansion --preload '$ORIGIN/../evil.so' /bin/true
+  loader_form_not_refused argv0-separate-value --argv0 "$EXEC_TMP/workcell-state-native" /bin/true
+  loader_form_not_refused argv0-attached-value "--argv0=$EXEC_TMP/workcell-state-native" /bin/true
+  loader_form_not_refused inhibit-rpath-empty-value --inhibit-rpath= /bin/true
+  loader_form_not_refused hwcaps-mask-separate-value --glibc-hwcaps-mask "$EXEC_TMP/workcell-state-native" /bin/true
+  # The split-at-equals defect the Rust table records as pending: the truncated
+  # prefix is a mutable native payload, so only this lane can observe it.
+  loader_form_not_refused target-with-equals-sign "$EXEC_TMP/workcell-state-native=x"
   if WORKCELL_MODE=breakglass "$EXEC_TMP/workcell-state-native" >/tmp/state-native-workcell-mode-bypass.out 2>&1; then
     echo "expected strict profile to ignore caller-supplied WORKCELL_MODE for mutable native execution" >&2
     exit 1


### PR DESCRIPTION
## Summary

The exec guard refuses a dynamic-loader invocation that reaches a mutable
native payload. Review found the same defect shape many times: the argument
walk missed one syntactic form of an invocation it already judged in another
form. Each fix proved one form. Nothing held the set of forms together.

This change adds `runtime/container/rust/tests/loader_forms.rs`, a table with
one row for each invocation form. A row names the form and the classification
the guard must reach. The driver calls the guard through its exported entry
points, captures the message the guard writes to file descriptor 2, and
compares that message with the row.

A row that must not refuse puts an option of unknown arity where the option
value belongs. A walk that reads that value as the exec target reaches an
option it does not know and refuses. The absence of a refusal is therefore the
proof that the walk consumed the value.

The table covers these forms:

- `--argv0 X`, `--argv0=X`, `--inhibit-rpath=`, `--inhibit-rpath X`,
  `--glibc-hwcaps-mask X`.
- An option of unknown arity, an option abbreviation, valueless options, and
  `--`.
- `--library-path` and `--audit` with colon and semicolon separators, and
  `--preload` with an `$ORIGIN` value.
- `LD_LIBRARY_PATH` with colon and semicolon separators.
- `LD_PRELOAD` with a space, a colon, and a newline beside the approved guard.
- `execveat` resolution against a directory descriptor.
- A non-ELF regular file target, the ENOEXEC fallback target through the
  `execvp` search, and a directory target as their control.
- A null environ, a relative `PATH` entry, a `.` entry, an overlong `PATH`
  component, and an empty name.

Three rows carry a pending marker with a reason instead of a green assertion:

- The split-at-equals form needs a mutable exec root. Only the runtime image
  has one. The container smoke row `target-with-equals-sign` holds it.
- The `env(1)` short-option cluster needs the protected runtime stat
  signatures. Only the runtime image has them. The container smoke fixture
  `.workcell-env-cluster-node-shebang` holds it.
- A raw-syscall row observes nothing, and no lane holds it. The built shared
  object exports `workcell_syscall_shim` and does not export `syscall`, so
  nothing interposes a raw `syscall(SYS_execve, ...)`. That gap is pre-existing
  on `main` and is recorded for the trampoline unit of the series.

`scripts/container-smoke.sh` replays the loader argument forms against the real
loader inside the runtime image. Those rows put the `/state` native payload in
the exec-target position for a refused row, and in an option-value position for
a row that must not refuse. Every row states its own result: a refused row wants
the block message, a row the loader accepts wants status 0 from `/bin/true`, and
a row the loader itself rejects wants the loader's own text and no block
message. The smoke lane also gets a live `#!/usr/bin/env -iS` shebang fixture,
which holds the short-option cluster form.

Both lanes start with a control row. The Rust matrix asserts a known refusal
before it believes any other row. The smoke lane runs the same control. An
earlier harness in this series reported a false pass because nothing was
interposed, and only a control row exposed it.

This change adds a test file and smoke rows. It does not change
`runtime/container/rust/src/lib.rs`.

### Findings this counters

The matrix is the deterministic counter for the loader and exec bypass class,
which was 24 findings in the reviewed corpus and 100 percent accepted. It also
holds the mutation-gap class for this guard: each row states a behaviour that a
mutant of the guard breaks. The pending markers keep the split-at-equals form,
the `env(1)` cluster form, and the raw-syscall form out of a false green.

## Testing

- `cargo fmt --all --check` on the host and in `rust:1.97.1-slim-trixie`.
- `cargo clippy --all-targets --locked --offline -- -D warnings` on the host
  and in `rust:1.97.1-slim-trixie`.
- `cargo test --locked --offline` on the host and in
  `rust:1.97.1-slim-trixie`. The Linux-only rows run in the image. The host
  reports them as skipped.
- `go build ./...`.
- `./scripts/dev-quick-check.sh`.
- `shellcheck -x scripts/container-smoke.sh` and `bash -n
  scripts/container-smoke.sh`.
- All required GitHub checks pass on `27e1c6aa`, including Container smoke
  and Validate repository. Container smoke ran the new loader form rows and the
  new `env -iS` shebang fixture against the real runtime image.
- A probe of the real loader in the pinned image supplied the expected result
  for each smoke row. `--argv0 X`, `--glibc-hwcaps-mask X` and
  `--inhibit-cache` return 0. `--argv0=X` and `--inhibit-rpath=` return 1 with
  `unrecognized option`. A target with an equals sign returns 127 and names the
  whole path.
- Mutation evidence. Five mutants of `src/lib.rs`, each killed by a named row:
  1. The unknown-arity arm returns nothing. The control row fails.
  2. A value-taking option does not consume a separate value. The
     `--argv0 separate value` row fails.
  3. `LD_PRELOAD` is compared by prefix instead of equality. The
     `LD_PRELOAD space separator` row fails.
  4. Every target counts as loader interpreted. The `a directory target` row
     fails.
  5. The loader-environment check is deleted from `guarded_execvp`. The
     `ENOEXEC fallback target found through the execvp search` row fails.

  The tree passes again after each mutant is reverted.
