### PR TITLE
!B Clear Bash startup variables for runtime script children

### DIFF
--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -491,11 +491,20 @@ var runtimeStartupPrologueScripts = []string{
 	"runtime-user.sh",
 }
 
-const runtimeStartupClearLine = "unset BASH_ENV ENV"
+const (
+	runtimeStartupClearLine = "unset BASH_ENV ENV"
+	// runtimeStartupGuardBlock must follow runtimeStartupClearLine immediately:
+	// unset fails on a variable a planted startup file already marked readonly,
+	// and errexit is not on yet, so the survival check is what stops the script.
+	runtimeStartupGuardBlock = "[[ -z \"${BASH_ENV+set}${ENV+set}\" ]] || {\n" +
+		"  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2\n" +
+		"  exit 2\n" +
+		"}\n"
+)
 
 // runtimeStartupPrologue returns the prologue of the named runtime script up to
-// and including its runtimeStartupClearLine, and fails when the script runs any
-// command before that line.
+// and including its runtimeStartupGuardBlock, and fails when the script runs any
+// command before the clearing pair or separates the two.
 func runtimeStartupPrologue(tb testing.TB, name string) string {
 	tb.Helper()
 
@@ -505,10 +514,15 @@ func runtimeStartupPrologue(tb testing.TB, name string) string {
 		tb.Fatalf("read %s: %v", path, err)
 	}
 	lines := strings.Split(string(body), "\n")
+	guardLines := strings.Count(runtimeStartupGuardBlock, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == runtimeStartupClearLine {
-			return strings.Join(lines[:i+1], "\n") + "\n"
+			end := i + 1 + guardLines
+			if end > len(lines) || strings.Join(lines[i+1:end], "\n")+"\n" != runtimeStartupGuardBlock {
+				tb.Fatalf("%s does not follow %q with the survival guard", name, runtimeStartupClearLine)
+			}
+			return strings.Join(lines[:end], "\n") + "\n"
 		}
 		if i > 0 && trimmed != "" && !strings.HasPrefix(trimmed, "#") {
 			tb.Fatalf("%s runs %q before clearing BASH_ENV/ENV", name, trimmed)
@@ -521,16 +535,23 @@ func runtimeStartupPrologue(tb testing.TB, name string) string {
 // runChildStartupProbe runs prologue as `bash <file>` — the way entrypoint.sh
 // and runtime-user.sh start their bash children — with BASH_ENV and ENV both
 // pointing at a planted startup file, and reports how many times that file was
-// sourced. The script's own shell always sources it once, because bypassing the
-// shebang means the file is read before the script's first line; a second
-// sourcing means the child bash read it too.
-func runChildStartupProbe(tb testing.TB, prologue string) int {
+// sourced and how the script exited. The script's own shell always sources it
+// once, because bypassing the shebang means the file is read before the script's
+// first line; a second sourcing means the child bash read it too. When pin is
+// set the planted file also marks both variables readonly, which is what an
+// attacker who already reached that first sourcing would do to survive the
+// unset.
+func runChildStartupProbe(tb testing.TB, prologue string, pin bool) (sourced, exitCode int) {
 	tb.Helper()
 
 	dir := tb.TempDir()
 	log := filepath.Join(dir, "sourced.log")
 	planted := filepath.Join(dir, "planted.sh")
-	if err := os.WriteFile(planted, []byte("echo sourced >>'"+log+"'\n"), 0o600); err != nil {
+	plantedBody := "echo sourced >>'" + log + "'\n"
+	if pin {
+		plantedBody += "readonly BASH_ENV ENV\n"
+	}
+	if err := os.WriteFile(planted, []byte(plantedBody), 0o600); err != nil {
 		tb.Fatalf("write planted startup file: %v", err)
 	}
 	script := filepath.Join(dir, "prologue.sh")
@@ -540,20 +561,26 @@ func runChildStartupProbe(tb testing.TB, prologue string) int {
 
 	cmd := exec.Command("bash", script)
 	cmd.Env = append(os.Environ(), "BASH_ENV="+planted, "ENV="+planted)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		tb.Fatalf("prologue probe failed: %v (%s)", err, output)
-	}
-	body, err := os.ReadFile(log)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		tb.Fatalf("read sourcing log: %v", err)
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			tb.Fatalf("prologue probe failed: %v (%s)", err, output)
+		}
+		exitCode = exitErr.ExitCode()
 	}
-	return strings.Count(string(body), "sourced\n")
+	body, readErr := os.ReadFile(log)
+	if readErr != nil {
+		tb.Fatalf("read sourcing log: %v", readErr)
+	}
+	return strings.Count(string(body), "sourced\n"), exitCode
 }
 
 // TestRuntimeScriptProloguesClearBashStartupFilesForChildren pins the prologue
 // that keeps a plain-bash child of a runtime script from sourcing an
-// attacker-supplied BASH_ENV/ENV startup file, and carries its own negative
-// control: with the clearing line removed, the child sources the planted file.
+// attacker-supplied BASH_ENV/ENV startup file. Each case carries its own
+// negative control: drop the line under test and the child sources the planted
+// file.
 func TestRuntimeScriptProloguesClearBashStartupFilesForChildren(t *testing.T) {
 	t.Parallel()
 
@@ -562,12 +589,25 @@ func TestRuntimeScriptProloguesClearBashStartupFilesForChildren(t *testing.T) {
 			t.Parallel()
 
 			prologue := runtimeStartupPrologue(t, name)
-			if got := runChildStartupProbe(t, prologue); got != 1 {
-				t.Fatalf("%s: planted startup file sourced %d times, want 1 (the script's own shell only)", name, got)
+			if got, code := runChildStartupProbe(t, prologue, false); got != 1 || code != 0 {
+				t.Fatalf("%s: planted startup file sourced %d times (exit %d), want 1 and exit 0 (the script's own shell only)", name, got, code)
 			}
-			without := strings.Replace(prologue, runtimeStartupClearLine+"\n", "", 1)
-			if got := runChildStartupProbe(t, without); got != 2 {
-				t.Fatalf("%s: control without %q sourced the planted file %d times, want 2 (script and child)", name, runtimeStartupClearLine, got)
+			// The pre-change prologue: neither line present.
+			bare := strings.Replace(prologue, runtimeStartupGuardBlock, "", 1)
+			bare = strings.Replace(bare, runtimeStartupClearLine+"\n", "", 1)
+			if got, _ := runChildStartupProbe(t, bare, false); got != 2 {
+				t.Fatalf("%s: control without the clearing pair sourced the planted file %d times, want 2 (script and child)", name, got)
+			}
+
+			// A planted file that pins both variables readonly makes the unset
+			// fail while errexit is still off, so the guard has to stop the
+			// script before it starts a child.
+			if got, code := runChildStartupProbe(t, prologue, true); got != 1 || code != 2 {
+				t.Fatalf("%s: pinned startup file sourced %d times (exit %d), want 1 and exit 2 (refused before the child)", name, got, code)
+			}
+			withoutGuard := strings.Replace(prologue, runtimeStartupGuardBlock, "", 1)
+			if got, _ := runChildStartupProbe(t, withoutGuard, true); got != 2 {
+				t.Fatalf("%s: control without the survival guard sourced the pinned file %d times, want 2 (script and child)", name, got)
 			}
 		})
 	}

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -478,3 +478,97 @@ func TestCheckPRShapeCountsRenameDestinationArea(t *testing.T) {
 		t.Fatalf("check-pr-shape did not count both rename areas: %q", output)
 	}
 }
+
+// runtimeStartupPrologueScripts lists the runtime scripts whose prologue must
+// clear BASH_ENV and ENV. Callers start several of them as plain
+// `/bin/bash <script>`, which bypasses the shebang that would otherwise clear
+// the two variables, so each script has to clear them for its own children.
+var runtimeStartupPrologueScripts = []string{
+	"development-wrapper.sh",
+	"entrypoint.sh",
+	"home-control-plane.sh",
+	"provider-wrapper.sh",
+	"runtime-user.sh",
+}
+
+const runtimeStartupClearLine = "unset BASH_ENV ENV"
+
+// runtimeStartupPrologue returns the prologue of the named runtime script up to
+// and including its runtimeStartupClearLine, and fails when the script runs any
+// command before that line.
+func runtimeStartupPrologue(tb testing.TB, name string) string {
+	tb.Helper()
+
+	path := filepath.Join(repoRoot(tb), "runtime", "container", name)
+	body, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatalf("read %s: %v", path, err)
+	}
+	lines := strings.Split(string(body), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == runtimeStartupClearLine {
+			return strings.Join(lines[:i+1], "\n") + "\n"
+		}
+		if i > 0 && trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			tb.Fatalf("%s runs %q before clearing BASH_ENV/ENV", name, trimmed)
+		}
+	}
+	tb.Fatalf("%s prologue does not contain %q", name, runtimeStartupClearLine)
+	return ""
+}
+
+// runChildStartupProbe runs prologue as `bash <file>` — the way entrypoint.sh
+// and runtime-user.sh start their bash children — with BASH_ENV and ENV both
+// pointing at a planted startup file, and reports how many times that file was
+// sourced. The script's own shell always sources it once, because bypassing the
+// shebang means the file is read before the script's first line; a second
+// sourcing means the child bash read it too.
+func runChildStartupProbe(tb testing.TB, prologue string) int {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	log := filepath.Join(dir, "sourced.log")
+	planted := filepath.Join(dir, "planted.sh")
+	if err := os.WriteFile(planted, []byte("echo sourced >>'"+log+"'\n"), 0o600); err != nil {
+		tb.Fatalf("write planted startup file: %v", err)
+	}
+	script := filepath.Join(dir, "prologue.sh")
+	if err := os.WriteFile(script, []byte(prologue+"/bin/bash -c ':'\n"), 0o600); err != nil {
+		tb.Fatalf("write prologue script: %v", err)
+	}
+
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(), "BASH_ENV="+planted, "ENV="+planted)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		tb.Fatalf("prologue probe failed: %v (%s)", err, output)
+	}
+	body, err := os.ReadFile(log)
+	if err != nil {
+		tb.Fatalf("read sourcing log: %v", err)
+	}
+	return strings.Count(string(body), "sourced\n")
+}
+
+// TestRuntimeScriptProloguesClearBashStartupFilesForChildren pins the prologue
+// that keeps a plain-bash child of a runtime script from sourcing an
+// attacker-supplied BASH_ENV/ENV startup file, and carries its own negative
+// control: with the clearing line removed, the child sources the planted file.
+func TestRuntimeScriptProloguesClearBashStartupFilesForChildren(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range runtimeStartupPrologueScripts {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			prologue := runtimeStartupPrologue(t, name)
+			if got := runChildStartupProbe(t, prologue); got != 1 {
+				t.Fatalf("%s: planted startup file sourced %d times, want 1 (the script's own shell only)", name, got)
+			}
+			without := strings.Replace(prologue, runtimeStartupClearLine+"\n", "", 1)
+			if got := runChildStartupProbe(t, without); got != 2 {
+				t.Fatalf("%s: control without %q sourced the planted file %d times, want 2 (script and child)", name, runtimeStartupClearLine, got)
+			}
+		})
+	}
+}

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -218,13 +218,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/development-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/development-wrapper.sh",
-      "sha256": "2e6c4c65b86a166f7a963e390e85e3d43d963d90a0bf5a73d0f8456a36641a4a"
+      "sha256": "4bf01197880c128eeee84e3e6afbf8a6ed108ffe81e54b2c0a0f77511f352ca3"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/entrypoint.sh",
       "runtime_path": "/usr/local/libexec/workcell/entrypoint.sh",
