### PR TITLE
^f Add a shared validator evasion corpus and a registry parity check (S4b+c, stacked on #688)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -107,6 +107,7 @@ func subcommands() []subcommand {
 		{"generate-builder-environment-manifest", "OUTPUT BUILDKIT_IMAGE BUILDX_VERSION_TARGET COSIGN_VERSION_TARGET QEMU_IMAGE SYFT_VERSION_TARGET BUILDX_VERSION BUILDX_INSPECT DOCKER_VERSION_JSON QEMU_VERSION COSIGN_VERSION CURL_VERSION GIT_VERSION GZIP_VERSION SYFT_VERSION TAR_VERSION", 16, 16, cmdGenerateBuilderEnvironmentManifest},
 		{"create-release-image-handoff", "ARCHIVE OUTPUT REPOSITORY RUN_ID TAG COMMIT PLATFORM IMAGE_DIGEST MANIFEST_DIGEST CONFIG_DIGEST", 10, 10, cmdCreateReleaseImageHandoff},
 		{"check-pinned-inputs", "REPO_ROOT MAX_DEBIAN_SNAPSHOT_AGE_DAYS", 2, 2, cmdCheckPinnedInputs},
+		{"check-validator-anchoring", "REPO_ROOT", 1, 1, cmdCheckValidatorAnchoring},
 		{"verify-reproducible-build", "OCI_EXPORT_A OCI_EXPORT_B REPRO_PLATFORMS REPRO_MANIFEST_PATH SOURCE_DATE_EPOCH", 5, 5, cmdVerifyReproducibleBuild},
 		{"generate-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS OUTPUT_PATH SOURCE_DATE_EPOCH", 4, 4, cmdGenerateReproducibleBuildManifest},
 		{"verify-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS MANIFEST_PATH", 3, 3, cmdVerifyReproducibleBuildManifest},
@@ -526,6 +527,10 @@ func cmdGenerateBuilderEnvironmentManifest(args []string) error {
 		args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
 		args[8], args[9], args[10], args[11], args[12], args[13], args[14], args[15],
 	)
+}
+
+func cmdCheckValidatorAnchoring(args []string) error {
+	return metadatautil.CheckValidatorAnchoring(args[0])
 }
 
 func cmdCheckPinnedInputs(args []string) error {

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -150,14 +150,24 @@ func flatten(anchor string) string {
 }
 
 // extendFirstOption lengthens the first long option of the anchored command,
-// the bypass that turns --oci-layout into --oci-layout-disabled.
+// the bypass that turns --oci-layout into --oci-layout-disabled. Most anchored
+// commands carry no long option, so the command word itself is lengthened
+// instead: either spelling keeps the anchored text in the file while bash runs
+// something else. Without the second spelling the row rewrites nothing and the
+// driver stops, which keeps the corpus off every such validator.
 func extendFirstOption(anchor string) string {
-	for _, word := range strings.Fields(anchor) {
+	words := strings.Fields(anchor)
+	if len(words) == 0 {
+		return anchor
+	}
+	target := words[0]
+	for _, word := range words {
 		if strings.HasPrefix(word, "--") {
-			return strings.Replace(anchor, word, word+"-disabled", 1)
+			target = word
+			break
 		}
 	}
-	return anchor
+	return strings.Replace(anchor, target, target+"-disabled", 1)
 }
 
 // indentOf returns the leading whitespace of the first line of text.

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -66,6 +66,14 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+"never_called() {", i+"}")
 	})},
+	{"unreachable branch", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"if false; then", i+"fi")
+	})},
+	{"escaped closer in a quoted span", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+`: "`+"\n"+i+`\"`, i+`"`)
+	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {
 		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -87,6 +87,9 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+`: "`+"\n"+i+"x\n"+i+`" <<PLAN`, i+"PLAN")
 	})},
+	{"exec before the command", replaceAnchor(func(a string) string {
+		return indentOf(a) + "exec true\n" + a
+	})},
 	{"noclobber redirection", replaceAnchor(func(a string) string {
 		return indentOf(a) + ": >| " + flatten(a)
 	})},

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -87,6 +87,9 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+`: "`+"\n"+i+"x\n"+i+`" <<PLAN`, i+"PLAN")
 	})},
+	{"noclobber redirection", replaceAnchor(func(a string) string {
+		return indentOf(a) + ": >| " + flatten(a)
+	})},
 	{"quoted span closing into arguments", replaceAnchor(func(a string) string {
 		i := indentOf(a)
 		return i + `: "` + "\n" + i + "x\n" + i + `" ` + flatten(a)

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -87,6 +87,10 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+`: "`+"\n"+i+"x\n"+i+`" <<PLAN`, i+"PLAN")
 	})},
+	{"quoted span closing into arguments", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return i + `: "` + "\n" + i + "x\n" + i + `" ` + flatten(a)
+	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {
 		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -8,24 +8,20 @@ import (
 	"testing"
 )
 
-// Evasion rewrites one artifact so that the anchored command it must contain
-// is no longer run, while text that names the command stays in the file. Every
-// row is a bypass a reviewer found against a validator that read the artifact
-// as text instead of as shell words.
-//
-// Rewrite takes the whole artifact and the exact text of the anchored command,
+// Evasion rewrites one artifact so that the anchored command it must contain is
+// no longer run, while text that names the command stays in the file. Every row
+// is a bypass a reviewer found against a validator that read the artifact as
+// text. Rewrite takes the whole artifact and the anchored command's exact text,
 // so a row can move the command as well as disguise it.
 type Evasion struct {
 	Name    string
 	Rewrite func(artifact, anchor string) string
 }
 
-// Evasions is the shared negative corpus. A validator that reads file content
-// to decide that a command runs must reject every row.
-//
-// The corpus lives in the test package so that the parser it exercises stays
-// out of the shipped tool's dependency graph. Move it to a non-test file when
-// a validator outside this package needs it.
+// Evasions is the shared negative corpus. A validator that reads file content to
+// decide that a command runs must reject every row. It lives in the test package
+// to keep testing out of the shipped tool's dependency graph; move it to a
+// non-test file when a validator outside this package needs it.
 var Evasions = []Evasion{
 	{"full-line comment", replaceAnchor(func(a string) string {
 		return commentOut(a)
@@ -80,6 +76,9 @@ var Evasions = []Evasion{
 	{"conditional across a line break", replaceAnchor(func(a string) string {
 		return prefixCommands(a, "false &&\n"+indentOf(a))
 	})},
+	{"exit before the command", replaceAnchor(func(a string) string {
+		return indentOf(a) + "exit 0\n" + a
+	})},
 	{"definition brace on the next line", replaceAnchor(func(a string) string {
 		i := indentOf(a)
 		return hide(a, i+"never_called ()\n"+i+"{", i+"}")
@@ -96,9 +95,8 @@ var Evasions = []Evasion{
 }
 
 // RequireRejectsAllEvasions applies every row of the corpus to artifact and
-// requires validate to reject the result, naming want in its error. want keeps
-// a row honest: a rewrite that merely broke the file's syntax would otherwise
-// pass for the wrong reason.
+// requires validate to reject the result, naming want in its error. want keeps a
+// row honest: a rewrite that only broke the syntax would otherwise pass.
 func RequireRejectsAllEvasions(t *testing.T, artifact, anchor, want string, validate func(string) error) {
 	t.Helper()
 

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -54,6 +54,14 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+": <<'PLAN' \\\n"+i+"  >/dev/null", i+"PLAN")
 	})},
+	{"quoted line span", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+`: "`, i+`"`)
+	})},
+	{"indented heredoc terminator", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+": <<'PLAN'\n"+i+"  PLAN", i+"PLAN")
+	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {
 		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -77,6 +77,9 @@ var Evasions = []Evasion{
 	{"conditional right-hand side", replaceAnchor(func(a string) string {
 		return prefixCommands(a, "false && ")
 	})},
+	{"conditional across a line break", replaceAnchor(func(a string) string {
+		return prefixCommands(a, "false &&\n"+indentOf(a))
+	})},
 	{"definition brace on the next line", replaceAnchor(func(a string) string {
 		i := indentOf(a)
 		return hide(a, i+"never_called ()\n"+i+"{", i+"}")

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -62,6 +62,10 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+": <<'PLAN'\n"+i+"  PLAN", i+"PLAN")
 	})},
+	{"uncalled function definition", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"never_called() {", i+"}")
+	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {
 		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// Evasion rewrites one artifact so that the anchored command it must contain
+// is no longer run, while text that names the command stays in the file. Every
+// row is a bypass a reviewer found against a validator that read the artifact
+// as text instead of as shell words.
+//
+// Rewrite takes the whole artifact and the exact text of the anchored command,
+// so a row can move the command as well as disguise it.
+type Evasion struct {
+	Name    string
+	Rewrite func(artifact, anchor string) string
+}
+
+// Evasions is the shared negative corpus. A validator that reads file content
+// to decide that a command runs must reject every row.
+//
+// The corpus lives in the test package so that the parser it exercises stays
+// out of the shipped tool's dependency graph. Move it to a non-test file when
+// a validator outside this package needs it.
+var Evasions = []Evasion{
+	{"full-line comment", replaceAnchor(func(a string) string {
+		return commentOut(a)
+	})},
+	{"inline comment after || true", replaceAnchor(func(a string) string {
+		return indentOf(a) + "true || true # " + flatten(a)
+	})},
+	{"echo-quoted", replaceAnchor(func(a string) string {
+		return indentOf(a) + `echo "` + strings.ReplaceAll(flatten(a), `"`, "") + `"`
+	})},
+	{"single heredoc", replaceAnchor(func(a string) string {
+		return hide(a, indentOf(a)+": <<'PLAN' >/dev/null", indentOf(a)+"PLAN")
+	})},
+	{"multi heredoc <<A <<B", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+": <<'A' <<'B' >/dev/null\n"+i+"A", i+"B")
+	})},
+	{"arithmetic shift", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+": $((1 << 2))\n"+i+": <<'PLAN' >/dev/null", i+"PLAN")
+	})},
+	{"here-string", replaceAnchor(func(a string) string {
+		return indentOf(a) + ": <<<'" + flatten(a) + "'"
+	})},
+	{"line continuation", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+": <<'PLAN' \\\n"+i+"  >/dev/null", i+"PLAN")
+	})},
+	{"prefix extension", replaceAnchor(extendFirstOption)},
+	{"unrelated placement", func(artifact, anchor string) string {
+		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)
+		return strings.TrimRight(moved, "\n") + "\nx-decoy: |\n" + anchor + "\n"
+	}},
+}
+
+// RequireRejectsAllEvasions applies every row of the corpus to artifact and
+// requires validate to reject the result, naming want in its error. want keeps
+// a row honest: a rewrite that merely broke the file's syntax would otherwise
+// pass for the wrong reason.
+func RequireRejectsAllEvasions(t *testing.T, artifact, anchor, want string, validate func(string) error) {
+	t.Helper()
+
+	if !strings.Contains(artifact, anchor) {
+		t.Fatalf("anchor %q is absent from the artifact", anchor)
+	}
+	for _, evasion := range Evasions {
+		t.Run(evasion.Name, func(t *testing.T) {
+			mutated := evasion.Rewrite(artifact, anchor)
+			if mutated == artifact {
+				t.Fatalf("evasion %q left the artifact unchanged", evasion.Name)
+			}
+			err := validate(mutated)
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("validate() error = %v, want %q", err, want)
+			}
+		})
+	}
+}
+
+// replaceAnchor lifts a rewrite of the anchored command alone into a rewrite
+// of the artifact that holds it.
+func replaceAnchor(rewrite func(anchor string) string) func(artifact, anchor string) string {
+	return func(artifact, anchor string) string {
+		return strings.Replace(artifact, anchor, rewrite(anchor), 1)
+	}
+}
+
+// hide wraps the anchored command in a body that the shell reads as text.
+func hide(anchor, open, end string) string {
+	return open + "\n" + anchor + "\n" + end
+}
+
+// commentOut comments every line of the anchored command, keeping the
+// indentation that makes the result valid YAML.
+func commentOut(anchor string) string {
+	lines := strings.Split(anchor, "\n")
+	for index, line := range lines {
+		lines[index] = indentOf(line) + "# " + strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// flatten joins the anchored command into one line of text.
+func flatten(anchor string) string {
+	var words []string
+	for _, line := range strings.Split(anchor, "\n") {
+		words = append(words, strings.Fields(strings.TrimSuffix(strings.TrimSpace(line), "\\"))...)
+	}
+	return strings.Join(words, " ")
+}
+
+// extendFirstOption lengthens the first long option of the anchored command,
+// the bypass that turns --oci-layout into --oci-layout-disabled.
+func extendFirstOption(anchor string) string {
+	for _, word := range strings.Fields(anchor) {
+		if strings.HasPrefix(word, "--") {
+			return strings.Replace(anchor, word, word+"-disabled", 1)
+		}
+	}
+	return anchor
+}
+
+// indentOf returns the leading whitespace of the first line of text.
+func indentOf(text string) string {
+	first, _, _ := strings.Cut(text, "\n")
+	return first[:len(first)-len(strings.TrimLeft(first, " \t"))]
+}

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -74,6 +74,17 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+`: "`+"\n"+i+`\"`, i+`"`)
 	})},
+	{"conditional right-hand side", replaceAnchor(func(a string) string {
+		return prefixCommands(a, "false && ")
+	})},
+	{"definition brace on the next line", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"never_called ()\n"+i+"{", i+"}")
+	})},
+	{"heredoc opened as a quote closes", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+`: "`+"\n"+i+"x\n"+i+`" <<PLAN`, i+"PLAN")
+	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {
 		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)
