### PR TITLE
^B Carry quote provenance through the shell word reader so quoted syntax stays text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,9 @@ the runtime boundary or explicit security guarantees in the name of convenience.
   - a here-string and an arithmetic shift
   - a quoted echo decoy and a prefix extension
   - a line continuation and placement in an unrelated job
+  - quoted syntax: a separator, a reserved word, a brace, an ANSI-C heredoc
+    delimiter, and a command word split across a single-quoted newline
+  - a conditional command group
 - A shell script that reads a directory inventory to make a trust decision
   must prove that the walk completed. Emit a completion sentinel after a
   successful walk, or capture the exit status of the walk. Bash does not

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -117,9 +117,20 @@ var Evasions = []Evasion{
 		return hide(a, i+`: <<$'\x50LAN'`+"\n"+i+`\x50LAN`, i+"PLAN")
 	})},
 	{"single-quoted line break", replaceAnchor(splitCommandWords)},
+	{"escaped apostrophe in an ANSI-C word", replaceAnchor(func(a string) string {
+		return prefixCommands(a, `: $'x\'; `)
+	})},
 	{"conditional command group", replaceAnchor(func(a string) string {
 		i := indentOf(a)
 		return hide(a, i+"false && {", i+"}")
+	})},
+	{"argument brace in a guarded group", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"false && {\n"+i+"echo }", i+"}")
+	})},
+	{"argument brace in a definition body", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"never_called() {\n"+i+"echo }", i+"}")
 	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -112,6 +112,10 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return hide(a, i+": <<$'PLAN'\n"+i+"$PLAN", i+"PLAN")
 	})},
+	{"ANSI-C escape in a heredoc delimiter", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+`: <<$'\x50LAN'`+"\n"+i+`\x50LAN`, i+"PLAN")
+	})},
 	{"single-quoted line break", replaceAnchor(splitCommandWords)},
 	{"conditional command group", replaceAnchor(func(a string) string {
 		i := indentOf(a)

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -120,6 +120,14 @@ var Evasions = []Evasion{
 	{"escaped apostrophe in an ANSI-C word", replaceAnchor(func(a string) string {
 		return prefixCommands(a, `: $'x\'; `)
 	})},
+	{"ANSI-C span across a line break", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return i + `: $'x` + "\n" + prefixCommands(a, `\'; `) + "\n" + i + `'`
+	})},
+	{"negated guarded group", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"false && ! {", i+"}")
+	})},
 	{"conditional command group", replaceAnchor(func(a string) string {
 		i := indentOf(a)
 		return hide(a, i+"false && {", i+"}")

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -117,6 +117,10 @@ var Evasions = []Evasion{
 		return hide(a, i+`: <<$'\x50LAN'`+"\n"+i+`\x50LAN`, i+"PLAN")
 	})},
 	{"single-quoted line break", replaceAnchor(splitCommandWords)},
+	{"locale-translated heredoc delimiter", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+`: <<$"PLAN"`+"\n"+i+"PLAN", i+"PLAN")
+	})},
 	{"escaped apostrophe in an ANSI-C word", replaceAnchor(func(a string) string {
 		return prefixCommands(a, `: $'x\'; `)
 	})},

--- a/internal/metadatautil/evasions_test.go
+++ b/internal/metadatautil/evasions_test.go
@@ -97,6 +97,26 @@ var Evasions = []Evasion{
 		i := indentOf(a)
 		return i + `: "` + "\n" + i + "x\n" + i + `" ` + flatten(a)
 	})},