-      "sha256": "49a33dc4b43c0d87090c2dcc0be78ffe8d9af14cd7832e7ad72c19c69dd386ef"
+      "sha256": "21683cbcaa6f7bbf3ea566d0dbe9fbc6ca53498f08e23d815853a3423203e251"
     },
     {
       "kind": "runtime-control-plane",
@@ -236,7 +236,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "f699292966cf737b9700008c090750319b23ab7dac617a4e236e82f2952e2b35"
+      "sha256": "a9eb5b0b7c7262301420610b02295e1a62b5cfe1890e439a5d3bfa2d8f9c1d7d"
     },
     {
       "kind": "runtime-control-plane",
@@ -254,7 +254,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "fdf553db0f799ec09d9e4e02a359f5f97bada6e3b0d18a94e9d191ecc6a3392b"
+      "sha256": "8d9cbd196006345c2d7ffa7d5be15b1faa5669d1ff96305865915afc43b454bb"
     },
     {
       "kind": "runtime-control-plane",
@@ -266,7 +266,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/runtime-user.sh",
       "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
-      "sha256": "b9a4bd99fd90f322f4f07dab9dae43b2f2787a27ad6dc65e11c2818e4c28193e"
+      "sha256": "24bdd17c4b6b1131277f4fa7baa82f3c66a561baead493af6538fbd1be770ae5"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/control-plane-manifest.json
+++ b/runtime/container/control-plane-manifest.json
@@ -218,13 +218,13 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/development-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/development-wrapper.sh",
-      "sha256": "4bf01197880c128eeee84e3e6afbf8a6ed108ffe81e54b2c0a0f77511f352ca3"
+      "sha256": "aad08269a3902aa7ccfb9d8ebd46deefb82009f09d042c42e4f50cc2b555818e"
     },
     {
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/entrypoint.sh",
       "runtime_path": "/usr/local/libexec/workcell/entrypoint.sh",
-      "sha256": "21683cbcaa6f7bbf3ea566d0dbe9fbc6ca53498f08e23d815853a3423203e251"
+      "sha256": "18131bad8cb1db1e8b59ddc00d8f72059180554123f4d6393b35ecbe6143f209"
     },
     {
       "kind": "runtime-control-plane",
@@ -236,7 +236,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/home-control-plane.sh",
       "runtime_path": "/usr/local/libexec/workcell/home-control-plane.sh",
-      "sha256": "a9eb5b0b7c7262301420610b02295e1a62b5cfe1890e439a5d3bfa2d8f9c1d7d"
+      "sha256": "33991be9f174bce99b862f2be9cb816ce9b6473124812703b36533620ae5b447"
     },
     {
       "kind": "runtime-control-plane",
@@ -254,7 +254,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/provider-wrapper.sh",
       "runtime_path": "/usr/local/libexec/workcell/provider-wrapper.sh",
-      "sha256": "8d9cbd196006345c2d7ffa7d5be15b1faa5669d1ff96305865915afc43b454bb"
+      "sha256": "a153a0116efb94abbbf01cabd76e85829e6f883eba98481b9c3889dbab9c6c00"
     },
     {
       "kind": "runtime-control-plane",
@@ -266,7 +266,7 @@
       "kind": "runtime-control-plane",
       "repo_path": "runtime/container/runtime-user.sh",
       "runtime_path": "/usr/local/libexec/workcell/runtime-user.sh",
-      "sha256": "24bdd17c4b6b1131277f4fa7baa82f3c66a561baead493af6538fbd1be770ae5"
+      "sha256": "5f2e565e142f7c751034c874ee0ed1637bc899d0a2295cdc7a41cad7abd9fdf2"
     },
     {
       "kind": "runtime-control-plane",

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
 # also run as plain `/bin/bash <script>`, so clear them for every child bash.
+# A startup file that already ran can pin either one readonly, which makes the
+# unset fail while errexit is still off, so refuse to run while one survives.
 unset BASH_ENV ENV
+[[ -z "${BASH_ENV+set}${ENV+set}" ]] || {
+  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2
+  exit 2
+}
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-${WORKCELL_LAUNCH_TARGET:-}}"