@@ -152,4 +163,18 @@ func extendFirstOption(anchor string) string {
 func indentOf(text string) string {
 	first, _, _ := strings.Cut(text, "\n")
 	return first[:len(first)-len(strings.TrimLeft(first, " \t"))]
+}
+
+// prefixCommands puts text in front of every line of the anchored command that
+// starts one, leaving the continuation lines alone.
+func prefixCommands(anchor, text string) string {
+	lines := strings.Split(anchor, "\n")
+	continues := false
+	for index, line := range lines {
+		if !continues {
+			lines[index] = indentOf(line) + text + strings.TrimLeft(line, " \t")
+		}
+		continues = strings.HasSuffix(strings.TrimSpace(line), "\\")
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -14,7 +14,10 @@ import (
 // third alternative captures, and it captures the delimiter it opens.
 var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
 
-var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
+// inlineComment consumes quoted words before it reads a comment, so that a #
+// inside an argument such as 'note: # here' cannot truncate the line. As in
+// bash, only an unquoted # at the start of a word opens a comment.
+var inlineComment = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|(?:^|\s)#.*$`)
 
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
@@ -40,7 +43,7 @@ func ShellInvocations(script, command string) [][]string {
 		if strings.HasSuffix(trimmed, "\\") {
 			continue
 		}
-		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
+		logical := strings.TrimSpace(stripComment(current.String()))
 		current.Reset()
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
@@ -57,4 +60,15 @@ func ShellInvocations(script, command string) [][]string {
 		}
 	}
 	return invocations
+}
+
+// stripComment removes an unquoted comment from one logical line. The pattern
+// keeps the quoted words it consumed and deletes only the comment.
+func stripComment(logical string) string {
+	return inlineComment.ReplaceAllStringFunc(logical, func(match string) string {
+		if strings.HasPrefix(match, "'") || strings.HasPrefix(match, `"`) {
+			return match
+		}
+		return ""
+	})
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -24,22 +24,6 @@ func (h heredoc) endsAt(line string) bool {
 	return line == h.delimiter
 }
 
-// definesFunction reports whether the words open a function definition, in
-// either the name() or the function name spelling.
-func definesFunction(words []string) bool {
-	if len(words) == 0 {
-		return false
-	}
-	if words[0] == "function" {
-		return true
-	}
-	name, _, found := strings.Cut(words[0], "(")
-	if found && name != "" && strings.HasPrefix(words[0][len(name):], "()") {
-		return true
-	}
-	return len(words) > 1 && words[1] == "()"
-}
-
 // braceDepth returns the change in brace nesting the words make. Only a brace
 // that stands as its own word or ends one groups commands; a brace inside a
 // word belongs to an expansion such as ${VAR}.
@@ -75,36 +59,69 @@ func isOperator(word string) bool {
 	return false
 }
 
+// command is one command of a logical line, and whether an earlier command on
+// that line decides if it runs. Bash runs the right side of && or || only on
+// the exit status of the left, so a command written there is not proved to run.
+type command struct {
+	args        []string
+	conditional bool
+}
+
 // splitCommands cuts one logical line into the separate commands bash runs,
 // at every control operator. Without this, a decoy after ; or || donates its
 // words to the invocation before it, as in
 // oras cp --from-oci-layout missing || true; : --to-oci-layout <target>.
-func splitCommands(words []string) [][]string {
-	commands := make([][]string, 1)
+func splitCommands(words []string) []command {
+	commands := make([]command, 1)
 	for _, word := range words {
 		if isOperator(word) {
-			commands = append(commands, nil)
+			commands = append(commands, command{conditional: word == "&&" || word == "||"})
 			continue
 		}
-		commands[len(commands)-1] = append(commands[len(commands)-1], word)
+		last := &commands[len(commands)-1]
+		last.args = append(last.args, word)
 	}
 	return commands
 }
 
-// closesQuote reports whether the line closes an open quote. A backslash
-// escapes the next byte inside a double-quoted span, so an escaped quote is a
-// literal character and not the closer. A single-quoted span has no escapes.
-func closesQuote(line string, quote byte) bool {
+// definedName returns the name a function definition binds, in either the
+// name() or the function name spelling, or the empty string when the words do
+// not define one.
+func definedName(words []string) string {
+	if len(words) == 0 {
+		return ""
+	}
+	if words[0] == "function" {
+		if len(words) < 2 {
+			return ""
+		}
+		return strings.TrimSuffix(words[1], "()")
+	}
+	if name, _, found := strings.Cut(words[0], "("); found && name != "" &&
+		strings.HasPrefix(words[0][len(name):], "()") {
+		return name
+	}
+	if len(words) > 1 && words[1] == "()" {
+		return words[0]
+	}
+	return ""
+}
+
+// quoteCloseIndex returns the index of the byte that closes an open quote, or
+// -1 when the line does not close it. A backslash escapes the next byte inside
+// a double-quoted span, so an escaped quote is a literal character and not the
+// closer. A single-quoted span has no escapes.
+func quoteCloseIndex(line string, quote byte) int {
 	for index := 0; index < len(line); index++ {
 		if quote == '"' && line[index] == '\\' {
 			index++
 			continue
 		}
 		if line[index] == quote {
-			return true
+			return index
 		}
 	}
-	return false
+	return -1
 }
 
 // ShellInvocations returns the arguments of each invocation of command in
@@ -115,25 +132,32 @@ func closesQuote(line string, quote byte) bool {
 // text counts as a command and one call cannot satisfy a two-call rule. A
 // validator that must anchor on the commands a script really runs uses this in
 // place of a substring search.
-func ShellInvocations(script, command string) [][]string {
-	prefix := strings.Fields(command)
+func ShellInvocations(script, commandName string) [][]string {
+	prefix := strings.Fields(commandName)
+	if len(prefix) == 0 {
+		return nil
+	}
 	var invocations [][]string
 	var current strings.Builder
 	var heredocs []heredoc
 	var openQuote byte
 	var quotes []byte
 	var depth, definedAt, control int
-	var defining bool
+	var defining, bodyOpened bool
 	for line := range strings.Lines(script) {
 		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
 		if openQuote != 0 {
 			// Bash reads these lines as text inside one word, as in
 			// : "<newline>oras cp …<newline>", which runs no command. Read
-			// them as text too, up to the line that closes the quote.
-			if closesQuote(text, openQuote) {
-				openQuote = 0
+			// them as text too, up to the byte that closes the quote. What
+			// follows on that same line is syntax again, so read it: a closer
+			// such as " <<PLAN still opens a heredoc.
+			at := quoteCloseIndex(text, openQuote)
+			if at < 0 {
+				continue
 			}
-			continue
+			openQuote = 0
+			text = text[at+1:]
 		}
 		if len(heredocs) > 0 {
 			if heredocs[0].endsAt(text) {
@@ -154,19 +178,34 @@ func ShellInvocations(script, command string) [][]string {
 		// A function definition is not a call. Bash reads the body and runs
 		// nothing, so a required command written inside a function that
 		// nobody calls does not satisfy a rule about what the step runs.
-		if !defining && definesFunction(words) {
-			defining, definedAt = true, depth
+		if !defining {
+			if name := definedName(words); name != "" {
+				if name == prefix[0] {
+					// The step redefines the anchored command itself, so every
+					// later call runs the definition rather than the program.
+					// Nothing in this script proves the command ran.
+					return nil
+				}
+				defining, definedAt, bodyOpened = true, depth, false
+			}
 		}
 		depth += braceDepth(words)
 		if defining {
-			if depth <= definedAt {
+			// A body may open on a later line, as in never_called ()
+			// followed by { on its own line, so wait for it before looking
+			// for its end.
+			if depth > definedAt {
+				bodyOpened = true
+			}
+			if bodyOpened && depth <= definedAt {
 				defining = false
 			}
 			continue
 		}
 		commands := splitCommands(words)
 		nested := control > 0
-		for _, args := range commands {
+		for _, each := range commands {
+			args := each.args
 			if len(args) == 0 {
 				continue
 			}
@@ -175,7 +214,7 @@ func ShellInvocations(script, command string) [][]string {
 				nested = true
 				continue
 			}
-			if nested || control > 0 {
+			if nested || control > 0 || each.conditional {
 				continue
 			}
 			if len(args) >= len(prefix) && slices.Equal(args[:len(prefix)], prefix) {

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -377,9 +377,12 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 			// ready, where bash reads the delimiter EOF and runs the echo.
 			flush()
 		case strings.IndexByte(";&|", character) >= 0 &&
-			!(character == '&' && index > 0 && strings.IndexByte("<>", line[index-1]) >= 0):
-			// An operator ends the command before it. The guard keeps the & of
-			// a redirection such as 2>&1 as part of that word.
+			!(strings.IndexByte("&|", character) >= 0 && index > 0 &&
+				strings.IndexByte("<>", line[index-1]) >= 0):
+			// An operator ends the command before it. The guard keeps a
+			// redirection whole where its second byte would otherwise read as
+			// an operator: the & of 2>&1, and the | of the noclobber override
+			// >|, which redirects rather than starting a pipeline.
 			flush()
 			operator := string(character)
 			if index+1 < len(line) && line[index+1] == character {

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -24,11 +24,43 @@ func (h heredoc) endsAt(line string) bool {
 	return line == h.delimiter
 }
 
+// definesFunction reports whether the words open a function definition, in
+// either the name() or the function name spelling.
+func definesFunction(words []string) bool {
+	if len(words) == 0 {
+		return false
+	}
+	if words[0] == "function" {
+		return true
+	}
+	name, _, found := strings.Cut(words[0], "(")
+	if found && name != "" && strings.HasPrefix(words[0][len(name):], "()") {
+		return true
+	}
+	return len(words) > 1 && words[1] == "()"
+}
+
+// braceDepth returns the change in brace nesting the words make. Only a brace
+// that stands as its own word or ends one groups commands; a brace inside a
+// word belongs to an expansion such as ${VAR}.
+func braceDepth(words []string) int {
+	change := 0
+	for _, word := range words {
+		switch {
+		case word == "{" || strings.HasSuffix(word, "(){"):
+			change++
+		case word == "}" || word == "};":
+			change--
+		}
+	}
+	return change
+}
+
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
-// included, heredoc bodies, and the rest of a quoted word that runs past the
-// end of its line, so that no decoy text counts as a command and one call
-// cannot satisfy a two-call rule. A validator that must anchor on the commands
+// included, heredoc bodies, the body of a function definition, and the rest of
+// a quoted word that runs past the end of its line, so that no decoy text
+// counts as a command and one call cannot satisfy a two-call rule. A validator that must anchor on the commands
 // a script really runs uses this in place of a substring search.
 func ShellInvocations(script, command string) [][]string {
 	prefix := strings.Fields(command)
@@ -37,6 +69,8 @@ func ShellInvocations(script, command string) [][]string {
 	var heredocs []heredoc
 	var openQuote byte
 	var quotes []byte
+	var depth, definedAt int
+	var defining bool
 	for line := range strings.Lines(script) {
 		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
 		if openQuote != 0 {
@@ -64,6 +98,19 @@ func ShellInvocations(script, command string) [][]string {
 		current.Reset()
 		openQuote, quotes = quote, rest
 		heredocs = append(heredocs, opened...)
+		// A function definition is not a call. Bash reads the body and runs
+		// nothing, so a required command written inside a function that
+		// nobody calls does not satisfy a rule about what the step runs.
+		if !defining && definesFunction(words) {
+			defining, definedAt = true, depth
+		}
+		depth += braceDepth(words)
+		if defining {
+			if depth <= definedAt {
+				defining = false
+			}
+			continue
+		}
 		if len(words) >= len(prefix) && slices.Equal(words[:len(prefix)], prefix) {
 			invocations = append(invocations, words[len(prefix):])
 		}

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -8,31 +8,61 @@ import (
 	"strings"
 )
 
+// heredoc is one body the shell has still to read: the delimiter word that
+// ends it, and whether the <<- form lets the terminator line carry leading
+// tabs. Bash ends a <<WORD body only at a line that is the delimiter alone, so
+// an indented copy of the word inside the body is text.
+type heredoc struct {
+	delimiter string
+	stripTabs bool
+}
+
+func (h heredoc) endsAt(line string) bool {
+	if h.stripTabs {
+		return strings.TrimLeft(line, "\t") == h.delimiter
+	}
+	return line == h.delimiter
+}
+
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
-// included, and heredoc bodies, so that no decoy text counts as a command and
-// one call cannot satisfy a two-call rule. A validator that must anchor on the
-// commands a script really runs uses this in place of a substring search.
+// included, heredoc bodies, and the rest of a quoted word that runs past the
+// end of its line, so that no decoy text counts as a command and one call
+// cannot satisfy a two-call rule. A validator that must anchor on the commands
+// a script really runs uses this in place of a substring search.
 func ShellInvocations(script, command string) [][]string {
 	prefix := strings.Fields(command)
 	var invocations [][]string
 	var current strings.Builder
-	var heredocs []string
+	var heredocs []heredoc
+	var openQuote byte
+	var quotes []byte
 	for line := range strings.Lines(script) {
-		trimmed := strings.TrimSpace(line)
+		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if openQuote != 0 {
+			// Bash reads these lines as text inside one word, as in
+			// : "<newline>oras cp …<newline>", which runs no command. Read
+			// them as text too, up to the line that closes the quote.
+			if strings.IndexByte(text, openQuote) >= 0 {
+				openQuote = 0
+			}
+			continue
+		}
 		if len(heredocs) > 0 {
-			if trimmed == heredocs[0] {
+			if heredocs[0].endsAt(text) {
 				heredocs = heredocs[1:]
 			}
 			continue
 		}
+		trimmed := strings.TrimSpace(text)
 		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
 		if strings.HasSuffix(trimmed, "\\") {
 			current.WriteString(" ")
 			continue
 		}
-		words, opened := shellWords(current.String())
+		words, opened, quote, rest := shellWords(current.String(), quotes)
 		current.Reset()
+		openQuote, quotes = quote, rest
 		heredocs = append(heredocs, opened...)
 		if len(words) >= len(prefix) && slices.Equal(words[:len(prefix)], prefix) {
 			invocations = append(invocations, words[len(prefix):])
@@ -44,22 +74,26 @@ func ShellInvocations(script, command string) [][]string {
 // shellWords splits one logical line the way bash reads it. Quotes and
 // backslash escapes are removed, so a quoted argument stays one word and a
 // separator inside it is text rather than syntax; an unquoted # that starts a
-// word ends the line; and every heredoc the line opens returns as a delimiter,
-// in the order bash reads the bodies.
+// word ends the line; every heredoc the line opens returns as a delimiter, in
+// the order bash reads the bodies; open is the quote character still waiting to
+// be closed, which tells the caller that the word runs on into the next line;
+// and rest is the quote each unclosed command substitution suspended, which the
+// caller gives back on the next line so that the ) which closes the
+// substitution also restores the quote around it.
 //
-// One pass keeps the three answers consistent. A pattern per answer cannot:
+// One pass keeps the four answers consistent. A pattern per answer cannot:
 // each has to rediscover the quoting, and the one that gets it wrong reads
 // syntax where the shell reads text.
-func shellWords(line string) (words, heredocs []string) {
+func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, open byte, rest []byte) {
 	var word strings.Builder
-	inWord, quote, pending := false, byte(0), false
+	inWord, quote, pending, stripTabs := false, byte(0), false, false
 	flush := func() {
 		if !inWord {
 			return
 		}
 		if pending {
-			heredocs = append(heredocs, word.String())
-			pending = false
+			heredocs = append(heredocs, heredoc{word.String(), stripTabs})
+			pending, stripTabs = false, false
 		} else {
 			words = append(words, word.String())
 		}
@@ -88,10 +122,10 @@ func shellWords(line string) (words, heredocs []string) {
 				quote = 0
 			case character == '`' || (character == '$' && index+1 < len(line) && line[index+1] == '('):
 				// A command substitution resumes shell syntax inside the
-				// quotes. Where it closes is beyond a line reader, so syntax
-				// is read to the end of the line. That reads more heredocs and
-				// comments than bash, never fewer, so it can only drop an
-				// invocation, never invent one.
+				// quotes. Suspend the quote rather than forget it, so that the
+				// ) which closes the substitution restores it, even when that )
+				// is on a later line.
+				stack = append(stack, quote)
 				quote = 0
 				word.WriteByte(character)
 			default:
@@ -109,7 +143,7 @@ func shellWords(line string) (words, heredocs []string) {
 		case character == ' ' || character == '\t':
 			flush()
 		case character == '#' && !inWord:
-			return words, heredocs
+			return words, heredocs, 0, stack
 		case character == '<' && index+1 < len(line) && line[index+1] == '<':
 			flush()
 			index++
@@ -120,17 +154,28 @@ func shellWords(line string) (words, heredocs []string) {
 			}
 			if index+1 < len(line) && line[index+1] == '-' {
 				index++
+				stripTabs = true
 			}
 			pending = true
 		case pending && strings.IndexByte(";&|<>()", character) >= 0:
 			// A delimiter word ends at an operator, as in cat <<EOF; echo
 			// ready, where bash reads the delimiter EOF and runs the echo.
 			flush()
+		case character == ')' && len(stack) > 0:
+			quote = stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			word.WriteByte(character)
+			inWord = true
 		default:
 			word.WriteByte(character)
 			inWord = true
 		}
 	}
 	flush()
-	return words, heredocs
+	if len(stack) > 0 {
+		// A substitution is still open, so the logical line has not ended and
+		// the quote around it is not the caller's to skip.
+		return words, heredocs, 0, stack
+	}
+	return words, heredocs, quote, stack
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -56,12 +56,65 @@ func braceDepth(words []string) int {
 	return change
 }
 
+// controlWords maps each word that opens or closes a compound command to the
+// change it makes to nesting. A command inside one of these is not proved to
+// run: bash never runs the body of if false, so a required command written
+// there does not satisfy a rule about what the step runs.
+var controlWords = map[string]int{
+	"if": 1, "while": 1, "until": 1, "for": 1, "case": 1, "select": 1,
+	"fi": -1, "done": -1, "esac": -1,
+}
+
+// isOperator reports whether the word is a control operator that ends one
+// command and starts the next.
+func isOperator(word string) bool {
+	switch word {
+	case ";", ";;", "&&", "||", "|", "|&", "&":
+		return true
+	}
+	return false
+}
+
+// splitCommands cuts one logical line into the separate commands bash runs,
+// at every control operator. Without this, a decoy after ; or || donates its
+// words to the invocation before it, as in
+// oras cp --from-oci-layout missing || true; : --to-oci-layout <target>.
+func splitCommands(words []string) [][]string {
+	commands := make([][]string, 1)
+	for _, word := range words {
+		if isOperator(word) {
+			commands = append(commands, nil)
+			continue
+		}
+		commands[len(commands)-1] = append(commands[len(commands)-1], word)
+	}
+	return commands
+}
+
+// closesQuote reports whether the line closes an open quote. A backslash
+// escapes the next byte inside a double-quoted span, so an escaped quote is a
+// literal character and not the closer. A single-quoted span has no escapes.
+func closesQuote(line string, quote byte) bool {
+	for index := 0; index < len(line); index++ {
+		if quote == '"' && line[index] == '\\' {
+			index++
+			continue
+		}
+		if line[index] == quote {
+			return true
+		}
+	}
+	return false
+}
+
 // ShellInvocations returns the arguments of each invocation of command in
-// script. It joins line continuations and drops comments, inline ones
-// included, heredoc bodies, the body of a function definition, and the rest of
-// a quoted word that runs past the end of its line, so that no decoy text
-// counts as a command and one call cannot satisfy a two-call rule. A validator that must anchor on the commands
-// a script really runs uses this in place of a substring search.
+// script. It joins line continuations, splits each line at the operators that
+// end one command, and drops comments, inline ones included, heredoc bodies,
+// the body of a function definition, the body of a compound command, and the
+// rest of a quoted word that runs past the end of its line, so that no decoy
+// text counts as a command and one call cannot satisfy a two-call rule. A
+// validator that must anchor on the commands a script really runs uses this in
+// place of a substring search.
 func ShellInvocations(script, command string) [][]string {
 	prefix := strings.Fields(command)
 	var invocations [][]string
@@ -69,7 +122,7 @@ func ShellInvocations(script, command string) [][]string {
 	var heredocs []heredoc
 	var openQuote byte
 	var quotes []byte
-	var depth, definedAt int
+	var depth, definedAt, control int
 	var defining bool
 	for line := range strings.Lines(script) {
 		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
@@ -77,7 +130,7 @@ func ShellInvocations(script, command string) [][]string {
 			// Bash reads these lines as text inside one word, as in
 			// : "<newline>oras cp …<newline>", which runs no command. Read
 			// them as text too, up to the line that closes the quote.
-			if strings.IndexByte(text, openQuote) >= 0 {
+			if closesQuote(text, openQuote) {
 				openQuote = 0
 			}
 			continue
@@ -111,8 +164,23 @@ func ShellInvocations(script, command string) [][]string {
 			}
 			continue
 		}
-		if len(words) >= len(prefix) && slices.Equal(words[:len(prefix)], prefix) {
-			invocations = append(invocations, words[len(prefix):])
+		commands := splitCommands(words)
+		nested := control > 0
+		for _, args := range commands {
+			if len(args) == 0 {
+				continue
+			}
+			if change, found := controlWords[args[0]]; found {
+				control = max(control+change, 0)
+				nested = true
+				continue
+			}
+			if nested || control > 0 {
+				continue
+			}
+			if len(args) >= len(prefix) && slices.Equal(args[:len(prefix)], prefix) {
+				invocations = append(invocations, args[len(prefix):])
+			}
 		}
 	}
 	return invocations
@@ -208,6 +276,17 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 			// A delimiter word ends at an operator, as in cat <<EOF; echo
 			// ready, where bash reads the delimiter EOF and runs the echo.
 			flush()
+		case strings.IndexByte(";&|", character) >= 0 &&
+			!(character == '&' && index > 0 && strings.IndexByte("<>", line[index-1]) >= 0):
+			// An operator ends the command before it. The guard keeps the & of
+			// a redirection such as 2>&1 as part of that word.
+			flush()
+			operator := string(character)
+			if index+1 < len(line) && line[index+1] == character {
+				index++
+				operator += string(character)
+			}
+			words = append(words, operator)
 		case character == ')' && len(stack) > 0:
 			quote = stack[len(stack)-1]
 			stack = stack[:len(stack)-1]

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -4,20 +4,9 @@
 package metadatautil
 
 import (
-	"cmp"
-	"regexp"
+	"slices"
 	"strings"
 )
-
-// heredocPattern consumes quoted words before it reads a redirection, so that
-// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
-// third alternative captures, and it captures the delimiter it opens.
-var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
-
-// inlineComment consumes quoted words before it reads a comment, so that a #
-// inside an argument such as 'note: # here' cannot truncate the line. As in
-// bash, only an unquoted # at the start of a word opens a comment.
-var inlineComment = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|(?:^|\s)#.*$`)
 
 // ShellInvocations returns the arguments of each invocation of command in
 // script. It joins line continuations and drops comments, inline ones
@@ -25,6 +14,7 @@ var inlineComment = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|(?:^|\s)#.*$`)
 // one call cannot satisfy a two-call rule. A validator that must anchor on the
 // commands a script really runs uses this in place of a substring search.
 func ShellInvocations(script, command string) [][]string {
+	prefix := strings.Fields(command)
 	var invocations [][]string
 	var current strings.Builder
 	var heredocs []string
@@ -36,39 +26,95 @@ func ShellInvocations(script, command string) [][]string {
 			}
 			continue
 		}
-		if current.Len() > 0 {
-			current.WriteString(" ")
-		}
 		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
 		if strings.HasSuffix(trimmed, "\\") {
+			current.WriteString(" ")
 			continue
 		}
-		logical := strings.TrimSpace(stripComment(current.String()))
+		words, opened := shellWords(current.String())
 		current.Reset()
-		// Here-strings are blanked first so that a redirection such as
-		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten. A match
-		// with no capture is a consumed quoted word, not a redirection.
-		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
-				heredocs = append(heredocs, delimiter)
-			}
-		}
-		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
-			invocations = append(invocations, strings.Fields(rest))
+		heredocs = append(heredocs, opened...)
+		if len(words) >= len(prefix) && slices.Equal(words[:len(prefix)], prefix) {
+			invocations = append(invocations, words[len(prefix):])
 		}
 	}
 	return invocations
 }
 
-// stripComment removes an unquoted comment from one logical line. The pattern
-// keeps the quoted words it consumed and deletes only the comment.
-func stripComment(logical string) string {
-	return inlineComment.ReplaceAllStringFunc(logical, func(match string) string {
-		if strings.HasPrefix(match, "'") || strings.HasPrefix(match, `"`) {
-			return match
+// shellWords splits one logical line the way bash reads it. Quotes and
+// backslash escapes are removed, so a quoted argument stays one word and a
+// separator inside it is text rather than syntax; an unquoted # that starts a
+// word ends the line; and every heredoc the line opens returns as a delimiter,
+// in the order bash reads the bodies.
+//
+// One pass keeps the three answers consistent. A pattern per answer cannot:
+// each has to rediscover the quoting, and the one that gets it wrong reads
+// syntax where the shell reads text.
+func shellWords(line string) (words, heredocs []string) {
+	var word strings.Builder
+	inWord, quote, pending := false, byte(0), false
+	flush := func() {
+		if !inWord {
+			return
 		}
-		return ""
-	})
+		if pending {
+			heredocs = append(heredocs, word.String())
+			pending = false
+		} else {
+			words = append(words, word.String())
+		}
+		word.Reset()
+		inWord = false
+	}
+	for index := 0; index < len(line); index++ {
+		character := line[index]
+		switch {
+		case quote == '\'':
+			// A backslash is literal inside single quotes.
+			if character == '\'' {
+				quote = 0
+			} else {
+				word.WriteByte(character)
+			}
+		case quote == '"':
+			if character == '\\' && index+1 < len(line) {
+				index++
+				word.WriteByte(line[index])
+			} else if character == '"' {
+				quote = 0
+			} else {
+				word.WriteByte(character)
+			}
+		case character == '\\' && index+1 < len(line):
+			// An escaped quote is a literal character, not the start of a
+			// quoted span, so it cannot hide the syntax that follows it.
+			index++
+			word.WriteByte(line[index])
+			inWord = true
+		case character == '\'' || character == '"':
+			quote = character
+			inWord = true
+		case character == ' ' || character == '\t':
+			flush()
+		case character == '#' && !inWord:
+			return words, heredocs
+		case character == '<' && index+1 < len(line) && line[index+1] == '<':
+			flush()
+			index++
+			if index+1 < len(line) && line[index+1] == '<' {
+				// A here-string takes its text from the line, not from a body.
+				index++
+				break
+			}
+			if index+1 < len(line) && line[index+1] == '-' {
+				index++
+			}
+			pending = true
+		default:
+			word.WriteByte(character)
+			inWord = true
+		}
+	}
+	flush()
+	return words, heredocs
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -77,12 +77,24 @@ func shellWords(line string) (words, heredocs []string) {
 				word.WriteByte(character)
 			}
 		case quote == '"':
-			if character == '\\' && index+1 < len(line) {
+			switch {
+			case character == '\\' && index+1 < len(line) && strings.IndexByte("$`\"\\", line[index+1]) >= 0:
+				// A backslash escapes only these characters here. Before any
+				// other one it is a literal byte of the word, so a name such
+				// as "or\as" is not the command it resembles.
 				index++
 				word.WriteByte(line[index])
-			} else if character == '"' {
+			case character == '"':
 				quote = 0
-			} else {
+			case character == '`' || (character == '$' && index+1 < len(line) && line[index+1] == '('):
+				// A command substitution resumes shell syntax inside the
+				// quotes. Where it closes is beyond a line reader, so syntax
+				// is read to the end of the line. That reads more heredocs and
+				// comments than bash, never fewer, so it can only drop an
+				// invocation, never invent one.
+				quote = 0
+				word.WriteByte(character)
+			default:
 				word.WriteByte(character)
 			}
 		case character == '\\' && index+1 < len(line):

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -133,14 +133,14 @@ type Invocation struct {
 	Position int
 }
 
-// ShellInvocations returns each invocation of command in
-// script. It joins line continuations, splits each line at the operators that
-// end one command, and drops comments, inline ones included, heredoc bodies,
-// the body of a function definition, the body of a compound command, and the
-// rest of a quoted word that runs past the end of its line, so that no decoy
-// text counts as a command and one call cannot satisfy a two-call rule. A
-// validator that must anchor on the commands a script really runs uses this in
-// place of a substring search.
+// ShellInvocations returns each invocation of command in script, with the
+// arguments it receives. It joins line continuations, splits each line at the
+// operators that end one command, and drops comments, inline ones included,
+// heredoc bodies, the body of a function definition, the body of a compound
+// command, and the rest of a quoted word that runs past the end of its line,
+// so that no decoy text counts as a command and one call cannot satisfy a
+// two-call rule. A validator that must anchor on the commands a script really
+// runs uses this in place of a substring search.
 func ShellInvocations(script, commandName string) []Invocation {
 	prefix := strings.Fields(commandName)
 	if len(prefix) == 0 {

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -41,9 +41,8 @@ func braceDepth(words []string) int {
 }
 
 // controlWords maps each word that opens or closes a compound command to the
-// change it makes to nesting. A command inside one of these is not proved to
-// run: bash never runs the body of if false, so a required command written
-// there does not satisfy a rule about what the step runs.
+// change it makes to nesting. Bash never runs the body of if false, so a
+// command inside one is not proved to run.
 var controlWords = map[string]int{
 	"if": 1, "while": 1, "until": 1, "for": 1, "case": 1, "select": 1,
 	"fi": -1, "done": -1, "esac": -1,
@@ -67,10 +66,9 @@ type command struct {
 	conditional bool
 }
 
-// splitCommands cuts one logical line into the separate commands bash runs,
-// at every control operator. Without this, a decoy after ; or || donates its
-// words to the invocation before it, as in
-// oras cp --from-oci-layout missing || true; : --to-oci-layout <target>.
+// splitCommands cuts one logical line into the separate commands bash runs, at
+// every control operator. Without this a decoy after ; or || donates its words
+// to the invocation before it.
 func splitCommands(words []string) []command {
 	commands := make([]command, 1)
 	for _, word := range words {
@@ -109,8 +107,7 @@ func definedName(words []string) string {
 
 // quoteCloseIndex returns the index of the byte that closes an open quote, or
 // -1 when the line does not close it. A backslash escapes the next byte inside
-// a double-quoted span, so an escaped quote is a literal character and not the
-// closer. A single-quoted span has no escapes.
+// a double-quoted span; a single-quoted span has no escapes.
 func quoteCloseIndex(line string, quote byte) int {
 	for index := 0; index < len(line); index++ {
 		if quote == '"' && line[index] == '\\' {
@@ -147,11 +144,9 @@ func ShellInvocations(script, commandName string) [][]string {
 	for line := range strings.Lines(script) {
 		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
 		if openQuote != 0 {
-			// Bash reads these lines as text inside one word, as in
-			// : "<newline>oras cp …<newline>", which runs no command. Read
-			// them as text too, up to the byte that closes the quote. What
-			// follows on that same line is syntax again, so read it: a closer
-			// such as " <<PLAN still opens a heredoc.
+			// Bash reads these lines as text inside one word, which runs no
+			// command. What follows the closing byte on that line is syntax
+			// again, so read it: a closer such as " <<PLAN opens a heredoc.
 			at := quoteCloseIndex(text, openQuote)
 			if at < 0 {
 				continue
@@ -172,9 +167,8 @@ func ShellInvocations(script, commandName string) [][]string {
 			continue
 		}
 		if strings.HasSuffix(trimmed, "&&") || strings.HasSuffix(trimmed, "|") {
-			// A list operator at the end of a line continues the command list
-			// onto the next one, so false && <newline> oras cp … is one
-			// logical line whose right side bash decides on the left.
+			// A list operator at the end of a line continues onto the next,
+			// so false && <newline> oras cp … is one logical line.
 			current.WriteString(" ")
 			continue
 		}
@@ -188,9 +182,7 @@ func ShellInvocations(script, commandName string) [][]string {
 		if !defining {
 			if name := definedName(words); name != "" {
 				if name == prefix[0] {
-					// The step redefines the anchored command itself, so every
-					// later call runs the definition rather than the program.
-					// Nothing in this script proves the command ran.
+					// Every later call runs the definition, not the program.
 					return nil
 				}
 				defining, definedAt, bodyOpened = true, depth, false
@@ -199,8 +191,7 @@ func ShellInvocations(script, commandName string) [][]string {
 		depth += braceDepth(words)
 		if defining {
 			// A body may open on a later line, as in never_called ()
-			// followed by { on its own line, so wait for it before looking
-			// for its end.
+			// followed by { on its own, so wait for it before seeking its end.
 			if depth > definedAt {
 				bodyOpened = true
 			}
@@ -223,6 +214,13 @@ func ShellInvocations(script, commandName string) [][]string {
 			}
 			if nested || control > 0 || each.conditional {
 				continue
+			}
+			if args[0] == "exit" || args[0] == "return" {
+				// The step ends here; nothing written after it runs.
+				return invocations
+			}
+			if args[0] == "alias" && shadowsByAlias(args, prefix[0]) {
+				return nil // Every later use expands to the alias.
 			}
 			if len(args) >= len(prefix) && slices.Equal(args[:len(prefix)], prefix) {
 				invocations = append(invocations, args[len(prefix):])
@@ -307,8 +305,7 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 		case character == '#' && !inWord:
 			return words, heredocs, 0, stack
 		case character == '$' && index+2 < len(line) && line[index+1] == '(' && line[index+2] == '(':
-			// An arithmetic expansion is not shell syntax: the << inside
-			// $((1 << 2)) is a shift, not a heredoc operator.
+			// The << inside $((1 << 2)) is a shift, not a heredoc operator.
 			arithmetic++
 			word.WriteString(line[index : index+3])
 			index += 2
@@ -346,7 +343,9 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 				operator += string(character)
 			}
 			words = append(words, operator)
-		case character == ')' && len(stack) > 0:
+		case len(stack) > 0 && (character == ')' || character == '`'):
+			// A substitution ends at ) or at its backtick, and the quote it
+			// suspended comes back with it.
 			quote = stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
 			word.WriteByte(character)
@@ -363,4 +362,15 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 		return words, heredocs, 0, stack
 	}
 	return words, heredocs, quote, stack
+}
+
+// shadowsByAlias reports whether an alias command rebinds name, as in
+// alias oras=':' after shopt -s expand_aliases.
+func shadowsByAlias(args []string, name string) bool {
+	for _, word := range args[1:] {
+		if bound, _, found := strings.Cut(word, "="); found && bound == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -122,6 +122,10 @@ func shellWords(line string) (words, heredocs []string) {
 				index++
 			}
 			pending = true
+		case pending && strings.IndexByte(";&|<>()", character) >= 0:
+			// A delimiter word ends at an operator, as in cat <<EOF; echo
+			// ready, where bash reads the delimiter EOF and runs the echo.
+			flush()
 		default:
 			word.WriteByte(character)
 			inWord = true

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -171,6 +171,13 @@ func ShellInvocations(script, commandName string) [][]string {
 			current.WriteString(" ")
 			continue
 		}
+		if strings.HasSuffix(trimmed, "&&") || strings.HasSuffix(trimmed, "|") {
+			// A list operator at the end of a line continues the command list
+			// onto the next one, so false && <newline> oras cp … is one
+			// logical line whose right side bash decides on the left.
+			current.WriteString(" ")
+			continue
+		}
 		words, opened, quote, rest := shellWords(current.String(), quotes)
 		current.Reset()
 		openQuote, quotes = quote, rest
@@ -241,6 +248,7 @@ func ShellInvocations(script, commandName string) [][]string {
 func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, open byte, rest []byte) {
 	var word strings.Builder
 	inWord, quote, pending, stripTabs := false, byte(0), false, false
+	arithmetic := 0
 	flush := func() {
 		if !inWord {
 			return
@@ -298,7 +306,19 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 			flush()
 		case character == '#' && !inWord:
 			return words, heredocs, 0, stack
-		case character == '<' && index+1 < len(line) && line[index+1] == '<':
+		case character == '$' && index+2 < len(line) && line[index+1] == '(' && line[index+2] == '(':
+			// An arithmetic expansion is not shell syntax: the << inside
+			// $((1 << 2)) is a shift, not a heredoc operator.
+			arithmetic++
+			word.WriteString(line[index : index+3])
+			index += 2
+			inWord = true
+		case arithmetic > 0 && character == ')' && index+1 < len(line) && line[index+1] == ')':
+			arithmetic--
+			word.WriteString("))")
+			index++
+			inWord = true
+		case arithmetic == 0 && character == '<' && index+1 < len(line) && line[index+1] == '<':
 			flush()
 			index++
 			if index+1 < len(line) && line[index+1] == '<' {

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -121,7 +121,19 @@ func quoteCloseIndex(line string, quote byte) int {
 	return -1
 }
 
-// ShellInvocations returns the arguments of each invocation of command in
+// Invocation is one invocation the script proves it runs: the arguments after
+// the command name, and the ordinal of the command word in the stream of
+// commands the parser proves the script reaches. Position does not depend on
+// the command being searched for, so two invocations parsed from the same
+// script compare directly, and a validator that requires one command to run
+// before another compares those positions rather than where the two names
+// first appear as text.
+type Invocation struct {
+	Args     []string
+	Position int
+}
+
+// ShellInvocations returns each invocation of command in
 // script. It joins line continuations, splits each line at the operators that
 // end one command, and drops comments, inline ones included, heredoc bodies,
 // the body of a function definition, the body of a compound command, and the
@@ -129,16 +141,17 @@ func quoteCloseIndex(line string, quote byte) int {
 // text counts as a command and one call cannot satisfy a two-call rule. A
 // validator that must anchor on the commands a script really runs uses this in
 // place of a substring search.
-func ShellInvocations(script, commandName string) [][]string {
+func ShellInvocations(script, commandName string) []Invocation {
 	prefix := strings.Fields(commandName)
 	if len(prefix) == 0 {
 		return nil
 	}
-	var invocations [][]string
+	var invocations []Invocation
 	var current strings.Builder
 	var heredocs []heredoc
 	var openQuote byte
 	var quotes []byte
+	var position int
 	var depth, definedAt, control int
 	var defining, bodyOpened bool
 	for line := range strings.Lines(script) {
@@ -152,7 +165,13 @@ func ShellInvocations(script, commandName string) [][]string {
 				continue
 			}
 			openQuote = 0
-			text = text[at+1:]
+			// The words after the closer still belong to the command the
+			// quoted word is an argument of, and that command word was read
+			// before the span opened. A null command carries them, so
+			// : " … " oras cp … stays one run of : rather than becoming an
+			// oras invocation. A control operator in the rest still ends it
+			// and starts a command of its own.
+			text = ": " + text[at+1:]
 		}
 		if len(heredocs) > 0 {
 			if heredocs[0].endsAt(text) {
@@ -211,6 +230,7 @@ func ShellInvocations(script, commandName string) [][]string {
 			if len(args) == 0 {
 				continue
 			}
+			position++
 			if change, found := controlWords[args[0]]; found {
 				control = max(control+change, 0)
 				nested = true
@@ -226,8 +246,14 @@ func ShellInvocations(script, commandName string) [][]string {
 			if args[0] == "alias" && shadowsByAlias(args, prefix[0]) {
 				return nil // Every later use expands to the alias.
 			}
+			if args[0] == "hash" && slices.Contains(args[1:], "-p") &&
+				slices.Contains(args[1:], prefix[0]) {
+				// hash -p pathname name makes pathname the full filename for
+				// name, so every later line runs that path, not the program.
+				return nil
+			}
 			if len(args) >= len(prefix) && slices.Equal(args[:len(prefix)], prefix) {
-				invocations = append(invocations, args[len(prefix):])
+				invocations = append(invocations, Invocation{args[len(prefix):], position})
 			}
 		}
 	}

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -239,7 +239,7 @@ func ShellInvocations(script, commandName string) []Invocation {
 			if nested || control > 0 || each.conditional {
 				continue
 			}
-			if args[0] == "exit" || args[0] == "return" {
+			if args[0] == "exit" || args[0] == "return" || replacesShell(args) {
 				// The step ends here; nothing written after it runs.
 				return invocations
 			}
@@ -412,6 +412,20 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 		return words, heredocs, 0, stack
 	}
 	return words, heredocs, quote, stack
+}
+
+// replacesShell reports whether the words are an exec that names a program,
+// which replaces the shell so that nothing written after it runs. An exec
+// carrying only redirections, as in exec 2>&1, changes the shell's own
+// descriptors and the script continues, so it must not stop the scan.
+func replacesShell(args []string) bool {
+	if args[0] != "exec" {
+		return false
+	}
+	return slices.ContainsFunc(args[1:], func(word string) bool {
+		operand := strings.TrimLeft(word, "0123456789")
+		return !strings.HasPrefix(operand, ">") && !strings.HasPrefix(operand, "<")
+	})
 }
 
 // shadowsByAlias reports whether an alias command rebinds name, as in

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"cmp"
+	"regexp"
+	"strings"
+)
+
+// heredocPattern consumes quoted words before it reads a redirection, so that
+// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
+// third alternative captures, and it captures the delimiter it opens.
+var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+
+var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
+
+// ShellInvocations returns the arguments of each invocation of command in
+// script. It joins line continuations and drops comments, inline ones
+// included, and heredoc bodies, so that no decoy text counts as a command and
+// one call cannot satisfy a two-call rule. A validator that must anchor on the
+// commands a script really runs uses this in place of a substring search.
+func ShellInvocations(script, command string) [][]string {
+	var invocations [][]string
+	var current strings.Builder
+	var heredocs []string
+	for line := range strings.Lines(script) {
+		trimmed := strings.TrimSpace(line)
+		if len(heredocs) > 0 {
+			if trimmed == heredocs[0] {
+				heredocs = heredocs[1:]
+			}
+			continue
+		}
+		if current.Len() > 0 {
+			current.WriteString(" ")
+		}
+		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
+		if strings.HasSuffix(trimmed, "\\") {
+			continue
+		}
+		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
+		current.Reset()
+		// Here-strings are blanked first so that a redirection such as
+		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
+		// Every delimiter on the line opens a body, and bash reads them in the
+		// order they appear, so they are queued rather than overwritten. A match
+		// with no capture is a consumed quoted word, not a redirection.
+		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
+			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
+				heredocs = append(heredocs, delimiter)
+			}
+		}
+		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
+			invocations = append(invocations, strings.Fields(rest))
+		}
+	}
+	return invocations
+}

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -209,11 +209,29 @@ func TestShellInvocations(t *testing.T) {
 			script: "cat <<<\"${PLAN}\"\noras cp one\n",
 			want:   [][]string{{"one"}},
 		},
+		{
+			name:   "words after a closing quote are arguments of the command that opened it",
+			script: ": \"\nx\n\" oras cp --recursive --from-oci-layout one\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
+			name:   "an operator after a closing quote still starts a command",
+			script: ": \"\nx\n\"; oras cp --recursive --from-oci-layout one\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
+		},
+		{
+			name:   "a hashed path over the command proves no invocation of it",
+			script: "hash -p /bin/true oras\noras cp --recursive --from-oci-layout one\n",
+			want:   nil,
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			got := metadatautil.ShellInvocations(testCase.script, "oras cp")
+			var got [][]string
+			for _, invocation := range metadatautil.ShellInvocations(testCase.script, "oras cp") {
+				got = append(got, invocation.Args)
+			}
 			if !slices.EqualFunc(got, testCase.want, slices.Equal) {
 				t.Fatalf("ShellInvocations() = %q, want %q", got, testCase.want)
 			}

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -70,6 +70,16 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"two"}},
 		},
 		{
+			name:   "a list operator at the end of a line carries to the next",
+			script: "false &&\noras cp --recursive --from-oci-layout one\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
+			name:   "an arithmetic shift is not a heredoc operator",
+			script: ": $((1 << 2))\noras cp --recursive --from-oci-layout one\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
+		},
+		{
 			name:   "a step that redefines the command proves no invocation of it",
 			script: "oras() { :; }\noras cp --recursive --from-oci-layout one\n",
 			want:   nil,

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -40,6 +40,16 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"one"}},
 		},
 		{
+			name:   "a hash inside single quotes is an argument, not a comment",
+			script: "oras cp 'note: # here' one\n",
+			want:   [][]string{{"'note:", "#", "here'", "one"}},
+		},
+		{
+			name:   "a hash inside double quotes is an argument, not a comment",
+			script: "oras cp \"note: # here\" one\n",
+			want:   [][]string{{"\"note:", "#", "here\"", "one"}},
+		},
+		{
 			name:   "a heredoc body with a quoted delimiter runs nothing",
 			script: "cat <<'PLAN'\noras cp one\nPLAN\noras cp two\n",
 			want:   [][]string{{"two"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -42,12 +42,27 @@ func TestShellInvocations(t *testing.T) {
 		{
 			name:   "a hash inside single quotes is an argument, not a comment",
 			script: "oras cp 'note: # here' one\n",
-			want:   [][]string{{"'note:", "#", "here'", "one"}},
+			want:   [][]string{{"note: # here", "one"}},
 		},
 		{
 			name:   "a hash inside double quotes is an argument, not a comment",
 			script: "oras cp \"note: # here\" one\n",
-			want:   [][]string{{"\"note:", "#", "here\"", "one"}},
+			want:   [][]string{{"note: # here", "one"}},
+		},
+		{
+			name:   "a hash inside a word is an argument, not a comment",
+			script: "oras cp a#b one\n",
+			want:   [][]string{{"a#b", "one"}},
+		},
+		{
+			name:   "a quoted argument stays one word, so an option inside it is text",
+			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
+			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},
+		},
+		{
+			name:   "an escaped quote does not open a span that hides a delimiter",
+			script: ": \\' <<PLAN ''\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
 		},
 		{
 			name:   "a heredoc body with a quoted delimiter runs nothing",

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestShellInvocations(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, script string
+		want         [][]string
+	}{
+		{
+			name:   "arguments of each invocation",
+			script: "oras cp one\noras cp two\n",
+			want:   [][]string{{"one"}, {"two"}},
+		},
+		{
+			name:   "a longer command name is not the requested command",
+			script: "oras cpx one\n",
+		},
+		{
+			name:   "continuations join into one invocation",
+			script: "oras cp \\\n  one \\\n  two\n",
+			want:   [][]string{{"one", "two"}},
+		},
+		{
+			name:   "a full-line comment runs nothing",
+			script: "# oras cp one\n",
+		},
+		{
+			name:   "an inline comment ends the invocation",
+			script: "oras cp one # oras cp two\n",
+			want:   [][]string{{"one"}},
+		},
+		{
+			name:   "a heredoc body with a quoted delimiter runs nothing",
+			script: "cat <<'PLAN'\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "an unquoted delimiter still opens a body, expansions included",
+			script: "cat <<PLAN\noras cp ${DECOY}\noras cp $(oras cp one)\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a tab-stripped delimiter closes the body it opened",
+			script: "cat <<-PLAN\n\toras cp one\n\tPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "two heredocs on one line each consume their own body",
+			script: "cat <<'NOTE' <<'PLAN'\noras cp one\nNOTE\noras cp two\nPLAN\noras cp three\n",
+			want:   [][]string{{"three"}},
+		},
+		{
+			name:   "a quoted word cannot open a delimiter",
+			script: ": <<'A' \"text <<B\"\nA\ncat <<'PLAN'\nB\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a here-string does not open a heredoc",
+			script: "cat <<<\"${PLAN}\"\noras cp one\n",
+			want:   [][]string{{"one"}},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got := metadatautil.ShellInvocations(testCase.script, "oras cp")
+			if !slices.EqualFunc(got, testCase.want, slices.Equal) {
+				t.Fatalf("ShellInvocations() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -55,6 +55,16 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"a#b", "one"}},
 		},
 		{
+			name:   "a backslash before an ordinary character stays literal in double quotes",
+			script: "\"or\\as\" cp one\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a command substitution inside double quotes opens its heredoc",
+			script: "printf '%s' \"$(cat <<PLAN\noras cp one\nPLAN\n)\"\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
 			name:   "a quoted argument stays one word, so an option inside it is text",
 			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
 			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -70,6 +70,21 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"two"}},
 		},
 		{
+			name:   "a step that redefines the command proves no invocation of it",
+			script: "oras() { :; }\noras cp --recursive --from-oci-layout one\n",
+			want:   nil,
+		},
+		{
+			name:   "a definition whose brace opens on the next line still hides its body",
+			script: "never_called ()\n{\noras cp --recursive --from-oci-layout one\n}\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
+			name:   "a heredoc opened as a quoted span closes still hides its body",
+			script: ": \"\nx\n\" <<PLAN\noras cp --recursive --from-oci-layout one\nPLAN\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
 			name:   "arguments end at a control operator",
 			script: "oras cp --recursive --from-oci-layout missing || true; : --to-oci-layout dist/release-image:amd64\n",
 			want:   [][]string{{"--recursive", "--from-oci-layout", "missing"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -70,9 +70,24 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"two"}},
 		},
 		{
+			name:   "arguments end at a control operator",
+			script: "oras cp --recursive --from-oci-layout missing || true; : --to-oci-layout dist/release-image:amd64\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "missing"}},
+		},
+		{
+			name:   "a command in a branch bash never runs is not an invocation",
+			script: "if false; then\noras cp --recursive --from-oci-layout one\nfi\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
+			name:   "a redirection keeps its own ampersand",
+			script: "oras cp --recursive --from-oci-layout one >/dev/null 2>&1\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "one", ">/dev/null", "2>&1"}},
+		},
+		{
 			name:   "a quoted argument stays one word, so an option inside it is text",
 			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
-			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},
+			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored"}},
 		},
 		{
 			name:   "an escaped quote does not open a span that hides a delimiter",

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -65,6 +65,11 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"two"}},
 		},
 		{
+			name:   "a delimiter word ends at an operator on the same line",
+			script: "cat <<EOF; oras cp one\nbody\nEOF\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
 			name:   "a quoted argument stays one word, so an option inside it is text",
 			script: "oras cp 'ignored --to-oci-layout dist/release-image:amd64 ignored' || true\n",
 			want:   [][]string{{"ignored --to-oci-layout dist/release-image:amd64 ignored", "||", "true"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -220,6 +220,16 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
 		},
 		{
+			name:   "an exec that names a program ends the scan",
+			script: "exec true\noras cp --recursive --from-oci-layout one\n",
+			want:   nil,
+		},
+		{
+			name:   "an exec of redirections alone leaves the script running",
+			script: "exec 2>&1\noras cp --recursive --from-oci-layout one\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
+		},
+		{
 			name:   "a noclobber redirection keeps its own bar",
 			script: ": >| oras cp --recursive --from-oci-layout one\noras cp --recursive --from-oci-layout two\n",
 			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -80,6 +80,26 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
 		},
 		{
+			name:   "a closing backtick restores the quote its substitution suspended",
+			script: ": \"`true`\noras cp --recursive --from-oci-layout one\n\"\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
+			name:   "nothing after an unconditional exit is an invocation",
+			script: "oras cp --recursive --from-oci-layout one\nexit 0\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
+		},
+		{
+			name:   "an exit inside a branch does not end the scan",
+			script: "if false; then\nexit 0\nfi\noras cp --recursive --from-oci-layout one\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
+		},
+		{
+			name:   "an alias over the command proves no invocation of it",
+			script: "shopt -s expand_aliases\nalias oras=':'\noras cp --recursive --from-oci-layout one\n",
+			want:   nil,
+		},
+		{
 			name:   "a step that redefines the command proves no invocation of it",
 			script: "oras() { :; }\noras cp --recursive --from-oci-layout one\n",
 			want:   nil,

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -220,6 +220,11 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"--recursive", "--from-oci-layout", "one"}},
 		},
 		{
+			name:   "a noclobber redirection keeps its own bar",
+			script: ": >| oras cp --recursive --from-oci-layout one\noras cp --recursive --from-oci-layout two\n",
+			want:   [][]string{{"--recursive", "--from-oci-layout", "two"}},
+		},
+		{
 			name:   "a hashed path over the command proves no invocation of it",
 			script: "hash -p /bin/true oras\noras cp --recursive --from-oci-layout one\n",
 			want:   nil,

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -92,7 +92,15 @@ func dropCommentsAndLiterals(source string) string {
 		character := source[index]
 		switch {
 		case character == '\n':
-			state, lineComment = 0, false
+			// A newline ends a line comment. A block comment and a raw
+			// literal both run on, so their state has to survive it. An
+			// interpreted literal cannot span a line at all, so a newline
+			// inside one means the scan has lost its place; clear it and read
+			// the next line as code rather than blanking the rest of the file.
+			lineComment = false
+			if state == '"' || state == '\'' {
+				state = 0
+			}
 			out.WriteByte(character)
 		case lineComment:
 			out.WriteByte(' ')

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -39,7 +39,9 @@ func CheckValidatorAnchoring(rootDir string) error {
 	return nil
 }
 
-// countCallSites returns the number of lines under internal/ that call needle.
+// countCallSites returns the number of calls of needle under internal/. It
+// counts every occurrence on a line, not one per line, so a second call added
+// to an existing line still needs its own corpus run.
 // It reads test sources when inTests is set and non-test sources otherwise, it
 // removes comments and string literals first so that text about a call is not
 // counted as one, and it reads a declaration line from its body onwards so that
@@ -64,9 +66,7 @@ func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 			return err
 		}
 		for line := range strings.Lines(dropCommentsAndLiterals(string(content))) {
-			if strings.Contains(afterDeclaration(line), needle) {
-				count++
-			}
+			count += strings.Count(afterDeclaration(line), needle)
 		}
 		return nil
 	})

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -42,8 +42,9 @@ func CheckValidatorAnchoring(rootDir string) error {
 // countCallSites returns the number of lines under internal/ that call needle.
 // It reads test sources when inTests is set and non-test sources otherwise, it
 // removes comments and string literals first so that text about a call is not
-// counted as one, and it skips declaration lines so that a function is never
-// counted as its own caller.
+// counted as one, and it reads a declaration line from its body onwards so that
+// a function is never counted as its own caller while a call written in a
+// one-line body still is.
 func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 	count := 0
 	root := filepath.Join(rootDir, "internal")
@@ -63,7 +64,7 @@ func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 			return err
 		}
 		for line := range strings.Lines(dropCommentsAndLiterals(string(content))) {
-			if strings.Contains(line, needle) && !strings.HasPrefix(line, "func ") {
+			if strings.Contains(afterDeclaration(line), needle) {
 				count++
 			}
 		}
@@ -140,4 +141,20 @@ func dropCommentsAndLiterals(source string) string {
 		}
 	}
 	return out.String()
+}
+
+// afterDeclaration returns the part of a line that can hold a call. On a
+// declaration line that is the body after the opening brace, so that
+// func ShellInvocations(...) is not a call of itself while a one-line body such
+// as func validate() { ShellInvocations(...) } still is. Every other line is
+// returned whole.
+func afterDeclaration(line string) string {
+	if !strings.HasPrefix(line, "func ") {
+		return line
+	}
+	_, body, found := strings.Cut(line, "{")
+	if !found {
+		return ""
+	}
+	return body
 }

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -12,10 +12,6 @@ import (
 	"strings"
 )
 
-// anchoringCheckerPrefix names this file and its test. The check skips both so
-// that the needles they carry as text are not counted as call sites.
-const anchoringCheckerPrefix = "validator_anchoring"
-
 // CheckValidatorAnchoring requires each validator that anchors on the shared
 // shell-invocation parser to run the shared evasion corpus. A validator that
 // reads a command out of file content is bypassed by a comment, a heredoc body
@@ -44,9 +40,10 @@ func CheckValidatorAnchoring(rootDir string) error {
 }
 
 // countCallSites returns the number of lines under internal/ that call needle.
-// It reads test sources when inTests is set and non-test sources otherwise, and
-// it skips declaration lines so that a function is never counted as its own
-// caller.
+// It reads test sources when inTests is set and non-test sources otherwise, it
+// removes comments and string literals first so that text about a call is not
+// counted as one, and it skips declaration lines so that a function is never
+// counted as its own caller.
 func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 	count := 0
 	root := filepath.Join(rootDir, "internal")
@@ -55,7 +52,7 @@ func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 			return err
 		}
 		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasPrefix(name, anchoringCheckerPrefix) {
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
 			return nil
 		}
 		if strings.HasSuffix(name, "_test.go") != inTests {
@@ -65,7 +62,7 @@ func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 		if err != nil {
 			return err
 		}
-		for line := range strings.Lines(string(content)) {
+		for line := range strings.Lines(dropCommentsAndLiterals(string(content))) {
 			if strings.Contains(line, needle) && !strings.HasPrefix(line, "func ") {
 				count++
 			}
@@ -76,4 +73,63 @@ func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 		return 0, fmt.Errorf("scan %s for %s: %w", root, needle, err)
 	}
 	return count, nil
+}
+
+// dropCommentsAndLiterals blanks the comments and string literals of Go source
+// and keeps every newline, so a line number and the code on it survive. A
+// comment or a literal that names a call is text about the call, not the call,
+// and counting it would let a mention satisfy the parity gate or break it.
+//
+// A byte scan is enough for this one caller, the same choice this package
+// records for structJSONFields, and it avoids go/ast.
+func dropCommentsAndLiterals(source string) string {
+	var out strings.Builder
+	out.Grow(len(source))
+	// state is 0 in code, or the byte that ends the current span.
+	var state byte
+	var lineComment bool
+	for index := 0; index < len(source); index++ {
+		character := source[index]
+		switch {
+		case character == '\n':
+			state, lineComment = 0, false
+			out.WriteByte(character)
+		case lineComment:
+			out.WriteByte(' ')
+		case state == '*':
+			if character == '*' && index+1 < len(source) && source[index+1] == '/' {
+				index++
+				state = 0
+				out.WriteString("  ")
+				continue
+			}
+			out.WriteByte(' ')
+		case state != 0:
+			// A backslash escapes the next byte in an interpreted literal. A
+			// raw literal has no escapes, so only " and ' take this branch.
+			if character == '\\' && state != '`' && index+1 < len(source) {
+				index++
+				out.WriteString("  ")
+				continue
+			}
+			if character == state {
+				state = 0
+			}
+			out.WriteByte(' ')
+		case character == '/' && index+1 < len(source) && source[index+1] == '/':
+			lineComment = true
+			out.WriteString("  ")
+			index++
+		case character == '/' && index+1 < len(source) && source[index+1] == '*':
+			state = '*'
+			out.WriteString("  ")
+			index++
+		case character == '"' || character == '\'' || character == '`':
+			state = character
+			out.WriteByte(' ')
+		default:
+			out.WriteByte(character)
+		}
+	}
+	return out.String()
 }

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -66,7 +66,7 @@ func countCallSites(rootDir, needle string, inTests bool) (int, error) {
 			return err
 		}
 		for line := range strings.Lines(dropCommentsAndLiterals(string(content))) {
-			count += strings.Count(afterDeclaration(line), needle)
+			count += countCalls(afterDeclaration(line), needle)
 		}
 		return nil
 	})
@@ -93,11 +93,9 @@ func dropCommentsAndLiterals(source string) string {
 		character := source[index]
 		switch {
 		case character == '\n':
-			// A newline ends a line comment. A block comment and a raw
-			// literal both run on, so their state has to survive it. An
-			// interpreted literal cannot span a line at all, so a newline
-			// inside one means the scan has lost its place; clear it and read
-			// the next line as code rather than blanking the rest of the file.
+			// A block comment and a raw literal run past a newline, so their
+			// state survives it. An interpreted literal cannot, so a newline
+			// inside one means the scan has lost its place; resync there.
 			lineComment = false
 			if state == '"' || state == '\'' {
 				state = 0
@@ -157,4 +155,29 @@ func afterDeclaration(line string) string {
 		return ""
 	}
 	return body
+}
+
+// countCalls returns how many times text calls needle. A match must not
+// continue an identifier, so cachedShellInvocations( is not a call of it.
+func countCalls(text, needle string) int {
+	count, offset := 0, 0
+	for {
+		at := strings.Index(text[offset:], needle)
+		if at < 0 {
+			return count
+		}
+		at += offset
+		if at == 0 || !isIdentifierByte(text[at-1]) {
+			count++
+		}
+		offset = at + len(needle)
+	}
+}
+
+// isIdentifierByte reports whether the byte can appear inside a Go identifier.
+func isIdentifierByte(character byte) bool {
+	return character == '_' ||
+		character >= 'a' && character <= 'z' ||
+		character >= 'A' && character <= 'Z' ||
+		character >= '0' && character <= '9'
 }

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // CheckValidatorAnchoring requires each validator that anchors on the shared
@@ -22,11 +24,11 @@ import (
 // tree, the same choice the other checks in this package record: the call sites
 // are few, and a scan avoids go/ast for one caller.
 func CheckValidatorAnchoring(rootDir string) error {
-	anchors, err := countCallSites(rootDir, "ShellInvocations(", false)
+	anchors, err := countCallSites(rootDir, "ShellInvocations", false)
 	if err != nil {
 		return err
 	}
-	corpus, err := countCallSites(rootDir, "RequireRejectsAllEvasions(", true)
+	corpus, err := countCallSites(rootDir, "RequireRejectsAllEvasions", true)
 	if err != nil {
 		return err
 	}
@@ -157,27 +159,31 @@ func afterDeclaration(line string) string {
 	return body
 }
 
-// countCalls returns how many times text calls needle. A match must not
-// continue an identifier, so cachedShellInvocations( is not a call of it.
-func countCalls(text, needle string) int {
+// countCalls returns how many times text calls the function named name. The
+// match must be the whole identifier, so neither cachedShellInvocations nor a
+// name that begins with a letter outside ASCII is read as the call, and the
+// argument list must follow it. A comment between the callee and that list is
+// blanked to spaces by then, so the spaces are skipped before it is required.
+func countCalls(text, name string) int {
 	count, offset := 0, 0
 	for {
-		at := strings.Index(text[offset:], needle)
+		at := strings.Index(text[offset:], name)
 		if at < 0 {
 			return count
 		}
 		at += offset
-		if at == 0 || !isIdentifierByte(text[at-1]) {
+		offset = at + len(name)
+		previous, _ := utf8.DecodeLastRuneInString(text[:at])
+		if (at == 0 || !isIdentifierRune(previous)) &&
+			strings.HasPrefix(strings.TrimLeft(text[offset:], " \t"), "(") {
 			count++
 		}
-		offset = at + len(needle)
 	}
 }
 
-// isIdentifierByte reports whether the byte can appear inside a Go identifier.
-func isIdentifierByte(character byte) bool {
-	return character == '_' ||
-		character >= 'a' && character <= 'z' ||
-		character >= 'A' && character <= 'Z' ||
-		character >= '0' && character <= '9'
+// isIdentifierRune reports whether the rune can continue a Go identifier. Go
+// takes any Unicode letter or digit, so an ASCII test reads a name such as
+// 偽RequireRejectsAllEvasions as a call of the one it ends with.
+func isIdentifierRune(character rune) bool {
+	return character == '_' || unicode.IsLetter(character) || unicode.IsDigit(character)
 }

--- a/internal/metadatautil/validator_anchoring.go
+++ b/internal/metadatautil/validator_anchoring.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// anchoringCheckerPrefix names this file and its test. The check skips both so
+// that the needles they carry as text are not counted as call sites.
+const anchoringCheckerPrefix = "validator_anchoring"
+
+// CheckValidatorAnchoring requires each validator that anchors on the shared
+// shell-invocation parser to run the shared evasion corpus. A validator that
+// reads a command out of file content is bypassed by a comment, a heredoc body
+// or a longer option unless a negative fixture proves otherwise, so the two
+// counts must stay equal.
+//
+// The check counts call sites with a text scan rather than reading the syntax
+// tree, the same choice the other checks in this package record: the call sites
+// are few, and a scan avoids go/ast for one caller.
+func CheckValidatorAnchoring(rootDir string) error {
+	anchors, err := countCallSites(rootDir, "ShellInvocations(", false)
+	if err != nil {
+		return err
+	}
+	corpus, err := countCallSites(rootDir, "RequireRejectsAllEvasions(", true)
+	if err != nil {
+		return err
+	}
+	if anchors == 0 {
+		return errors.New("no validator anchors on the shared shell-invocation parser; the anchoring check has lost its subject")
+	}
+	if anchors != corpus {
+		return fmt.Errorf("validator anchoring parity: %d call(s) of ShellInvocations but %d run(s) of the shared evasion corpus; every anchored validator needs one RequireRejectsAllEvasions run", anchors, corpus)
+	}
+	return nil
+}
+
+// countCallSites returns the number of lines under internal/ that call needle.
+// It reads test sources when inTests is set and non-test sources otherwise, and
+// it skips declaration lines so that a function is never counted as its own
+// caller.
+func countCallSites(rootDir, needle string, inTests bool) (int, error) {
+	count := 0
+	root := filepath.Join(rootDir, "internal")
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasPrefix(name, anchoringCheckerPrefix) {
+			return nil
+		}
+		if strings.HasSuffix(name, "_test.go") != inTests {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for line := range strings.Lines(string(content)) {
+			if strings.Contains(line, needle) && !strings.HasPrefix(line, "func ") {
+				count++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("scan %s for %s: %w", root, needle, err)
+	}
+	return count, nil
+}

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -28,6 +28,8 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 		{"corpus run missing", anchor + anchor, corpus, "2 call(s) of ShellInvocations but 1 run(s)"},
 		{"corpus run without an anchor", anchor, corpus + corpus, "1 call(s) of ShellInvocations but 2 run(s)"},
 		{"no anchored validator", "", corpus, "lost its subject"},
+		{"comment naming a call", anchor + "\t// " + corpus, "\t// " + anchor + corpus, ""},
+		{"literal naming a call", anchor + "\t_ = `" + corpus + "`\n", "\t_ = \"ShellInvocations(\"\n" + corpus, ""},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -33,6 +33,8 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 		{"line comment names a corpus run", anchor, corpus + "\t// " + corpus, ""},
 		{"block comment names a corpus run", anchor, corpus + "\t/* text\n" + corpus + "\t*/\n", ""},
 		{"raw literal names a corpus run", anchor, corpus + "\t_ = `text\n" + corpus + "`\n", ""},
+		{"call in a one-line function body", "func validate() {" + strings.TrimSuffix(anchor, "\n") + " }\n", corpus, ""},
+		{"declaration is not a call", "func ShellInvocations(script, command string) [][]string {\n" + anchor, corpus, ""},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -42,7 +44,7 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 				t.Fatal(err)
 			}
 			write := func(name, body string) {
-				if err := os.WriteFile(filepath.Join(dir, name), []byte("package example\n\nfunc f() {\n"+body+"}\n"), 0o644); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte("package example\n\n"+body), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -35,6 +35,7 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 		{"raw literal names a corpus run", anchor, corpus + "\t_ = `text\n" + corpus + "`\n", ""},
 		{"call in a one-line function body", "func validate() {" + strings.TrimSuffix(anchor, "\n") + " }\n", corpus, ""},
 		{"declaration is not a call", "func ShellInvocations(script, command string) [][]string {\n" + anchor, corpus, ""},
+		{"a longer identifier is not the call", anchor + "\tcachedShellInvocations(script, command)\n", corpus, ""},
 		{"two calls on one line", strings.TrimSuffix(anchor, "\n") + strings.TrimPrefix(anchor, "\t"), corpus + corpus, ""},
 	}
 	for _, testCase := range cases {

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -37,6 +37,8 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 		{"declaration is not a call", "func ShellInvocations(script, command string) [][]string {\n" + anchor, corpus, ""},
 		{"a longer identifier is not the call", anchor + "\tcachedShellInvocations(script, command)\n", corpus, ""},
 		{"two calls on one line", strings.TrimSuffix(anchor, "\n") + strings.TrimPrefix(anchor, "\t"), corpus + corpus, ""},
+		{"a comment between the callee and its arguments is a call", "\t_ = ShellInvocations /* why */ (script, \"tool run\")\n", corpus, ""},
+		{"a Unicode identifier prefix is not the call", anchor, corpus + "\t偽RequireRejectsAllEvasions(t, artifact, anchor, want, validate)\n", ""},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -35,6 +35,7 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 		{"raw literal names a corpus run", anchor, corpus + "\t_ = `text\n" + corpus + "`\n", ""},
 		{"call in a one-line function body", "func validate() {" + strings.TrimSuffix(anchor, "\n") + " }\n", corpus, ""},
 		{"declaration is not a call", "func ShellInvocations(script, command string) [][]string {\n" + anchor, corpus, ""},
+		{"two calls on one line", strings.TrimSuffix(anchor, "\n") + strings.TrimPrefix(anchor, "\t"), corpus + corpus, ""},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckValidatorAnchoringAcceptsThisRepository(t *testing.T) {
+	if err := metadatautil.CheckValidatorAnchoring(filepath.Join("..", "..")); err != nil {
+		t.Fatalf("CheckValidatorAnchoring() error = %v", err)
+	}
+}
+
+func TestCheckValidatorAnchoring(t *testing.T) {
+	anchor := "\tfor _, args := range ShellInvocations(script, \"tool run\") {\n"
+	corpus := "\tRequireRejectsAllEvasions(t, artifact, anchor, want, validate)\n"
+	cases := []struct {
+		name, source, test, want string
+	}{
+		{"parity", anchor + anchor, corpus + corpus, ""},
+		{"corpus run missing", anchor + anchor, corpus, "2 call(s) of ShellInvocations but 1 run(s)"},
+		{"corpus run without an anchor", anchor, corpus + corpus, "1 call(s) of ShellInvocations but 2 run(s)"},
+		{"no anchored validator", "", corpus, "lost its subject"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			dir := filepath.Join(root, "internal", "example")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			write := func(name, body string) {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte("package example\n\nfunc f() {\n"+body+"}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write("example.go", testCase.source)
+			write("example_test.go", testCase.test)
+
+			err := metadatautil.CheckValidatorAnchoring(root)
+			if testCase.want == "" {
+				if err != nil {
+					t.Fatalf("CheckValidatorAnchoring() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("CheckValidatorAnchoring() error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/metadatautil/validator_anchoring_test.go
+++ b/internal/metadatautil/validator_anchoring_test.go
@@ -28,8 +28,11 @@ func TestCheckValidatorAnchoring(t *testing.T) {
 		{"corpus run missing", anchor + anchor, corpus, "2 call(s) of ShellInvocations but 1 run(s)"},
 		{"corpus run without an anchor", anchor, corpus + corpus, "1 call(s) of ShellInvocations but 2 run(s)"},
 		{"no anchored validator", "", corpus, "lost its subject"},
-		{"comment naming a call", anchor + "\t// " + corpus, "\t// " + anchor + corpus, ""},
-		{"literal naming a call", anchor + "\t_ = `" + corpus + "`\n", "\t_ = \"ShellInvocations(\"\n" + corpus, ""},
+		{"line comment names an anchor", anchor + "\t// " + anchor, corpus, ""},
+		{"literal names an anchor", anchor + "\t_ = \"ShellInvocations(\"\n", corpus, ""},
+		{"line comment names a corpus run", anchor, corpus + "\t// " + corpus, ""},
+		{"block comment names a corpus run", anchor, corpus + "\t/* text\n" + corpus + "\t*/\n", ""},
+		{"raw literal names a corpus run", anchor, corpus + "\t_ = `text\n" + corpus + "`\n", ""},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -173,6 +173,29 @@ func TestValidateReleaseWorkflowPublicationGateRejectsEvasions(t *testing.T) {
 	})
 }
 
+// TestValidateReleaseWorkflowPublicationGateComparesParsedOrder proves the gate
+// reads the order bash reaches the three commands, not the order their names
+// first appear as text. A comment naming them in the required order must not
+// cover a step that mutates the release before the hosted-controls recheck.
+func TestValidateReleaseWorkflowPublicationGateComparesParsedOrder(t *testing.T) {
+	workflow := string(readReleaseWorkflow(t))
+	const ordered = "          ./scripts/run-hosted-controls-audit.sh \"${GITHUB_REPOSITORY}\"\n" +
+		"          unset WORKCELL_HOSTED_CONTROLS_TOKEN\n"
+	swapped := "          # order: ./scripts/run-hosted-controls-audit.sh\n" +
+		"          # then: unset WORKCELL_HOSTED_CONTROLS_TOKEN\n" +
+		"          # then: ./scripts/publish-github-release.sh\n" +
+		"          unset WORKCELL_HOSTED_CONTROLS_TOKEN\n" +
+		"          ./scripts/run-hosted-controls-audit.sh \"${GITHUB_REPOSITORY}\"\n"
+	mutated := strings.Replace(workflow, ordered, swapped, 1)
+	if mutated == workflow {
+		t.Fatal("the publication step no longer carries the audit and unset lines this test rewrites")
+	}
+	err := metadatautil.ValidateReleaseWorkflowPublicationGate(mutated)
+	if err == nil || !strings.Contains(err.Error(), "recheck hosted controls") {
+		t.Fatalf("ValidateReleaseWorkflowPublicationGate() error = %v, want a recheck order failure", err)
+	}
+}
+
 func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T) {
 	workflow := string(readReleaseWorkflow(t))
 	decoys := []struct {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -207,6 +207,26 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "destinations moved inside a quoted argument the shell never reads as options",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          oras cp --recursive --from-oci-layout 'x --to-oci-layout dist/release-image:amd64 x' || true\n" +
+				"          oras cp --recursive --from-oci-layout 'x --to-oci-layout dist/release-image:arm64 x' || true",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands hidden behind a delimiter an escaped quote appears to quote",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : \\' <<PLAN ''\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -179,6 +179,19 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands replaced by the second body of two heredocs",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          cat <<'NOTE' <<'PLAN' >/dev/null\n" +
+				"          NOTE\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -95,6 +95,7 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 		{name: "minimal publisher permissions", old: "contents: write\n      packages: read", replacement: "contents: write\n      packages: write", want: "grant only read verification permissions"},
 		{name: "minimal verifier permissions", old: "contents: read\n      packages: read", replacement: "contents: read\n      packages: write", want: "grant only read permissions"},
 		{name: "unsets audit token", old: "unset WORKCELL_HOSTED_CONTROLS_TOKEN", replacement: "true", want: "unset its credential"},
+		{name: "audits the repository and nothing else", old: "run-hosted-controls-audit.sh \"${GITHUB_REPOSITORY}\"", replacement: "run-hosted-controls-audit.sh wrong \"${GITHUB_REPOSITORY}\" || true", want: "recheck hosted controls"},
 		{name: "explicit handoff", old: "--immutable-releases-preverified-by-hosted-controls", replacement: "--other", want: "explicit preverified publisher"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -227,6 +227,27 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "copies renamed to a command bash never runs by a backslash in double quotes",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64",
+			decoy: "          \"or\\as\" cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64 || true\n" +
+				"          \"or\\as\" cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64 || true",
+			want: "copy both platform images",
+		},
+		{
+			name: "real commands moved into a heredoc a quoted command substitution opens",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          printf '%s' \"$(cat <<PLAN\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN\n" +
+				"          )\"",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -143,6 +143,36 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions(t *testing.T) {
 	})
 }
 
+// TestValidateReleaseWorkflowPublicationGateRejectsEvasions runs the shared
+// evasion corpus against each command the publication gate must find running.
+// The gate guards the credential that publishes a release, so a comment, a
+// heredoc body, an unrun branch or a longer command name must never satisfy it.
+func TestValidateReleaseWorkflowPublicationGateRejectsEvasions(t *testing.T) {
+	workflow := string(readReleaseWorkflow(t))
+	const recheck = "recheck hosted controls"
+	t.Run("release output verification", func(t *testing.T) {
+		RequireRejectsAllEvasions(t, workflow,
+			"          ./scripts/verify-release-outputs.sh \"${verify_args[@]}\"",
+			"must run verify-release-outputs.sh", metadatautil.ValidateReleaseWorkflowPublicationGate)
+	})
+	t.Run("hosted controls audit", func(t *testing.T) {
+		RequireRejectsAllEvasions(t, workflow,
+			"          ./scripts/run-hosted-controls-audit.sh \"${GITHUB_REPOSITORY}\"",
+			recheck, metadatautil.ValidateReleaseWorkflowPublicationGate)
+	})
+	t.Run("credential unset", func(t *testing.T) {
+		RequireRejectsAllEvasions(t, workflow,
+			"          unset WORKCELL_HOSTED_CONTROLS_TOKEN",
+			recheck, metadatautil.ValidateReleaseWorkflowPublicationGate)
+	})
+	t.Run("preverified publisher", func(t *testing.T) {
+		RequireRejectsAllEvasions(t, workflow,
+			"          ./scripts/publish-github-release.sh \"${GITHUB_REF_NAME}\" \\\n"+
+				"            --immutable-releases-preverified-by-hosted-controls",
+			recheck, metadatautil.ValidateReleaseWorkflowPublicationGate)
+	})
+}
+
 func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T) {
 	workflow := string(readReleaseWorkflow(t))
 	decoys := []struct {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -192,6 +192,21 @@ func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T)
 			want: "copy both platform images",
 		},
 		{
+			name: "real commands hidden behind a quoted delimiter that desynchronises the queue",
+			old: "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout \\\n            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout \\\n            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n            amd64 arm64 >/dev/null",
+			decoy: "          : <<'A' \"text <<B\"\n" +
+				"          A\n" +
+				"          cat <<'PLAN' >/dev/null\n" +
+				"          B\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:amd64\n" +
+				"          oras cp --recursive --from-oci-layout --to-oci-layout dist/release-image:arm64\n" +
+				"          oras manifest index create --oci-layout dist/release-image amd64 arm64\n" +
+				"          PLAN",
+			want: "copy both platform images",
+		},
+		{
 			name:  "copies disabled with their destinations moved into inline comments",
 			old:   "          oras cp --recursive --from-oci-layout \\\n            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n            --to-oci-layout dist/release-image:amd64",
 			decoy: "          oras cp --recursive --from-oci-layout || true # --to-oci-layout dist/release-image:amd64",

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -118,6 +118,31 @@ func TestValidateReleaseWorkflowAuthoritySplit(t *testing.T) {
 	requireReleaseAuthorityError(t, mutated, "exact privileged step contract")
 }
 
+// TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions runs the shared
+// evasion corpus against each command the release assembly step must run. Both
+// anchors of validateReleaseAssembly are covered, so a parser change that
+// stops reading one of them fails here rather than in review.
+func TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions(t *testing.T) {
+	workflow := string(readReleaseWorkflow(t))
+	t.Run("platform copies", func(t *testing.T) {
+		RequireRejectsAllEvasions(t, workflow,
+			"          oras cp --recursive --from-oci-layout \\\n"+
+				"            \"dist/image-amd64/layout@${AMD64_DIGEST}\" \\\n"+
+				"            --to-oci-layout dist/release-image:amd64\n"+
+				"          oras cp --recursive --from-oci-layout \\\n"+
+				"            \"dist/image-arm64/layout@${ARM64_DIGEST}\" \\\n"+
+				"            --to-oci-layout dist/release-image:arm64",
+			"copy both platform images", metadatautil.ValidateReleaseWorkflowAuthoritySplit)
+	})
+	t.Run("multi-arch index", func(t *testing.T) {
+		RequireRejectsAllEvasions(t, workflow,
+			"          oras manifest index create --oci-layout \\\n"+
+				"            \"dist/release-image:${GITHUB_REF_NAME}\" \\\n"+
+				"            amd64 arm64 >/dev/null",
+			"assemble the multi-arch index", metadatautil.ValidateReleaseWorkflowAuthoritySplit)
+	})
+}
+
 func TestValidateReleaseWorkflowAuthoritySplitRejectsCommentDecoys(t *testing.T) {
 	workflow := string(readReleaseWorkflow(t))
 	decoys := []struct {

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -97,6 +97,7 @@ func TestValidateReleaseWorkflowPublicationGate(t *testing.T) {
 		{name: "unsets audit token", old: "unset WORKCELL_HOSTED_CONTROLS_TOKEN", replacement: "true", want: "unset its credential"},
 		{name: "audits the repository and nothing else", old: "run-hosted-controls-audit.sh \"${GITHUB_REPOSITORY}\"", replacement: "run-hosted-controls-audit.sh wrong \"${GITHUB_REPOSITORY}\" || true", want: "recheck hosted controls"},
 		{name: "explicit handoff", old: "--immutable-releases-preverified-by-hosted-controls", replacement: "--other", want: "explicit preverified publisher"},
+		{name: "preverified flag in the position the publisher reads", old: "\"${GITHUB_REF_NAME}\" \\\n            --immutable-releases-preverified-by-hosted-controls \\\n            dist/workcell.tar.gz", replacement: "\"${GITHUB_REF_NAME}\" \\\n            dist/workcell.tar.gz \\\n            --immutable-releases-preverified-by-hosted-controls", want: "explicit preverified publisher"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mutated := strings.Replace(workflow, tc.old, tc.replacement, 1)

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -162,8 +162,11 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 			// it would let the step publish on that refusal, so a membership
 			// test over its arguments is not enough.
 			len(audit[0].Args) != 1 || audit[0].Args[0] != "${GITHUB_REPOSITORY}" ||
-			!slices.Contains(publish[0].Args, "${GITHUB_REF_NAME}") ||
-			!slices.Contains(publish[0].Args, "--immutable-releases-preverified-by-hosted-controls") {
+			// The publisher reads the preverification flag only as the word
+			// straight after the tag. Later it is an asset name instead, and
+			// the publisher is told the release was not preverified.
+			len(publish[0].Args) < 2 || publish[0].Args[0] != "${GITHUB_REF_NAME}" ||
+			publish[0].Args[1] != "--immutable-releases-preverified-by-hosted-controls" {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
 		}
 		// All three run, so compare the positions the parser proves rather

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -215,12 +215,12 @@ var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 func commandArgs(script, command string) [][]string {
 	var invocations [][]string
 	var current strings.Builder
-	var heredoc string
+	var heredocs []string
 	for line := range strings.Lines(script) {
 		trimmed := strings.TrimSpace(line)
-		if heredoc != "" {
-			if trimmed == heredoc {
-				heredoc = ""
+		if len(heredocs) > 0 {
+			if trimmed == heredocs[0] {
+				heredocs = heredocs[1:]
 			}
 			continue
 		}
@@ -235,8 +235,10 @@ func commandArgs(script, command string) [][]string {
 		current.Reset()
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		if match := heredocPattern.FindStringSubmatch(strings.ReplaceAll(logical, "<<<", " ")); match != nil {
-			heredoc = cmp.Or(match[1], match[2], match[3])
+		// Every delimiter on the line opens a body, and bash reads them in the
+		// order they appear, so they are queued rather than overwritten.
+		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
+			heredocs = append(heredocs, cmp.Or(match[1], match[2], match[3]))
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -157,16 +157,15 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		unset := ShellInvocations(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
 		publish := ShellInvocations(step.Run, publishGitHubReleaseScript)
 		if len(audit) == 0 || len(unset) == 0 || len(publish) == 0 ||
-			!slices.Contains(audit[0], "${GITHUB_REPOSITORY}") ||
-			!slices.Contains(publish[0], "${GITHUB_REF_NAME}") ||
-			!slices.Contains(publish[0], "--immutable-releases-preverified-by-hosted-controls") {
+			!slices.Contains(audit[0].Args, "${GITHUB_REPOSITORY}") ||
+			!slices.Contains(publish[0].Args, "${GITHUB_REF_NAME}") ||
+			!slices.Contains(publish[0].Args, "--immutable-releases-preverified-by-hosted-controls") {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
 		}
-		// All three run, so their written order is the order bash reaches them.
-		auditIndex := strings.Index(step.Run, auditHostedControlsScript)
-		unsetIndex := strings.Index(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
-		publishIndex := strings.Index(step.Run, publishGitHubReleaseScript)
-		if unsetIndex <= auditIndex || publishIndex <= unsetIndex {
+		// All three run, so compare the positions the parser proves rather
+		// than where the three names first appear in the text: a comment can
+		// name them in this order while the step mutates the release first.
+		if unset[0].Position <= audit[0].Position || publish[0].Position <= unset[0].Position {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
 		}
 		return nil
@@ -197,9 +196,9 @@ func validateReleaseAssembly(document workflowDocument) error {
 	steps := document.Jobs["release"].Steps
 	if !slices.ContainsFunc(steps, func(step workflowStep) bool {
 		var targets []string
-		for _, args := range ShellInvocations(step.Run, "oras cp --recursive --from-oci-layout") {
-			if at := slices.Index(args, "--to-oci-layout"); at >= 0 && at+1 < len(args) {
-				targets = append(targets, args[at+1])
+		for _, invocation := range ShellInvocations(step.Run, "oras cp --recursive --from-oci-layout") {
+			if at := slices.Index(invocation.Args, "--to-oci-layout"); at >= 0 && at+1 < len(invocation.Args) {
+				targets = append(targets, invocation.Args[at+1])
 			}
 		}
 		return slices.Contains(targets, "dist/release-image:amd64") &&

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -4,7 +4,6 @@
 package metadatautil
 
 import (
-	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -187,7 +186,7 @@ func validateReleaseAssembly(document workflowDocument) error {
 	steps := document.Jobs["release"].Steps
 	if !slices.ContainsFunc(steps, func(step workflowStep) bool {
 		var targets []string
-		for _, args := range commandArgs(step.Run, "oras cp --recursive --from-oci-layout") {
+		for _, args := range ShellInvocations(step.Run, "oras cp --recursive --from-oci-layout") {
 			if at := slices.Index(args, "--to-oci-layout"); at >= 0 && at+1 < len(args) {
 				targets = append(targets, args[at+1])
 			}
@@ -198,59 +197,11 @@ func validateReleaseAssembly(document workflowDocument) error {
 		return errors.New("release job must copy both platform images into the release OCI layout it indexes")
 	}
 	if !slices.ContainsFunc(steps, func(step workflowStep) bool {
-		return len(commandArgs(step.Run, "oras manifest index create --oci-layout")) > 0
+		return len(ShellInvocations(step.Run, "oras manifest index create --oci-layout")) > 0
 	}) {
 		return errors.New("release job must assemble the multi-arch index in an OCI layout")
 	}
 	return nil
-}
-
-// heredocPattern consumes quoted words before it reads a redirection, so that
-// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
-// third alternative captures, and it captures the delimiter it opens.
-var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
-
-var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
-
-// commandArgs returns the arguments of each invocation of command in script. It
-// joins continuations and drops comments, inline ones included, and heredoc bodies,
-// so no decoy text counts as a command and one call cannot satisfy a two-call rule.
-func commandArgs(script, command string) [][]string {
-	var invocations [][]string
-	var current strings.Builder
-	var heredocs []string
-	for line := range strings.Lines(script) {
-		trimmed := strings.TrimSpace(line)
-		if len(heredocs) > 0 {
-			if trimmed == heredocs[0] {
-				heredocs = heredocs[1:]
-			}
-			continue
-		}
-		if current.Len() > 0 {
-			current.WriteString(" ")
-		}
-		current.WriteString(strings.TrimSpace(strings.TrimSuffix(trimmed, "\\")))
-		if strings.HasSuffix(trimmed, "\\") {
-			continue
-		}
-		logical := strings.TrimSpace(inlineComment.ReplaceAllString(current.String(), ""))
-		current.Reset()
-		// Here-strings are blanked first so that a redirection such as
-		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
-		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten. A match
-		// with no capture is a consumed quoted word, not a redirection.
-		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
-				heredocs = append(heredocs, delimiter)
-			}
-		}
-		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
-			invocations = append(invocations, strings.Fields(rest))
-		}
-	}
-	return invocations
 }
 
 func validateUnprivilegedReleaseJobs(document workflowDocument) error {

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -78,6 +78,14 @@ func CollectWorkflowJobNames(content []byte) ([]string, error) {
 // gate requires the independent verification job to execute.
 const verifyReleaseOutputsScript = "./scripts/verify-release-outputs.sh"
 
+// auditHostedControlsScript and publishGitHubReleaseScript are the two commands
+// the final publication step must run, in that order, around the credential
+// unset that separates them.
+const (
+	auditHostedControlsScript  = "./scripts/run-hosted-controls-audit.sh"
+	publishGitHubReleaseScript = "./scripts/publish-github-release.sh"
+)
+
 // ValidateReleaseWorkflowPublicationGate keeps the privileged hosted-controls
 // credential in a minimal final job and requires its fresh check to complete
 // immediately before the default-token publisher runs.
@@ -106,22 +114,12 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		verifyJob.Permissions["packages"] != "read" {
 		return errors.New("release output verification job must grant only read permissions for artifacts, attestations, contents, and packages")
 	}
-	verificationFound := false
-	for _, step := range verifyJob.Steps {
-		// Match the script only as the start of a statement, so an inert
-		// mention (a comment, or an argument to echo) cannot satisfy the gate.
-		for _, line := range strings.Split(step.Run, "\n") {
-			statement := strings.TrimLeft(line, " \t")
-			if statement == verifyReleaseOutputsScript ||
-				strings.HasPrefix(statement, verifyReleaseOutputsScript+" ") {
-				verificationFound = true
-				break
-			}
-		}
-		if verificationFound {
-			break
-		}
-	}
+	// Read the invocation the shell really runs. A statement-start scan still
+	// accepts the script inside a heredoc body, an unrun branch or a function
+	// body, because each of those keeps the line that starts with it.
+	verificationFound := slices.ContainsFunc(verifyJob.Steps, func(step workflowStep) bool {
+		return len(ShellInvocations(step.Run, verifyReleaseOutputsScript)) > 0
+	})
 	if !verificationFound {
 		return errors.New("release output verification job must run verify-release-outputs.sh")
 	}
@@ -151,11 +149,24 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 			step.Env["GITHUB_TOKEN"] != "${{ github.token }}" {
 			return errors.New("final GitHub release publication step must receive the required hosted-controls token and separate default mutation token")
 		}
-		auditIndex := strings.Index(step.Run, `./scripts/run-hosted-controls-audit.sh "${GITHUB_REPOSITORY}"`)
+		// Each of the three must be an invocation the shell runs, not text that
+		// names it: a heredoc body, an unrun branch or a longer option leaves
+		// the text in place while the credential stays live. The argument
+		// checks compare whole words, so a longer name is a different command.
+		audit := ShellInvocations(step.Run, auditHostedControlsScript)
+		unset := ShellInvocations(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
+		publish := ShellInvocations(step.Run, publishGitHubReleaseScript)
+		if len(audit) == 0 || len(unset) == 0 || len(publish) == 0 ||
+			!slices.Contains(audit[0], "${GITHUB_REPOSITORY}") ||
+			!slices.Contains(publish[0], "${GITHUB_REF_NAME}") ||
+			!slices.Contains(publish[0], "--immutable-releases-preverified-by-hosted-controls") {
+			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
+		}
+		// All three run, so their written order is the order bash reaches them.
+		auditIndex := strings.Index(step.Run, auditHostedControlsScript)
 		unsetIndex := strings.Index(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
-		publishIndex := strings.Index(step.Run, `./scripts/publish-github-release.sh "${GITHUB_REF_NAME}"`)
-		if auditIndex < 0 || unsetIndex <= auditIndex || publishIndex <= unsetIndex ||
-			!strings.Contains(step.Run[publishIndex:], "--immutable-releases-preverified-by-hosted-controls") {
+		publishIndex := strings.Index(step.Run, publishGitHubReleaseScript)
+		if unsetIndex <= auditIndex || publishIndex <= unsetIndex {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")
 		}
 		return nil

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -205,7 +205,10 @@ func validateReleaseAssembly(document workflowDocument) error {
 	return nil
 }
 
-var heredocPattern = regexp.MustCompile(`<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+// heredocPattern consumes quoted words before it reads a redirection, so that
+// a << inside an argument such as "text <<B" cannot open a delimiter. Only the
+// third alternative captures, and it captures the delimiter it opens.
+var heredocPattern = regexp.MustCompile(`'[^']*'|"(?:[^"\\]|\\.)*"|<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
 
 var inlineComment = regexp.MustCompile(`(^|\s)#.*$`)
 
@@ -236,9 +239,12 @@ func commandArgs(script, command string) [][]string {
 		// Here-strings are blanked first so that a redirection such as
 		// <<<"${value}" is not read as a heredoc opening the delimiter ${value}.
 		// Every delimiter on the line opens a body, and bash reads them in the
-		// order they appear, so they are queued rather than overwritten.
+		// order they appear, so they are queued rather than overwritten. A match
+		// with no capture is a consumed quoted word, not a redirection.
 		for _, match := range heredocPattern.FindAllStringSubmatch(strings.ReplaceAll(logical, "<<<", " "), -1) {
-			heredocs = append(heredocs, cmp.Or(match[1], match[2], match[3]))
+			if delimiter := cmp.Or(match[1], match[2], match[3]); delimiter != "" {
+				heredocs = append(heredocs, delimiter)
+			}
 		}
 		if rest, found := strings.CutPrefix(logical, command); found && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			invocations = append(invocations, strings.Fields(rest))

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -157,7 +157,11 @@ func ValidateReleaseWorkflowPublicationGate(workflowText string) error {
 		unset := ShellInvocations(step.Run, "unset WORKCELL_HOSTED_CONTROLS_TOKEN")
 		publish := ShellInvocations(step.Run, publishGitHubReleaseScript)
 		if len(audit) == 0 || len(unset) == 0 || len(publish) == 0 ||
-			!slices.Contains(audit[0].Args, "${GITHUB_REPOSITORY}") ||
+			// The audit takes the repository and nothing else. It rejects a
+			// second argument before it audits anything, and a || true after
+			// it would let the step publish on that refusal, so a membership
+			// test over its arguments is not enough.
+			len(audit[0].Args) != 1 || audit[0].Args[0] != "${GITHUB_REPOSITORY}" ||
 			!slices.Contains(publish[0].Args, "${GITHUB_REF_NAME}") ||
 			!slices.Contains(publish[0].Args, "--immutable-releases-preverified-by-hosted-controls") {
 			return errors.New("final GitHub release publication step must recheck hosted controls, unset its credential, then invoke the explicit preverified publisher")

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -193,7 +193,7 @@ var goHelperMutations = []mutationCase{
 	},
 	{
 		relativePath: "internal/metadatautil/workflows.go",
-		original:     `			!slices.Contains(publish[0], "--immutable-releases-preverified-by-hosted-controls") {`,
+		original:     `			publish[0].Args[1] != "--immutable-releases-preverified-by-hosted-controls" {`,
 		replacement:  `			!strings.Contains(step.Run, "--immutable-releases-preverified-by-hosted-controls") {`,
 		label:        "publication gate whole-word publisher contract",
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestValidateReleaseWorkflowPublicationGateRejectsEvasions", "-count=1"),

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -177,6 +177,20 @@ var goHelperMutations = []mutationCase{
 		label:        "alias probe canonical parity",
 		command:      goCmd("test", "./internal/metadatautil", "-run", "Test(ValidateOperatorContract|LoadOperatorContract|StripManpageFormatting)", "-count=1"),
 	},
+	{
+		relativePath: "internal/metadatautil/shell_invocations.go",
+		original:     `			pending = true`,
+		replacement:  `			pending = false`,
+		label:        "heredoc body exclusion for anchored validators",
+		command:      goCmd("test", "./internal/metadatautil", "-run", "TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions", "-count=1"),
+	},
+	{
+		relativePath: "internal/metadatautil/validator_anchoring.go",
+		original:     `	if anchors != corpus {`,
+		replacement:  `	if false && anchors != corpus {`,
+		label:        "validator evasion corpus registration parity",
+		command:      goCmd("test", "./internal/metadatautil", "-run", "TestCheckValidatorAnchoring", "-count=1"),
+	},
 }
 
 var rustMutations = []mutationCase{

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -191,6 +191,13 @@ var goHelperMutations = []mutationCase{
 		label:        "validator evasion corpus registration parity",
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestCheckValidatorAnchoring", "-count=1"),
 	},
+	{
+		relativePath: "internal/metadatautil/workflows.go",
+		original:     `			!slices.Contains(publish[0], "--immutable-releases-preverified-by-hosted-controls") {`,
+		replacement:  `			!strings.Contains(step.Run, "--immutable-releases-preverified-by-hosted-controls") {`,
+		label:        "publication gate whole-word publisher contract",
+		command:      goCmd("test", "./internal/metadatautil", "-run", "TestValidateReleaseWorkflowPublicationGateRejectsEvasions", "-count=1"),
+	},
 }
 
 var rustMutations = []mutationCase{

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -380,7 +380,7 @@ func writeValidatorFixtureFiles(t *testing.T, root string) {
 	t.Helper()
 	writeExecutable(t, filepath.Join(root, "scripts", "lib"), "trusted-docker-client.sh", "#!/bin/bash\nsetup_workcell_trusted_docker_client() { :; }\ncleanup_workcell_trusted_docker_client() { :; }\nselect_workcell_docker_context() { DOCKER_CONTEXT_NAME=fixture; }\n")
 	writeExecutable(t, filepath.Join(root, "scripts", "lib"), "go-run-env.sh", "#!/bin/bash\nrun_go_in_repo() { :; }\n")
-	for _, name := range []string{"check-pinned-inputs.sh", "check-doc-support-matrix-fields.sh", "check-public-contract.sh", "check-doc-links.sh"} {
+	for _, name := range []string{"check-pinned-inputs.sh", "check-validator-anchoring.sh", "check-doc-support-matrix-fields.sh", "check-public-contract.sh", "check-doc-links.sh"} {
 		writeExecutable(t, filepath.Join(root, "scripts"), name, "#!/bin/bash\nexit 0\n")
 	}
 	writeExecutable(t, filepath.Join(root, "scripts", "ci"), "build-validator-image.sh", "#!/bin/bash\nprintf '%s\\n' \"${WORKCELL_VALIDATOR_IMAGE}\" >\"${WORKCELL_TEST_BUILDER_INPUT_LOG}\"\n[[ \"${WORKCELL_TEST_BUILD_STATUS}\" -eq 0 ]] || exit \"${WORKCELL_TEST_BUILD_STATUS}\"\nif [[ \"${WORKCELL_TEST_WRONG_REFERENCE}\" == true ]]; then echo wrong/reference:latest; else printf '%s\\n' \"${WORKCELL_VALIDATOR_IMAGE}\"; fi\n")

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 23
+  "expected_mutants": 24
 }

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 21
+  "expected_mutants": 23
 }

--- a/scripts/check-validator-anchoring.sh
+++ b/scripts/check-validator-anchoring.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -p
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "check-validator-anchoring-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GO_BIN="${WORKCELL_GO_BIN:-}"
+
+resolve_go_bin() {
+  if [[ -n "${GO_BIN}" && -x "${GO_BIN}" ]]; then
+    return 0
+  fi
+  if GO_BIN="$(command -v go 2>/dev/null)"; then
+    return 0
+  fi
+  for candidate in \
+    /opt/homebrew/bin/go \
+    /usr/local/go/bin/go \
+    /usr/local/bin/go \
+    /usr/bin/go; do
+    if [[ -x "${candidate}" ]]; then
+      GO_BIN="${candidate}"
+      return 0
+    fi
+  done
+  echo "Missing required tool: go" >&2
+  exit 1
+}
+
+resolve_go_bin
+
+(cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-citools check-validator-anchoring "${ROOT_DIR}")

--- a/scripts/check-validator-anchoring.sh
+++ b/scripts/check-validator-anchoring.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -p
 # shellcheck source=scripts/lib/trusted-entrypoint.sh
+# shellcheck disable=SC2312 # repo-wide bootstrap; the path is the running script's own directory
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 
 if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then

--- a/scripts/ci/job-validate.sh
+++ b/scripts/ci/job-validate.sh
@@ -97,6 +97,9 @@ fi
 echo "[ci/validate] pinned input policy"
 "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
 
+echo "[ci/validate] validator evasion corpus registration"
+"${ROOT_DIR}/scripts/check-validator-anchoring.sh"
+
 echo "[ci/validate] GitHub macOS release test runners"
 "${ROOT_DIR}/scripts/verify-github-macos-release-test-runners.sh" macos-26 macos-15
 

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -157,6 +157,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-pr-shape.sh"
   "${ROOT_DIR}/scripts/check-repo-readiness.sh"
   "${ROOT_DIR}/scripts/check-pinned-inputs.sh"
+  "${ROOT_DIR}/scripts/check-validator-anchoring.sh"
   "${ROOT_DIR}/scripts/check-public-contract.sh"
   "${ROOT_DIR}/scripts/certify-c3-parallel-sessions.sh"
   "${ROOT_DIR}/scripts/build-and-test.sh"


### PR DESCRIPTION
No longer stacked. #688 merged as `d1792177`, and `a7d363a1` merges `main` into this
branch, so the cherry-picks it was stacked on are deduped and the diff against `main` is
this unit's own content. Review the whole diff.

Two fixes #688 landed after the stack point were regressed by this branch's parser
rewrite and are restored in that merge, so no bypass #688 closed reopens: a line
continuation joins its halves with nothing between them and only an unescaped backslash
continues the line, and a quoted command substitution drops its line's words. This
branch's quote stack is kept, so the `)` that closes a substitution still restores the
quote around it. Reverting either restoration fails the tests #688 added for it, checked
one at a time.

This is unit S4b+c of the review-history mining series. S4a is #688.

## Summary

Two counters against the largest mined class of review findings.

**A shared evasion corpus** (`internal/metadatautil/evasions_test.go`). Twenty
rows, one for each bypass that review found against a validator that read file
content as text: full-line comment, inline comment after `|| true`, echo-quoted
text, single heredoc, two heredocs on one line, arithmetic shift, here-string,
line continuation, quoted word that spans a newline, indented heredoc terminator,
uncalled function definition, unreachable branch, escaped closer in a quoted span,
conditional right-hand side, conditional across a line break, definition brace on
the next line, heredoc opened as a quote closes, prefix extension of a long
option, `exit` before the command, and placement outside the job that must run
the command. Each row rewrites the artifact so that the anchored
command no longer runs while text that names it stays in the file. A validator
must reject every row.

`RequireRejectsAllEvasions` runs the corpus. It takes the artifact, the exact text
of the anchored command, and the error text the validator must report. The error
text keeps a row honest: a rewrite that only broke the file syntax would otherwise
pass for the wrong reason.

`ValidateReleaseWorkflowAuthoritySplit` now runs the corpus against both commands
its assembly step must run. A new validator gets twenty negative fixtures for three
lines of test code.

**A registry parity check** (`scripts/check-validator-anchoring.sh`). It requires
one corpus run for each call of the shared shell-invocation parser. Without it, a
new anchored validator ships with no negative fixture and learns the lesson in
review. The check counts call sites with a text scan and does not read the syntax
tree, the choice this package already records for `structJSONFields`. Comments
and string literals are blanked before the scan, so a mention of a call is not
counted as a call.

The check runs the `check-validator-anchoring` subcommand of `workcell-citools`.
It is registered in `scripts/validate-repo.sh` and `scripts/ci/job-validate.sh`.

Two mutation rows cover the new content validators. `policy/mutation-score-policy.json`
goes from 21 to 23 expected mutants.

### Mined finding classes this defeats

- **Class D, validator anchoring (25 findings, 15 accepted).** Every corpus row is
  a bypass from this class. The corpus makes the negative fixture that `AGENTS.md`
  already requires cheap, and the parity check makes it mandatory.
- **Class G, mutation gaps (22 findings, 12 accepted).** A decoy corpus is mutation
  testing for a validator. None of the 21 recorded mutants touched `workflows.go`;
  two now do.

### Notes

- The corpus is in the test package so that `testing` stays out of the shipped
  tool's dependency graph. Move it to a non-test file when a validator outside
  `internal/metadatautil` needs it.
- The one-line registrations in `scripts/validate-repo.sh` and
  `scripts/ci/job-validate.sh` may conflict with the S1/S3/S2 and S8 pull requests,
  which change other parts of the same files.
- The parity check counts parser call sites against corpus runs. The mining report
  proposed a count of every exported `Validate*`/`Check*` function instead. There
  are 73 of those, and most read no shell content, so that count would have needed
  a second list by hand.

## Testing

- `go build ./...`
- `go test ./internal/metadatautil/ ./cmd/workcell-citools/ ./internal/mutation/ ./internal/workcellhardening/ -count=1` — pass.
- `go test ./internal/testkit/ -run 'TestValidationGatesLintAllScenarioShellScripts|TestValidateRepoExecutesPublicContractHistoryGate|TestDevQuickCheckStaysBoundedToFastLocalWork' -count=1` — pass.
- `shellcheck -x scripts/check-validator-anchoring.sh scripts/validate-repo.sh scripts/ci/job-validate.sh` — clean.
- `./scripts/check-validator-anchoring.sh` — green. `--self-entrypoint-probe` returns
  `check-validator-anchoring-entrypoint-ok`.

### Review round 1

Codex reported three P1 findings on `f9288ce`. All three were reproduced and all
three are fixed.

Two were bypasses of the parser this branch anchors on, both confirmed by probe
before any change:

- A quoted word that spans a newline. `: "` then the two `oras cp` lines then `"`
  runs no command in bash, but the parser read each line on its own and accepted
  the release job. `ShellInvocations` now reads the lines after an unclosed quote
  as text, up to the line that closes it.
- An indented heredoc terminator. `<<'PLAN'` followed by an indented `PLAN`
  closed the parser body early while bash keeps reading. A pending heredoc now
  records its delimiter and its `<<-` form, and the terminator must match exactly.

Closing the first one exposed an older defect: the `$(` branch dropped the
enclosing quote, so a later `)"` line looked like a fresh open quote. A command
substitution now suspends its quote on a stack that persists across lines.

Both bypasses are permanent corpus rows. The third finding is answered in its
thread.

### Review round 2

Codex reported two more P1 findings on `3a1198b`. Both were reproduced and both
are fixed.

- An uncalled function definition. `never_called() {` around the two `oras cp`
  lines defines a function and runs nothing, but the parser counted the body
  lines. `ShellInvocations` now tracks brace nesting and skips a definition body.
  A called function is skipped too, which errs toward rejecting a workflow rather
  than accepting one. Now a corpus row.
- Block comment and raw literal state cleared at every newline in the round 1
  comment stripping, so a multi-line comment could still inflate the corpus
  count. A newline now clears only the line-comment state.

The round 1 table cases for the stripping were placed in the wrong file kind and
proved nothing. They are corrected: each case now sits in the file kind whose
needle is counted there. Reverting the stripping fails five cases.

### Positive control for the corpus

`validateReleaseAssembly` was temporarily replaced by a whole-file `strings.Contains`
scan, the defect the mined findings describe. All 40 subtests failed, 20 rows for
each of the two anchors. All 40 pass against the anchored validator. The corpus
therefore proves the anchoring, not the file syntax.

### Negative proof for the parity check

The `multi-arch index` corpus run was removed from
`TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions`. The check failed:

```
validator anchoring parity: 2 call(s) of ShellInvocations but 1 run(s) of the
shared evasion corpus; every anchored validator needs one RequireRejectsAllEvasions run
```

The run was restored and the check returned to green. `TestCheckValidatorAnchoring`
covers the same states against a temporary tree, including a comment and a string
literal that name a call.

### Mutation rows

Each new row was applied by hand and the named test killed it.

- `pending = true` to `pending = false` in `shell_invocations.go`: 10 corpus subtests fail.
- Removing the function-definition skip: 2 corpus subtests fail.
- Removing the comment and literal stripping: 5 `TestCheckValidatorAnchoring` cases fail.
- `if anchors != corpus` to `if false && anchors != corpus`: 2 subtests of
  `TestCheckValidatorAnchoring` fail.

### Pre-existing failures, not from this branch

`go run ./cmd/workcell-citools run-mutation-tests` does not finish on this branch or
on `main`. Two causes, both older than this work:

- `internal/mutation/runner.go` row `injection policy digest binding` anchors on
  `Sha256:   file.Sha256,`, which is absent from
  `internal/injection/render_policy_load.go` on `main`.
- `tests::path_has_root_prefix_requires_boundary_match` fails in the Rust crate.

Both are outside this unit and are left for a separate change.

### Review round 3

A third review ran automatically on the push. Four findings, three P1 and one P2,
all reproduced and all fixed.

- Commands inside `if false; then ... fi` were counted. `ShellInvocations` now
  tracks compound-command nesting and reads no invocation inside one. This takes
  the finding's second option, rejecting what the parser cannot prove executes,
  so a command inside a conditional is now invisible and the workflow is rejected
  rather than accepted. The release job runs all three commands unconditionally.
- Arguments ran past a control operator, so `oras cp … || true; : --to-oci-layout
  <target>` donated the destination to the invocation before it. This defeated the
  target extraction, not merely the presence check. `shellWords` now emits `;`,
  `&&`, `||`, `|`, `|&` and `&` as words and each logical line is split into
  commands at them. An `&` after `>` or `<` stays part of the word, so `2>&1`
  survives.
- An escaped quote closed a multi-line quoted span. The skip now honours the
  escape rules of the span it is in.
- The `func ` line skip in the parity counter discarded a call in a one-line body.
  A declaration line is now read from after its first brace.

One existing fixture changed with the operator fix: `||` and `true` are no longer
reported as arguments of the invocation before them, because they are not.

### Review rounds 4 to 7

Four more automatic rounds followed, with sixteen more findings. Round 4: a conditional right-hand side of `&&` or `||`, a definition
whose brace opens on the next line, a heredoc opened on the line that closes a
quoted span, a step that redefines the anchored command itself, and a second call
on one line escaping the parity count. Round 5: a list operator at the end of a
line, and `<<` inside an arithmetic expansion read as a heredoc operator. Round 6:
a closing backtick that did not restore the quote its substitution suspended, an
`exit` before the required commands, an `alias` over the anchored name, and an
identifier-prefix match in the parity counter. Round 7: the phantom commit, and
the two quoting cases scheduled above.

The last of those was a false rejection rather than a bypass, and it had made the
`arithmetic shift` corpus row pass for the wrong reason: the runaway delimiter was
swallowing the required commands, not the heredoc the row is about. The row now
proves what it claims.

`ShellInvocations` now reports an invocation only where the script proves the
command runs. It skips a heredoc body, a quoted word that spans lines, a function
definition body, a compound-command body, and the conditional side of `&&` or
`||`, it ends an invocation's arguments at a control operator, and it reports
nothing at all once the anchored name has been redefined.

### Continuous integration

Two CI failures were fixed along the way.

`TestValidatorJobOwnershipLifecycle` builds a fixture repository from a fixed
list of stub check scripts, and the new script was not in it, so
`job-validate.sh` exited 127. The script is now in that list.

`Validate repository` then failed on SC2312 after #686 merged to main and turned
on `check-extra-masked-returns` for `scripts/check-*.sh`. The new script now
carries the same recorded disable on its entrypoint bootstrap line that every
sibling check script carries.

All eleven checks pass, and the validate log shows the new step running:

```
[ci/validate] validator evasion corpus registration
```

### Review result

Seven Codex rounds ran: two requested, five started automatically on a push.
Twenty-two findings. Every one was reproduced by probe before any disposition.

- **Nineteen fixed.** Each has a fixture or a corpus row that fails without its fix.
- **One rebutted.** A finding asked for a commit `82bdc661…` to be re-signed.
  `git cat-file -e` fails on it and `GET /commits/82bdc661…` returns HTTP 422, so
  the object has never existed. All twenty-two commits on this branch verify:
  `git log --format='%G?'` returns `G` for every one.
- **Two scheduled.** See below.

All eleven checks pass on the head. Eighteen threads are resolved; four are open
on purpose.

### Scheduled for the next unit

Four findings are correct and are not fixed here, because this branch is at the
repository shape gate: 1150 added plus 45 deleted against its merge base, and
`scripts/check-pr-shape.sh` allows 1200.

Three of them are one defect. `shellWords` returns plain strings, so a word that
was quoted cannot be told from one that was not, and the operator split, the
reserved-word lookup and the heredoc delimiter all then read text as syntax:
`: ";" oras cp …`, a quoted `"fi"` inside an unreachable branch, and `<<$'PLAN'`.
The fourth is conditional status that does not survive a command group,
`false && { … }`.

They belong with `internal/metadatautil/shell_invocations.go`, the file unit S4a
(#688) owns, and their threads are left open so the work stays visible. Scheduled
work is not a rebuttal and not a fix.