+	{"quoted separator", replaceAnchor(func(a string) string {
+		return prefixCommands(a, `: ";" `)
+	})},
+	{"quoted compound-command closer", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"if false; then\n"+i+`"fi"`, i+"fi")
+	})},
+	{"quoted brace in a definition", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"never_called() {\n"+i+`"}"`, i+"}")
+	})},
+	{"ANSI-C heredoc delimiter", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+": <<$'PLAN'\n"+i+"$PLAN", i+"PLAN")
+	})},
+	{"single-quoted line break", replaceAnchor(splitCommandWords)},
+	{"conditional command group", replaceAnchor(func(a string) string {
+		i := indentOf(a)
+		return hide(a, i+"false && {", i+"}")
+	})},
 	{"prefix extension", replaceAnchor(extendFirstOption)},
 	{"unrelated placement", func(artifact, anchor string) string {
 		moved := strings.Replace(artifact, anchor, indentOf(anchor)+"true", 1)
@@ -178,6 +198,25 @@ func extendFirstOption(anchor string) string {
 		}
 	}
 	return strings.Replace(anchor, target, target+"-disabled", 1)
+}
+
+// splitCommandWords breaks the command word of every command line of the anchor
+// across a single-quoted newline. Inside single quotes bash keeps both the
+// backslash and the newline, so the word names no program and the command does
+// not run, while a reader that joins the halves before it knows the quoting
+// sees the anchored command with the arguments it expects.
+func splitCommandWords(anchor string) string {
+	lines := strings.Split(anchor, "\n")
+	continues := false
+	for index, line := range lines {
+		name, rest, found := strings.Cut(strings.TrimLeft(line, " \t"), " ")
+		if !continues && found && len(name) > 1 {
+			lines[index] = indentOf(line) + "'" + name[:1] + "\\\n" +
+				indentOf(anchor) + name[1:] + "' " + rest
+		}
+		continues = strings.HasSuffix(strings.TrimSpace(line), "\\")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // indentOf returns the leading whitespace of the first line of text.

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -55,24 +55,40 @@ func texts(words []word) []string {
 	return plain
 }
 
-// braceDepth returns the change in brace nesting the words make. Only an
-// unquoted brace that stands as its own word or ends one groups commands; a
-// brace inside a word belongs to an expansion such as ${VAR}, and a quoted one
-// is an ordinary command word.
-func braceDepth(words []word) int {
+// braceDepth returns the change in brace nesting the commands make.
+func braceDepth(commands []command) int {
 	change := 0
-	for _, each := range words {
-		if each.quoted {
-			continue
-		}
-		switch {
-		case each.text == "{" || strings.HasSuffix(each.text, "(){"):
-			change++
-		case each.text == "}" || each.text == "};":
-			change--
-		}
+	for _, each := range commands {
+		change += commandBrace(each)
 	}
 	return change
+}
+
+// commandBrace returns the change in brace nesting one command makes. A brace
+// groups commands only in command position and only unquoted: bash reads the }
+// of echo } as an argument, so a group is still open after it. A brace inside a
+// word belongs to an expansion such as ${VAR}. A definition header is not a
+// command, so the brace that opens its body stands in command position after
+// it, wherever on the header line it is written.
+func commandBrace(each command) int {
+	args := each.args
+	if len(args) == 0 || args[0].quoted {
+		return 0
+	}
+	if definedName(args) != "" {
+		if strings.HasSuffix(args[0].text, "(){") || slices.ContainsFunc(args[1:],
+			func(each word) bool { return !each.quoted && each.text == "{" }) {
+			return 1
+		}
+		return 0
+	}
+	switch args[0].text {
+	case "{":
+		return 1
+	case "}":
+		return -1
+	}
+	return 0
 }
 
 // controlWords maps each word that opens or closes a compound command to the
@@ -258,6 +274,7 @@ func ShellInvocations(script, commandName string) []Invocation {
 		// A function definition is not a call. Bash reads the body and runs
 		// nothing, so a required command written inside a function that
 		// nobody calls does not satisfy a rule about what the step runs.
+		commands := splitCommands(words)
 		if !defining {
 			if name := definedName(words); name != "" {
 				if name == prefix[0] {
@@ -267,7 +284,7 @@ func ShellInvocations(script, commandName string) []Invocation {
 				defining, definedAt, bodyOpened = true, depth, false
 			}
 		}
-		depth += braceDepth(words)
+		depth += braceDepth(commands)
 		if defining {
 			// A body may open on a later line, as in never_called ()
 			// followed by { on its own, so wait for it before seeking its end.
@@ -279,7 +296,6 @@ func ShellInvocations(script, commandName string) []Invocation {
 			}
 			continue
 		}
-		commands := splitCommands(words)
 		nested := control > 0
 		for _, each := range commands {
 			args := each.args
@@ -288,7 +304,7 @@ func ShellInvocations(script, commandName string) []Invocation {
 			}
 			position++
 			outside := groupDepth
-			groupDepth += braceDepth(args)
+			groupDepth += commandBrace(each)
 			if conditionalGroup >= 0 {
 				// Nothing inside the guarded group is proved to run, however
 				// many lines later the closing brace is. The commands written
@@ -394,9 +410,15 @@ func shellWords(line string, stack []byte) (
 			switch {
 			case character == '\'':
 				quote, ansiC = 0, false
-			case character == '\\' && ansiC:
+			case character == '\\' && ansiC && index+1 < len(line):
+				// A backslash escapes the next byte inside $'…', so an escaped
+				// apostrophe is a literal one and does not close the span. The
+				// span therefore keeps the rest of the line as text, where
+				// closing on it would expose a separator bash never reads.
 				ansiEscape = true
 				text.WriteByte(character)
+				index++
+				text.WriteByte(line[index])
 			default:
 				text.WriteByte(character)
 			}

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -24,16 +24,41 @@ func (h heredoc) endsAt(line string) bool {
 	return line == h.delimiter
 }
 
-// braceDepth returns the change in brace nesting the words make. Only a brace
-// that stands as its own word or ends one groups commands; a brace inside a
-// word belongs to an expansion such as ${VAR}.
-func braceDepth(words []string) int {
+// word is one word of a logical line, and whether any part of it was quoted.
+// Quoting takes a word's meaning as syntax away without changing its meaning as
+// a name: bash runs "oras" cp, while a quoted ; is an argument, a quoted fi is
+// an ordinary command, and a quoted } closes no group. A reader that returns
+// plain strings cannot tell the two apart, so every caller that asks whether a
+// word is syntax reads text as syntax.
+type word struct {
+	text   string
+	quoted bool
+}
+
+// texts returns the words' text, for the tests that read a word as a name. A
+// name keeps its meaning through quotes, so those tests ignore provenance.
+func texts(words []word) []string {
+	plain := make([]string, len(words))
+	for index, each := range words {
+		plain[index] = each.text
+	}
+	return plain
+}
+
+// braceDepth returns the change in brace nesting the words make. Only an
+// unquoted brace that stands as its own word or ends one groups commands; a
+// brace inside a word belongs to an expansion such as ${VAR}, and a quoted one
+// is an ordinary command word.
+func braceDepth(words []word) int {
 	change := 0
-	for _, word := range words {
+	for _, each := range words {
+		if each.quoted {
+			continue
+		}
 		switch {
-		case word == "{" || strings.HasSuffix(word, "(){"):
+		case each.text == "{" || strings.HasSuffix(each.text, "(){"):
 			change++
-		case word == "}" || word == "};":
+		case each.text == "}" || each.text == "};":
 			change--
 		}
 	}
@@ -58,49 +83,63 @@ func isOperator(word string) bool {
 	return false
 }
 
+// continuesLine reports whether an operator at the end of a line carries its
+// command onto the next one, so that false && <newline> oras cp … is one
+// logical line. A ; or an & ends the command instead.
+func continuesLine(word string) bool {
+	switch word {
+	case "&&", "||", "|":
+		return true
+	}
+	return false
+}
+
 // command is one command of a logical line, and whether an earlier command on
 // that line decides if it runs. Bash runs the right side of && or || only on
 // the exit status of the left, so a command written there is not proved to run.
 type command struct {
-	args        []string
+	args        []word
 	conditional bool
 }
 
 // splitCommands cuts one logical line into the separate commands bash runs, at
-// every control operator. Without this a decoy after ; or || donates its words
-// to the invocation before it.
-func splitCommands(words []string) []command {
+// every unquoted control operator. Without this a decoy after ; or || donates
+// its words to the invocation before it, and without the quote test a quoted
+// separator such as : ";" oras cp … starts a command bash never runs.
+func splitCommands(words []word) []command {
 	commands := make([]command, 1)
-	for _, word := range words {
-		if isOperator(word) {
-			commands = append(commands, command{conditional: word == "&&" || word == "||"})
+	for _, each := range words {
+		if !each.quoted && isOperator(each.text) {
+			commands = append(commands, command{conditional: each.text == "&&" || each.text == "||"})
 			continue
 		}
 		last := &commands[len(commands)-1]
-		last.args = append(last.args, word)
+		last.args = append(last.args, each)
 	}
 	return commands
 }
 
 // definedName returns the name a function definition binds, in either the
 // name() or the function name spelling, or the empty string when the words do
-// not define one.
-func definedName(words []string) string {
-	if len(words) == 0 {
+// not define one. A quoted first word defines nothing: bash reads "never_called()"
+// as a command name, so the lines after it are commands rather than a body.
+func definedName(words []word) string {
+	if len(words) == 0 || words[0].quoted {
 		return ""
 	}
-	if words[0] == "function" {
+	first := words[0].text
+	if first == "function" {
 		if len(words) < 2 {
 			return ""
 		}
-		return strings.TrimSuffix(words[1], "()")
+		return strings.TrimSuffix(words[1].text, "()")
 	}
-	if name, _, found := strings.Cut(words[0], "("); found && name != "" &&
-		strings.HasPrefix(words[0][len(name):], "()") {
+	if name, _, found := strings.Cut(first, "("); found && name != "" &&
+		strings.HasPrefix(first[len(name):], "()") {
 		return name
 	}
-	if len(words) > 1 && words[1] == "()" {
-		return words[0]
+	if len(words) > 1 && !words[1].quoted && words[1].text == "()" {
+		return first
 	}
 	return ""
 }
@@ -154,6 +193,11 @@ func ShellInvocations(script, commandName string) []Invocation {
 	var position int
 	var depth, definedAt, control int
 	var defining, bodyOpened bool
+	// conditionalGroup is the brace depth outside a command group that a && or
+	// a || guards, or -1 when no such group is open. Bash decides the whole
+	// group on one exit status, so nothing written inside false && { … } is
+	// proved to run, however many lines later the closing brace is.
+	conditionalGroup := -1
 	for line := range strings.Lines(script) {
 		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
 		if openQuote != 0 {
@@ -179,23 +223,24 @@ func ShellInvocations(script, commandName string) []Invocation {
 			}
 			continue
 		}
-		// A backslash continues the line only when it is not itself escaped,
-		// and bash then joins the two halves with nothing between them. A
-		// space after the backslash escapes the space instead, which ends the
-		// line and makes the next one a separate command.
-		if backslashes := len(text) - len(strings.TrimRight(text, `\`)); backslashes%2 == 1 {
-			current.WriteString(text[:len(text)-1])
+		current.WriteString(text)
+		words, opened, quote, rest, continues := shellWords(current.String(), quotes)
+		if continues {
+			// The line ends with a backslash the quoting leaves as syntax, and
+			// bash joins the two halves with nothing between them. Counting
+			// backslashes in the text before any quote state exists reads the
+			// literal one of 'or\ <newline> as' as a continuation and joins a
+			// command word bash keeps apart, in the fail-open direction.
+			joined := current.String()
+			current.Reset()
+			current.WriteString(joined[:len(joined)-1])
 			continue
 		}
-		current.WriteString(text)
-		if trimmed := strings.TrimRight(text, " \t"); strings.HasSuffix(trimmed, "&&") ||
-			strings.HasSuffix(trimmed, "|") {
-			// A list operator at the end of a line continues onto the next,
-			// so false && <newline> oras cp … is one logical line.
+		if last := len(words) - 1; last >= 0 && !words[last].quoted &&
+			continuesLine(words[last].text) {
 			current.WriteString(" ")
 			continue
 		}
-		words, opened, quote, rest := shellWords(current.String(), quotes)
 		current.Reset()
 		openQuote, quotes = quote, rest
 		heredocs = append(heredocs, opened...)
@@ -211,6 +256,7 @@ func ShellInvocations(script, commandName string) []Invocation {
 				defining, definedAt, bodyOpened = true, depth, false
 			}
 		}
+		outside := depth
 		depth += braceDepth(words)
 		if defining {
 			// A body may open on a later line, as in never_called ()
@@ -223,6 +269,12 @@ func ShellInvocations(script, commandName string) []Invocation {
 			}
 			continue
 		}
+		if conditionalGroup >= 0 {
+			if depth <= conditionalGroup {
+				conditionalGroup = -1
+			}
+			continue
+		}
 		commands := splitCommands(words)
 		nested := control > 0
 		for _, each := range commands {
@@ -231,51 +283,67 @@ func ShellInvocations(script, commandName string) []Invocation {
 				continue
 			}
 			position++
-			if change, found := controlWords[args[0]]; found {
-				control = max(control+change, 0)
-				nested = true
-				continue
+			if !args[0].quoted {
+				// A quoted reserved word is an ordinary command, so a "fi"
+				// inside if false; then closes no branch and the lines after
+				// it stay inside the branch bash never runs.
+				if change, found := controlWords[args[0].text]; found {
+					control = max(control+change, 0)
+					nested = true
+					continue
+				}
 			}
 			if nested || control > 0 || each.conditional {
 				continue
 			}
-			if args[0] == "exit" || args[0] == "return" || replacesShell(args) {
+			names := texts(args)
+			if names[0] == "exit" || names[0] == "return" || replacesShell(names) {
 				// The step ends here; nothing written after it runs.
 				return invocations
 			}
-			if args[0] == "alias" && shadowsByAlias(args, prefix[0]) {
+			if names[0] == "alias" && shadowsByAlias(names, prefix[0]) {
 				return nil // Every later use expands to the alias.
 			}
-			if args[0] == "hash" && slices.Contains(args[1:], "-p") &&
-				slices.Contains(args[1:], prefix[0]) {
+			if names[0] == "hash" && slices.Contains(names[1:], "-p") &&
+				slices.Contains(names[1:], prefix[0]) {
 				// hash -p pathname name makes pathname the full filename for
 				// name, so every later line runs that path, not the program.
 				return nil
 			}
-			if len(args) >= len(prefix) && slices.Equal(args[:len(prefix)], prefix) {
-				invocations = append(invocations, Invocation{args[len(prefix):], position})
+			if len(names) >= len(prefix) && slices.Equal(names[:len(prefix)], prefix) {
+				invocations = append(invocations, Invocation{names[len(prefix):], position})
 			}
+		}
+		if depth > outside && slices.ContainsFunc(commands, func(each command) bool {
+			return each.conditional
+		}) {
+			conditionalGroup = outside
 		}
 	}
 	return invocations
 }
 
 // shellWords splits one logical line the way bash reads it. Quotes and
-// backslash escapes are removed, so a quoted argument stays one word and a
-// separator inside it is text rather than syntax; an unquoted # that starts a
-// word ends the line; every heredoc the line opens returns as a delimiter, in
-// the order bash reads the bodies; open is the quote character still waiting to
-// be closed, which tells the caller that the word runs on into the next line;
-// and rest is the quote each unclosed command substitution suspended, which the
-// caller gives back on the next line so that the ) which closes the
-// substitution also restores the quote around it.
+// backslash escapes are removed but recorded, so a quoted argument stays one
+// word, a separator inside it is text rather than syntax, and the caller can
+// still tell a word that was quoted from one that was not; an unquoted # that
+// starts a word ends the line; every heredoc the line opens returns as a
+// delimiter, in the order bash reads the bodies; open is the quote character
+// still waiting to be closed, which tells the caller that the word runs on into
+// the next line; rest is the quote each unclosed command substitution
+// suspended, which the caller gives back on the next line so that the ) which
+// closes the substitution also restores the quote around it; and continues says
+// the line ended on a backslash that the quoting leaves as syntax, so bash
+// reads the next physical line as the rest of this one.
 //
-// One pass keeps the four answers consistent. A pattern per answer cannot:
+// One pass keeps the five answers consistent. A pattern per answer cannot:
 // each has to rediscover the quoting, and the one that gets it wrong reads
 // syntax where the shell reads text.
-func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, open byte, rest []byte) {
-	var word strings.Builder
-	inWord, quote, pending, stripTabs := false, byte(0), false, false
+func shellWords(line string, stack []byte) (
+	words []word, heredocs []heredoc, open byte, rest []byte, continues bool,
+) {
+	var text strings.Builder
+	inWord, quoted, quote, pending, stripTabs := false, false, byte(0), false, false
 	arithmetic := 0
 	// A line that carries a quoted command substitution donates no words. Where
 	// the substitution ends is beyond a line reader, and reading syntax over
@@ -290,13 +358,13 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 			return
 		}
 		if pending {
-			heredocs = append(heredocs, heredoc{word.String(), stripTabs})
+			heredocs = append(heredocs, heredoc{text.String(), stripTabs})
 			pending, stripTabs = false, false
 		} else {
-			words = append(words, word.String())
+			words = append(words, word{text.String(), quoted})
 		}
-		word.Reset()
-		inWord = false
+		text.Reset()
+		inWord, quoted = false, false
 	}
 	for index := 0; index < len(line); index++ {
 		character := line[index]
@@ -306,7 +374,7 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 			if character == '\'' {
 				quote = 0
 			} else {
-				word.WriteByte(character)
+				text.WriteByte(character)
 			}
 		case quote == '"':
 			switch {
@@ -315,7 +383,7 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 				// other one it is a literal byte of the word, so a name such
 				// as "or\as" is not the command it resembles.
 				index++
-				word.WriteByte(line[index])
+				text.WriteByte(line[index])
 			case character == '"':
 				quote = 0
 			case character == '`' || (character == '$' && index+1 < len(line) && line[index+1] == '('):
@@ -328,35 +396,49 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 				substituted = true
 				stack = append(stack, quote)
 				quote = 0
-				word.WriteByte(character)
+				text.WriteByte(character)
 			default:
-				word.WriteByte(character)
+				text.WriteByte(character)
 			}
-		case character == '\\' && index+1 < len(line):
-			// An escaped quote is a literal character, not the start of a
-			// quoted span, so it cannot hide the syntax that follows it.
+		case character == '\\' && index+1 == len(line):
+			// The line ends on a backslash no quote made literal, so bash
+			// reads the next physical line as the rest of this one. Only the
+			// reader that knows the quoting can say so.
+			continues = true
+		case character == '\\':
+			// An escaped character is a literal one, not the start of a quoted
+			// span, so it cannot hide the syntax that follows it. It is also
+			// no longer syntax itself, so \; is an argument rather than a
+			// separator, which is why the escape records provenance.
 			index++
-			word.WriteByte(line[index])
-			inWord = true
+			text.WriteByte(line[index])
+			inWord, quoted = true, true
 		case character == '\'' || character == '"':
 			quote = character
-			inWord = true
+			inWord, quoted = true, true
+		case character == '$' && index+1 < len(line) &&
+			(line[index+1] == '\'' || line[index+1] == '"'):
+			// $'…' and $"…" are quoting forms whose $ bash removes with the
+			// quotes, so a body opened as <<$'PLAN' ends at a PLAN line.
+			index++
+			quote = line[index]
+			inWord, quoted = true, true
 		case character == ' ' || character == '\t':
 			flush()
 		case character == '#' && !inWord:
 			if substituted {
-				return nil, heredocs, 0, stack
+				return nil, heredocs, 0, stack, false
 			}
-			return words, heredocs, 0, stack
+			return words, heredocs, 0, stack, false
 		case character == '$' && index+2 < len(line) && line[index+1] == '(' && line[index+2] == '(':
 			// The << inside $((1 << 2)) is a shift, not a heredoc operator.
 			arithmetic++
-			word.WriteString(line[index : index+3])
+			text.WriteString(line[index : index+3])
 			index += 2
 			inWord = true
 		case arithmetic > 0 && character == ')' && index+1 < len(line) && line[index+1] == ')':
 			arithmetic--
-			word.WriteString("))")
+			text.WriteString("))")
 			index++
 			inWord = true
 		case arithmetic == 0 && character == '<' && index+1 < len(line) && line[index+1] == '<':
@@ -389,16 +471,16 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 				index++
 				operator += string(character)
 			}
-			words = append(words, operator)
+			words = append(words, word{text: operator})
 		case len(stack) > 0 && (character == ')' || character == '`'):
 			// A substitution ends at ) or at its backtick, and the quote it
 			// suspended comes back with it.
 			quote = stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
-			word.WriteByte(character)
+			text.WriteByte(character)
 			inWord = true
 		default:
-			word.WriteByte(character)
+			text.WriteByte(character)
 			inWord = true
 		}
 	}
@@ -409,9 +491,9 @@ func shellWords(line string, stack []byte) (words []string, heredocs []heredoc, 
 	if len(stack) > 0 {
 		// A substitution is still open, so the logical line has not ended and
 		// the quote around it is not the caller's to skip.
-		return words, heredocs, 0, stack
+		return words, heredocs, 0, stack, continues
 	}
-	return words, heredocs, quote, stack
+	return words, heredocs, quote, stack, continues
 }
 
 // replacesShell reports whether the words are an exec that names a program,

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -72,6 +72,11 @@ func braceDepth(commands []command) int {
 // it, wherever on the header line it is written.
 func commandBrace(each command) int {
 	args := each.args
+	// ! negates the status of the command after it and is not a command of its
+	// own, so the brace behind it still stands in command position.
+	for len(args) > 0 && !args[0].quoted && args[0].text == "!" {
+		args = args[1:]
+	}
 	if len(args) == 0 || args[0].quoted {
 		return 0
 	}
@@ -170,16 +175,26 @@ func definedName(words []word) string {
 	return ""
 }
 
+// ansiCQuote names an open $'…' span in the one byte the reader carries between
+// physical lines. A shell quote is only ' or ", so $ is free to stand for the
+// third case: an apostrophe closes the span, and a backslash escapes the byte
+// after it, which a plain single-quoted span does not.
+const ansiCQuote = '$'
+
 // quoteCloseIndex returns the index of the byte that closes an open quote, or
 // -1 when the line does not close it. A backslash escapes the next byte inside
-// a double-quoted span; a single-quoted span has no escapes.
+// a double-quoted or an ANSI-C span; a plain single-quoted span has no escapes.
 func quoteCloseIndex(line string, quote byte) int {
+	closer := quote
+	if quote == ansiCQuote {
+		closer = '\''
+	}
 	for index := 0; index < len(line); index++ {
-		if quote == '"' && line[index] == '\\' {
+		if quote != '\'' && line[index] == '\\' {
 			index++
 			continue
 		}
-		if line[index] == quote {
+		if line[index] == closer {
 			return index
 		}
 	}
@@ -538,6 +553,11 @@ func shellWords(line string, stack []byte) (
 	flush()
 	if substituted {
 		words = nil
+	}
+	if quote == '\'' && ansiC {
+		// The span runs on into the next line with its escapes still live, so
+		// the caller must skip it by the ANSI-C rules, not the plain ones.
+		quote = ansiCQuote
 	}
 	if len(stack) > 0 {
 		// A substitution is still open, so the logical line has not ended and

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -12,12 +12,15 @@ import (
 // ends it, and whether the <<- form lets the terminator line carry leading
 // tabs. Bash ends a <<WORD body only at a line that is the delimiter alone, so
 // an indented copy of the word inside the body is text.
+//
 // unresolved records a delimiter this reader cannot spell. A $'…' delimiter
 // carries the ANSI-C escapes bash decodes before it compares a line, so
-// <<$'\x50LAN' ends at PLAN. Decoding them here would be a second, smaller copy
-// of that table, and a case it got wrong would end the body early and count
-// lines bash still reads as data. The body therefore runs to the end of the
-// script, which loses invocations rather than inventing them.
+// <<$'\x50LAN' ends at PLAN, and a $"…" delimiter is translated through the
+// locale catalog first, so its text here is not the text bash compares at all.
+// Resolving either would put a second copy of bash's own tables in this file,
+// and a case one of them got wrong would end the body early and count lines
+// bash still reads as data. The body therefore runs to the end of the script,
+// which loses invocations rather than inventing them.
 type heredoc struct {
 	delimiter  string
 	stripTabs  bool
@@ -393,7 +396,7 @@ func shellWords(line string, stack []byte) (
 ) {
 	var text strings.Builder
 	inWord, quoted, quote, pending, stripTabs := false, false, byte(0), false, false
-	ansiC, ansiEscape := false, false
+	ansiC, unresolved := false, false
 	arithmetic := 0
 	// A line that carries a quoted command substitution donates no words. Where
 	// the substitution ends is beyond a line reader, and reading syntax over
@@ -408,13 +411,13 @@ func shellWords(line string, stack []byte) (
 			return
 		}
 		if pending {
-			heredocs = append(heredocs, heredoc{text.String(), stripTabs, ansiEscape})
+			heredocs = append(heredocs, heredoc{text.String(), stripTabs, unresolved})
 			pending, stripTabs = false, false
 		} else {
 			words = append(words, word{text.String(), quoted})
 		}
 		text.Reset()
-		inWord, quoted, ansiEscape = false, false, false
+		inWord, quoted, unresolved = false, false, false
 	}
 	for index := 0; index < len(line); index++ {
 		character := line[index]
@@ -430,7 +433,7 @@ func shellWords(line string, stack []byte) (
 				// apostrophe is a literal one and does not close the span. The
 				// span therefore keeps the rest of the line as text, where
 				// closing on it would expose a separator bash never reads.
-				ansiEscape = true
+				unresolved = true
 				text.WriteByte(character)
 				index++
 				text.WriteByte(line[index])
@@ -484,10 +487,14 @@ func shellWords(line string, stack []byte) (
 		case character == '$' && index+1 < len(line) &&
 			(line[index+1] == '\'' || line[index+1] == '"'):
 			// $'…' and $"…" are quoting forms whose $ bash removes with the
-			// quotes, so a body opened as <<$'PLAN' ends at a PLAN line.
+			// quotes, so a body opened as <<$'PLAN' ends at a PLAN line. A
+			// $"…" word is translated through the locale catalog before that,
+			// so what it spells here is not what bash compares, and a
+			// delimiter written that way is unresolved from the start.
 			index++
 			quote = line[index]
 			ansiC = quote == '\''
+			unresolved = unresolved || !ansiC
 			inWord, quoted = true, true
 		case character == ' ' || character == '\t':
 			flush()

--- a/internal/metadatautil/shell_invocations.go
+++ b/internal/metadatautil/shell_invocations.go
@@ -12,12 +12,22 @@ import (
 // ends it, and whether the <<- form lets the terminator line carry leading
 // tabs. Bash ends a <<WORD body only at a line that is the delimiter alone, so
 // an indented copy of the word inside the body is text.
+// unresolved records a delimiter this reader cannot spell. A $'…' delimiter
+// carries the ANSI-C escapes bash decodes before it compares a line, so
+// <<$'\x50LAN' ends at PLAN. Decoding them here would be a second, smaller copy
+// of that table, and a case it got wrong would end the body early and count
+// lines bash still reads as data. The body therefore runs to the end of the
+// script, which loses invocations rather than inventing them.
 type heredoc struct {
-	delimiter string
-	stripTabs bool
+	delimiter  string
+	stripTabs  bool
+	unresolved bool
 }
 
 func (h heredoc) endsAt(line string) bool {
+	if h.unresolved {
+		return false
+	}
 	if h.stripTabs {
 		return strings.TrimLeft(line, "\t") == h.delimiter
 	}
@@ -194,10 +204,11 @@ func ShellInvocations(script, commandName string) []Invocation {
 	var depth, definedAt, control int
 	var defining, bodyOpened bool
 	// conditionalGroup is the brace depth outside a command group that a && or
-	// a || guards, or -1 when no such group is open. Bash decides the whole
+	// a || guards, or -1 when no such group is open, and groupDepth is the
+	// nesting the commands read so far have opened. Bash decides the whole
 	// group on one exit status, so nothing written inside false && { … } is
-	// proved to run, however many lines later the closing brace is.
-	conditionalGroup := -1
+	// proved to run.
+	conditionalGroup, groupDepth := -1, 0
 	for line := range strings.Lines(script) {
 		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
 		if openQuote != 0 {
@@ -256,7 +267,6 @@ func ShellInvocations(script, commandName string) []Invocation {
 				defining, definedAt, bodyOpened = true, depth, false
 			}
 		}
-		outside := depth
 		depth += braceDepth(words)
 		if defining {
 			// A body may open on a later line, as in never_called ()
@@ -269,12 +279,6 @@ func ShellInvocations(script, commandName string) []Invocation {
 			}
 			continue
 		}
-		if conditionalGroup >= 0 {
-			if depth <= conditionalGroup {
-				conditionalGroup = -1
-			}
-			continue
-		}
 		commands := splitCommands(words)
 		nested := control > 0
 		for _, each := range commands {
@@ -283,6 +287,25 @@ func ShellInvocations(script, commandName string) []Invocation {
 				continue
 			}
 			position++
+			outside := groupDepth
+			groupDepth += braceDepth(args)
+			if conditionalGroup >= 0 {
+				// Nothing inside the guarded group is proved to run, however
+				// many lines later the closing brace is. The commands written
+				// after that brace on its own line are outside the group and
+				// are read.
+				if groupDepth <= conditionalGroup {
+					conditionalGroup = -1
+				}
+				continue
+			}
+			if each.conditional && groupDepth > outside {
+				// The group this command opens is the one the && or the || in
+				// front of it guards. A conditional command elsewhere on the
+				// line guards no group of its own, so false && true; { runs
+				// its group whatever the status of true.
+				conditionalGroup = outside
+			}
 			if !args[0].quoted {
 				// A quoted reserved word is an ordinary command, so a "fi"
 				// inside if false; then closes no branch and the lines after
@@ -314,11 +337,6 @@ func ShellInvocations(script, commandName string) []Invocation {
 				invocations = append(invocations, Invocation{names[len(prefix):], position})
 			}
 		}
-		if depth > outside && slices.ContainsFunc(commands, func(each command) bool {
-			return each.conditional
-		}) {
-			conditionalGroup = outside
-		}
 	}
 	return invocations
 }
@@ -344,6 +362,7 @@ func shellWords(line string, stack []byte) (
 ) {
 	var text strings.Builder
 	inWord, quoted, quote, pending, stripTabs := false, false, byte(0), false, false
+	ansiC, ansiEscape := false, false
 	arithmetic := 0
 	// A line that carries a quoted command substitution donates no words. Where
 	// the substitution ends is beyond a line reader, and reading syntax over
@@ -358,26 +377,35 @@ func shellWords(line string, stack []byte) (
 			return
 		}
 		if pending {
-			heredocs = append(heredocs, heredoc{text.String(), stripTabs})
+			heredocs = append(heredocs, heredoc{text.String(), stripTabs, ansiEscape})
 			pending, stripTabs = false, false
 		} else {
 			words = append(words, word{text.String(), quoted})
 		}
 		text.Reset()
-		inWord, quoted = false, false
+		inWord, quoted, ansiEscape = false, false, false
 	}
 	for index := 0; index < len(line); index++ {
 		character := line[index]
 		switch {
 		case quote == '\'':
-			// A backslash is literal inside single quotes.
-			if character == '\'' {
-				quote = 0
-			} else {
+			// A backslash is literal inside single quotes, and an escape bash
+			// would decode inside $'…' makes the word unspellable here.
+			switch {
+			case character == '\'':
+				quote, ansiC = 0, false
+			case character == '\\' && ansiC:
+				ansiEscape = true
+				text.WriteByte(character)
+			default:
 				text.WriteByte(character)
 			}
 		case quote == '"':
 			switch {
+			case character == '\\' && index+1 == len(line):
+				// Bash removes a backslash-newline pair inside double quotes,
+				// so the line continues here as it does outside them.
+				continues = true
 			case character == '\\' && index+1 < len(line) && strings.IndexByte("$`\"\\", line[index+1]) >= 0:
 				// A backslash escapes only these characters here. Before any
 				// other one it is a literal byte of the word, so a name such
@@ -422,6 +450,7 @@ func shellWords(line string, stack []byte) (
 			// quotes, so a body opened as <<$'PLAN' ends at a PLAN line.
 			index++
 			quote = line[index]
+			ansiC = quote == '\''
 			inWord, quoted = true, true
 		case character == ' ' || character == '\t':
 			flush()

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -239,6 +239,46 @@ func TestShellInvocations(t *testing.T) {
 			script: "hash -p /bin/true oras\noras cp --recursive --from-oci-layout one\n",
 			want:   nil,
 		},
+		{
+			name:   "a quoted separator is an argument, not the end of a command",
+			script: ": \";\" oras cp one\n",
+			want:   nil,
+		},
+		{
+			name:   "an escaped separator is an argument, not the end of a command",
+			script: ": \\; oras cp one\n",
+			want:   nil,
+		},
+		{
+			name:   "a quoted reserved word closes no compound command",
+			script: "if false; then\n\"fi\"\noras cp one\nfi\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a quoted brace closes no definition body",
+			script: "never_called() {\n\"}\"\noras cp one\n}\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "an ANSI-C delimiter ends its body at the word the quotes hold",
+			script: ": <<$'PLAN'\n$PLAN\noras cp one\nPLAN\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "a backslash inside single quotes does not continue the line",
+			script: "'or\\\nas' cp one\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "conditional status survives a command group",
+			script: "false && {\noras cp one\n}\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "an unconditional command group runs its body",
+			script: "{\noras cp one\n}\n",
+			want:   [][]string{{"one"}},
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -325,6 +325,11 @@ func TestShellInvocations(t *testing.T) {
 			want:   [][]string{{"one"}},
 		},
 		{
+			name:   "a locale-translated delimiter ends no body this reader can spell",
+			script: ": <<$\"PLAN\"\nPLAN\noras cp one\nPLAN\n",
+			want:   nil,
+		},
+		{
 			name:   "an ANSI-C span keeps its escapes across a line break",
 			script: ": $'x\n\\'; oras cp one'\noras cp two\n",
 			want:   [][]string{{"two"}},

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -279,6 +279,26 @@ func TestShellInvocations(t *testing.T) {
 			script: "{\noras cp one\n}\n",
 			want:   [][]string{{"one"}},
 		},
+		{
+			name:   "an ANSI-C delimiter with an escape ends no body this reader can spell",
+			script: ": <<$'\\x50LAN'\n\\x50LAN\noras cp one\nPLAN\noras cp two\n",
+			want:   nil,
+		},
+		{
+			name:   "a backslash inside double quotes continues the line",
+			script: "\"or\\\nas\" cp one\n",
+			want:   [][]string{{"one"}},
+		},
+		{
+			name:   "a conditional command guards no group a later operator opens",
+			script: "false && true; {\noras cp one\n}\n",
+			want:   [][]string{{"one"}},
+		},
+		{
+			name:   "a command after a guarded group's closing brace is read",
+			script: "false && {\noras cp one\n}; oras cp two\n",
+			want:   [][]string{{"two"}},
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -299,6 +299,21 @@ func TestShellInvocations(t *testing.T) {
 			script: "false && {\noras cp one\n}; oras cp two\n",
 			want:   [][]string{{"two"}},
 		},
+		{
+			name:   "an escaped apostrophe does not close an ANSI-C word",
+			script: ": $'x\\'; oras cp one'\n",
+			want:   nil,
+		},
+		{
+			name:   "an argument brace closes no guarded group",
+			script: "false && {\necho }\noras cp one\n}\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "an argument brace closes no definition body",
+			script: "never_called() {\necho }\noras cp one\n}\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/metadatautil/shell_invocations_test.go
+++ b/internal/metadatautil/shell_invocations_test.go
@@ -314,6 +314,21 @@ func TestShellInvocations(t *testing.T) {
 			script: "never_called() {\necho }\noras cp one\n}\noras cp two\n",
 			want:   [][]string{{"two"}},
 		},
+		{
+			name:   "a negation does not move a guarded group out of command position",
+			script: "false && ! {\noras cp one\n}\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
+		{
+			name:   "an unguarded negated group runs its body",
+			script: "! {\noras cp one\n}\n",
+			want:   [][]string{{"one"}},
+		},
+		{
+			name:   "an ANSI-C span keeps its escapes across a line break",
+			script: ": $'x\n\\'; oras cp one'\noras cp two\n",
+			want:   [][]string{{"two"}},
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -185,6 +185,13 @@ var goHelperMutations = []mutationCase{
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions", "-count=1"),
 	},
 	{
+		relativePath: "internal/metadatautil/shell_invocations.go",
+		original:     `		if !each.quoted && isOperator(each.text) {`,
+		replacement:  `		if isOperator(each.text) {`,
+		label:        "quoted syntax stays text for anchored validators",
+		command:      goCmd("test", "./internal/metadatautil", "-run", "TestValidateReleaseWorkflowAuthoritySplitRejectsEvasions", "-count=1"),
+	},
+	{
 		relativePath: "internal/metadatautil/validator_anchoring.go",
 		original:     `	if anchors != corpus {`,
 		replacement:  `	if false && anchors != corpus {`,

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 24
+  "expected_mutants": 25
 }


### PR DESCRIPTION
This is the quote-provenance unit that four separate review loops converged on. It
closes the seven threads those loops left staged, and moves every one of their cases
into the shared evasion corpus as a live row.

## The one defect

`shellWords` returned plain strings. A word that was quoted could not be told from
one that was not, so every caller that asked whether a word is *syntax* read text as
syntax. Quoting takes a word's meaning as syntax away without changing its meaning as
a name: bash runs `"oras" cp`, while a quoted `;` is an argument, a quoted `fi` is an
ordinary command, and a quoted `}` closes no group.

A word now carries `quoted`, set by any quote span or escape that contributes to it,
and the line reader decides a line continuation *after* the quoting is known rather
than before it.

## The four converging loops

| Loop | Thread | Case |
|---|---|---|
| #688 round on `ShellInvocations` | Preserve newlines inside single-quoted text | `'or\` / `as'` |
| #688 round on the delimiter word | Handle ANSI-C quoted heredoc delimiters | `<<$'PLAN'` |
| #691 rounds 4–7 | Preserve quotes around shell operators | `: ";" oras cp …` |
| | Preserve quoting when recognizing compound-command closers | a quoted `"fi"` |
| | Apply quote removal to ANSI-C heredoc delimiters | `<<$'PLAN'` |
| | Propagate conditional status through command groups | `false && { … }` |
| #691 round 3 on the brace count | Preserve quoting when tracking function braces | a quoted `"}"` |

Each was confirmed by probe against the merged parser before any change, and each is
a bypass in the fail-open direction: bash runs nothing while the parser reports the
anchored invocation.

```
: ";" oras cp one                        => [{[one] 2}]
if false; then / "fi" / oras cp one / fi => [{[one] 4}]
: <<$'PLAN' / $PLAN / oras cp one / PLAN => [{[one] 2}]
false && { / oras cp one / }             => [{[one] 3}]
never_called() { / "}" / oras cp one / } => [{[one] 1}]
'or\ / as' cp one || true                => [{[one] 1}]
```

All six now return no invocation, and the validator rejects.

## Changes

**Quote provenance.** `shellWords` returns `[]word` rather than `[]string`. The
operator split, the reserved-word lookup, the brace count and the definition test
each ask for an *unquoted* word. A name test still ignores provenance, because a name
keeps its meaning through quotes.

**The line continuation moves after the quoting.** Counting trailing backslashes in
the text decided a continuation before any quote state existed, so the literal
backslash of `'or\` joined two halves bash keeps apart, and the parser reported an
`oras cp` that never ran. `shellWords` now reports `continues`, and the reader that
knows the quoting is the one that decides. The same move retires the textual
`HasSuffix` test for a list operator at the end of a line: the last *word* decides.

**ANSI-C and locale quoting.** `$'…'` and `$"…"` are quoting forms whose `$` bash
removes with the quotes, so a body opened as `<<$'PLAN'` now ends at a `PLAN` line. A
`$'…'` delimiter that carries an escape is left unresolved and ends no body at all;
see review round 1.

**Conditional status survives a command group.** Conditional status was a property of
one command on one logical line, so only the opening `{` of `false && {` was marked.
The brace depth of the group a conditional command opens is now held until that group
closes, and nothing written inside it is proved to run.

The fail-closed philosophy is unchanged. Where provenance is still ambiguous the
line's words are dropped; no path invents an invocation.

## Corpus

Thirteen new rows, taking the corpus from 23 to 36: `quoted separator`, `quoted
compound-command closer`, `quoted brace in a definition`, `ANSI-C heredoc delimiter`,
`ANSI-C escape in a heredoc delimiter`, `locale-translated heredoc delimiter`,
`escaped apostrophe in an ANSI-C word`,
`ANSI-C span across a line break`, `single-quoted line break`, `conditional command
group`, `negated guarded group`, `argument brace in a guarded group` and `argument
brace in a definition body`. The last six arrived with the review rounds below. Every
row runs against all six anchors of the two anchored validators, 216 subtests in all.

`single-quoted line break` needs its second physical line at column zero of the
shell. It gets there through the YAML block scalar: the row writes both halves at the
block indent, and the dedent the parser performs puts the continuation at column
zero, so the row stays valid YAML and is a live bypass.

## Testing

- `go build ./...`
- `go test ./internal/metadatautil/ ./cmd/workcell-citools/ -count=1` — pass.
- `go test ./internal/mutation/ -count=1` — pass.
- `./scripts/check-validator-anchoring.sh` — green.
- `gofmt -l`, `go vet ./internal/metadatautil/` — clean.

### Mutation rows

Each fix was reverted on its own and the run named the control that failed. Fifteen
mutants cover the unit, and each is killed by the row or the case that claims it:

| Reverted fix | Control that fails |
|---|---|
| operator split ignores quoting | `quoted separator` |
| reserved-word lookup ignores quoting | `quoted compound-command closer` |
| brace count ignores quoting | `quoted brace in a definition` |
| ANSI-C delimiter quoting removed | `ANSI-C escape in a heredoc delimiter` |
| ANSI-C escape resolved anyway | `ANSI-C escape in a heredoc delimiter` |
| continuation decided before quoting | `single-quoted line break` |
| conditional status stops at the group brace | `conditional command group` |
| double-quoted continuation dropped | a backslash inside double quotes continues the line |
| conditional bound to the whole line | a conditional command guards no group a later operator opens |
| closing-brace line stops at the brace | a command after a guarded group's closing brace is read |
| ANSI-C escape does not consume its byte | `escaped apostrophe in an ANSI-C word` |
| argument brace counts anywhere in the command | `argument brace in a guarded group` |
| negation hides the group brace | `negated guarded group` |
| ANSI-C mode lost across physical lines | `ANSI-C span across a line break` |
| locale-translated delimiter resolved anyway | `locale-translated heredoc delimiter` |

One row joins the registry, `quoted syntax stays text for anchored validators`, which
drops the quote test from the operator split. `TestValidateReleaseWorkflowAuthority
SplitRejectsEvasions` fails on `quoted_separator` under both anchors and returns to
green when the fix is restored. `policy/mutation-score-policy.json` goes from 24 to
25 expected mutants.

Nineteen cases join the direct parser table, eight of them positive controls that keep the
change from over-rejecting: an unconditional command group still runs its body, the
line after a closed conditional group is still read, a double-quoted backslash still
continues its line, and a conditional command guards no group a later operator opens.

`go run ./cmd/workcell-citools run-mutation-tests` does not finish on this branch or
on `main`, for the two causes recorded on #691 that are older than both. The new row
was therefore applied by hand, exactly as the runner applies one.

## Notes

- `AGENTS.md` records the two new evasion classes the corpus covers.
- `braceDepth` keeps its `};` case. The operator split has made that spelling
  unreachable since #691, so it is pre-existing dead code and is left alone rather
  than removed in a behaviour change.

## Review round 1

Codex reported four findings on `599b09d8`, one P1 and three P2. All four were
reproduced by probe before any disposition and all four are fixed in `8bab2ae2`.

- **An ANSI-C delimiter that carries an escape.** `<<$'\x50LAN'` makes bash read
  through a `PLAN` line, while this reader ended the body at the encoded bytes and
  counted the line between as a command. Decoding the escapes here would be a second,
  smaller copy of the table bash uses, and a case it got wrong would end a body early
  again, in the same direction. A delimiter whose `$'…'` span carried a backslash is
  therefore recorded as unresolved and ends no body at all, so the rest of the script
  is read as data. New corpus row, taking the corpus to 30, killed by two mutants.
- **A backslash-newline inside double quotes.** Bash removes the pair, so the line
  continues. Moving the continuation decision after the quoting made the double-quote
  branch consume the byte first, and the branch now reports the continuation as the
  unquoted case does. A false rejection this branch introduced.
- **A conditional command that guards no group.** Conditional status was tested for
  the whole logical line, so `false && true; {` marked a group the semicolon had
  already released. The test is now per command.
- **The line that closes a guarded group.** It was discarded whole, so a command
  written after the brace was lost. The group is tracked per command rather than per
  line.

The last three were false rejections this branch introduced; the first was a bypass.

Ten mutants now cover the unit, each applied by hand and each killed by exactly the
row or the case that claims it. The corpus is 27 rows against six anchors.

## Review round 2

Codex reported two P1 findings on `8bab2ae2`. Both were reproduced by probe before any
disposition, both are fixed in `012e5686`, and a third case of the second defect that
the finding did not name is fixed with it.

- **An escaped apostrophe inside `$'…'`.** A backslash there escapes the next byte, so
  `\'` is a literal apostrophe. Closing the span on it exposed the rest of the line as
  syntax, and `: $'x\'; oras cp one'` was read as two commands where bash runs one
  inert `:` with a single argument.
- **A brace outside command position.** Bash reads the `}` of `echo }` as an argument,
  but `braceDepth` counted every word of a line, so that argument closed whatever was
  open. Both consumers had the defect: it cleared a guarded group, and it ended a
  function definition body. The second was not named by the finding and is closed by
  the same fix. `braceDepth` now sums the commands of a logical line and
  `commandBrace` reads the first word of each, with a definition header as the one
  place where the brace stands in command position after it.

Both were bypasses. Three corpus rows and three direct cases join, taking the corpus to
33 rows, and both definition forms still hide their bodies while the line after a
definition is still read.

## Review round 3

Codex reported two P1 findings on `012e5686`. Both were reproduced by probe before any
disposition and both are fixed in `e0e4d1c3`.

- **A brace behind a negation.** `!` negates the status of the command after it and is
  not a command of its own, so the brace of `false && ! {` still stands in command
  position. `commandBrace` read only the first word, so the guarded group was never
  tracked. An unguarded `! { … }` still runs its body.
- **ANSI-C mode across a line break.** The escape rules of a `$'…'` span lived only
  inside `shellWords`, while the line reader carried the quote byte alone and skipped
  the tail of the span with the plain single-quote rules, so an escaped apostrophe on
  the continuation line read as the closer. A shell quote is only `'` or `"`, so `$`
  is free to name the third case between lines; the skip now honours the escapes.

Both were bypasses. Two corpus rows and three direct cases join, taking the corpus to 35 rows.

## Review round 4

One P1 finding came in automatically on the `e0e4d1c3` push, and is fixed in
`0f5d43fe`.

- **A locale-translated delimiter.** A `$"…"` word is translated through the locale
  catalog before quote removal, so the text it spells in the file is not the text bash
  compares against a body line. It took the disposition the `$'…'` escape case already
  carries: unresolved, ending no body, so the rest of the script is read as data. The
  word-scoped flag is renamed from `ansiEscape` to `unresolved`, since it now records
  two reasons a delimiter cannot be spelled here rather than one.

A bypass. One corpus row and one direct case join.

## Review result

Four Codex rounds ran, three requested and one automatic. Nine findings, eight P1 and
one P2. Every one
was reproduced by probe before any disposition, and every one is fixed; none was
rebutted. One further case, an argument brace ending a function definition body, was
found while fixing a round 2 finding and is fixed and covered with it.

Four of the nine were false rejections this branch introduced and five were bypasses.
Each has a corpus row or a direct case that fails without its fix, and eight positive
controls keep the change from over-rejecting. All threads on this pull request are
resolved.