--- a/runtime/container/development-wrapper.sh
+++ b/runtime/container/development-wrapper.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
+# also run as plain `/bin/bash <script>`, so clear them for every child bash.
+unset BASH_ENV ENV
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-${WORKCELL_LAUNCH_TARGET:-}}"

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
 # also run as plain `/bin/bash <script>`, so clear them for every child bash.
+# A startup file that already ran can pin either one readonly, which makes the
+# unset fail while errexit is still off, so refuse to run while one survives.
 unset BASH_ENV ENV
+[[ -z "${BASH_ENV+set}${ENV+set}" ]] || {
+  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2
+  exit 2
+}
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-}"

--- a/runtime/container/entrypoint.sh
+++ b/runtime/container/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
+# also run as plain `/bin/bash <script>`, so clear them for every child bash.
+unset BASH_ENV ENV
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-}"

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
 # also run as plain `/bin/bash <script>`, so clear them for every child bash.
+# A startup file that already ran can pin either one readonly, which makes the
+# unset fail while errexit is still off, so refuse to run while one survives.
 unset BASH_ENV ENV
+[[ -z "${BASH_ENV+set}${ENV+set}" ]] || {
+  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2
+  exit 2
+}
 
 # shellcheck source=runtime/container/assurance.sh
 source /usr/local/libexec/workcell/assurance.sh

--- a/runtime/container/home-control-plane.sh
+++ b/runtime/container/home-control-plane.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
+# also run as plain `/bin/bash <script>`, so clear them for every child bash.
+unset BASH_ENV ENV
 
 # shellcheck source=runtime/container/assurance.sh
 source /usr/local/libexec/workcell/assurance.sh

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
+# also run as plain `/bin/bash <script>`, so clear them for every child bash.
+unset BASH_ENV ENV
 set -euo pipefail
 
 AGENT_NAME="${WORKCELL_LAUNCH_TARGET:-${0##*/}}"

--- a/runtime/container/provider-wrapper.sh
+++ b/runtime/container/provider-wrapper.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
 # also run as plain `/bin/bash <script>`, so clear them for every child bash.
+# A startup file that already ran can pin either one readonly, which makes the
+# unset fail while errexit is still off, so refuse to run while one survives.
 unset BASH_ENV ENV
+[[ -z "${BASH_ENV+set}${ENV+set}" ]] || {
+  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2
+  exit 2
+}
 set -euo pipefail
 
 AGENT_NAME="${WORKCELL_LAUNCH_TARGET:-${0##*/}}"

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
 # The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
 # also run as plain `/bin/bash <script>`, so clear them for every child bash.
+# A startup file that already ran can pin either one readonly, which makes the
+# unset fail while errexit is still off, so refuse to run while one survives.
 unset BASH_ENV ENV
+[[ -z "${BASH_ENV+set}${ENV+set}" ]] || {
+  echo 'Workcell refuses a pinned BASH_ENV or ENV startup file.' >&2
+  exit 2
+}
 
 # shellcheck source=runtime/container/assurance.sh
 source /usr/local/libexec/workcell/assurance.sh

--- a/runtime/container/runtime-user.sh
+++ b/runtime/container/runtime-user.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# The shebang clears BASH_ENV/ENV only when the kernel applies it; these scripts
+# also run as plain `/bin/bash <script>`, so clear them for every child bash.
+unset BASH_ENV ENV
 
 # shellcheck source=runtime/container/assurance.sh
 source /usr/local/libexec/workcell/assurance.sh


### PR DESCRIPTION
## Summary

The five runtime scripts start with `#!/usr/bin/env -S BASH_ENV= ENV= bash`. That
clears the two Bash startup-file variables only when the kernel applies the
shebang. It is not a property of the script; it is a property of how the script
happened to be started.

Seven call sites start these scripts, and their siblings, as plain
`/bin/bash <script>` or `/bin/bash -c`. That form bypasses the shebang
completely, so the cleared state reaches the child only as long as every caller
in the chain still carries it. One `env -i`, one `env -u BASH_ENV`, one caller
that was itself started as `bash <script>`, and every one of these children
sources an attacker-supplied startup file instead. Six of the seven had no
in-script clearing to fall back on.

Each prologue now clears the two variables itself, before anything else runs, so
a child bash starts from a cleared state however its parent was started.

`unset` fails on a variable a startup file already marked readonly, and the
prologue runs before errexit is on, so a bare `unset` would fail silently and
leave the pinned file reachable by every later child. The clearing line is
therefore followed by a survival check that refuses the run.

### Child sites

| # | Site | Invoking shell | Child | Cleared before this change |
|---|---|---|---|---|
| 1 | `entrypoint.sh:148` (`stage_copilot_token_handoff_file`) | root | `bash -c` token writer, dropped to the runtime uid by `setpriv` | shebang only |
| 2 | `entrypoint.sh:165` (`stage_copilot_token_handoff_file`) | root | `entrypoint.sh` re-exec, stays root | shebang only |
| 3 | `entrypoint.sh:248` (top level) | root | `development-wrapper.sh` | shebang only |
| 4 | `entrypoint.sh:280` (top level) | root | `detached-stdin-wrapper.sh` | shebang only |
| 5 | `runtime-user.sh:295` (`workcell_start_apt_broker`) | root | `apt-broker.sh`, detached by `setsid -f`, stays root | shebang only |
| 6 | `runtime-user.sh:394` (`workcell_reexec_as_runtime_user`) | root | non-executable command path, dropped by `setpriv` | shebang only |
| 7 | `development-wrapper.sh:182` (top level) | runtime user | interactive shell | `sanitize_development_env` already unset both |

Sites 2, 3, 4 and 5 hand a root child to whatever `BASH_ENV` names.

`sanitize_development_env` and `sanitize_provider_env` keep their existing
`unset`, so those two scripts are now cleared in the prologue and again at
sanitize time. `entrypoint.sh`, `home-control-plane.sh` and `runtime-user.sh` had
no in-script clearing at all.

Line numbers are post-change.

## Testing

- `TestRuntimeScriptProloguesClearBashStartupFilesForChildren` reads each of the
  five real prologues, refuses any command placed before the clearing line, then
  runs the prologue the way the call sites do (`bash <file>`, shebang bypassed)
  with `BASH_ENV` and `ENV` both pointing at a planted startup file, and counts
  how many times that file is sourced. One sourcing with the clearing line (the
  script's own shell, which nothing in the file can prevent once the shebang is
  bypassed); two without it, because the child reads it as well. The negative
  control runs on every invocation.
- Control fails before the fix: reverting `entrypoint.sh` to the pre-change
  prologue gives
  `entrypoint.sh runs "set -euo pipefail" before clearing BASH_ENV/ENV`.
- `bash -n`, `shellcheck -x` and `shfmt -d -i 2 -ci` clean on all five scripts.
- Same property confirmed on the real runtime image (`bash 5.2.37`, Linux),
  since the local control runs on `bash 3.2`: for all five shipped prologues,
  the planted startup file is sourced once with the clearing line and twice
  without it, and all five parse under the image's bash.
- Pinned case on the same image: a planted file that runs `readonly BASH_ENV ENV`
  makes the `unset` fail, and all five prologues then exit 2 before starting a
  child; with the survival check removed the pinned file reaches the child.
- `go build ./...` and `go vet ./...` clean.
- `go test ./internal/testkit/ ./internal/workcellhardening/ ./internal/metadatautil/ -count=1` passes.
- `scripts/generate-control-plane-manifest.sh` regenerated the manifest for the
  five changed control-plane scripts; `scripts/verify-control-plane-manifest.sh`
  and `scripts/verify-build-input-manifest.sh` pass.
- `scripts/check-pinned-inputs.sh`, `check-public-contract.sh` and
  `check-public-repo-hygiene.sh` exit 0.
- PR shape: files=7 lines=119 areas=2 binary_files=0.


