### PR TITLE
^D Document the unconditional attestation posture and the release output check

### DIFF
--- a/docs/ci-threat-model.md
+++ b/docs/ci-threat-model.md
@@ -406,9 +406,9 @@ Run the hosted-control audit again.
    The same maintainer can sign a tag and approve the release environment.
    Workcell does not claim independent approval or separation of duties.
 
-7. **The code can omit attestations.**
-   `WORKCELL_RELEASE_NO_ATTEST=true` disables GitHub attestations.
-   Hosted policy pins this value to `false` for the canonical repository.
+7. **A reviewed code change can omit attestations.**
+   No repository variable disables GitHub attestations.
+   A fork must change and review the workflow and its validator.
    Cosign signatures remain mandatory.
 
 8. **Output verification shares the release run.**

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -159,7 +159,9 @@ No architecture build or assembly step can push packages or request an OIDC toke
 The `hosted-controls-audit` environment gates release preflight and final GitHub release publication.
 
 The release uses Cosign to create keyless Sigstore signatures.
-It also creates GitHub attestations when the reviewed hosted controls permit them.
+It creates GitHub attestations after a fixed public-repository guard.
+The guard reads the repository visibility from the GitHub event.
+It stops the release if the repository is not public.
 GitHub attestations do not replace Sigstore signatures.
 
 The final publisher has `actions: read` and `contents: write` permissions.
@@ -236,6 +238,11 @@ The canonical repository requires these variable values:
 - `WORKCELL_RELEASE_NO_ATTEST=false`
 - `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=false`
 
+The release workflow does not read those variables.
+It pins the attestation decision in versioned source.
+A variable change alone cannot make a release without attestations.
+The hosted-control policy still audits both values.
+
 The release environment permits protected `v*` tags only.
 It has no secret or variable content and no administrator bypass.
 
@@ -246,7 +253,8 @@ This requirement applies to public and private repositories.
 Private code scans and SARIF uploads depend on the GitHub plan.
 
 The public repository creates GitHub attestations.
-A private repository needs reviewed policy and plan support before it creates them.
+The canonical workflow stops for a private repository.
+A private repository needs a reviewed workflow change, a policy change, and plan support.
 
 ## Deliberate omissions
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -33,7 +33,7 @@ Nine assets contain release data:
 The other nine assets contain one Sigstore bundle for each release-data asset.
 The release also signs the runtime image in the container registry.
 
-By default, the release creates GitHub build-provenance attestations for these subjects:
+The release creates GitHub build-provenance attestations for these subjects:
 
 - the runtime image
 - the source bundle
@@ -45,6 +45,15 @@ By default, the release creates GitHub build-provenance attestations for these s
 The release also attaches an SBOM predicate to the image and source-bundle subjects.
 The SBOM files are not attestation subjects.
 Cosign signs each SBOM file as a release asset.
+
+After the signing job completes, an independent read-only job verifies the release outputs.
+It verifies all nine Sigstore bundles and the runtime image signature.
+It verifies the release image tag and the `sha-<commit>` image tag against the signed digest.
+It verifies eight provenance attestations and two SBOM attestations.
+The final publisher repeats these checks before it uploads the release assets.
+
+GitHub release immutability does not make GHCR tags immutable.
+Consumers must use `workcell-image.digest` as the image trust anchor.
 
 ## Published v1.0.2 evidence
 
@@ -101,6 +110,7 @@ The Sigstore path uses these parts:
 - short-lived Fulcio certificates
 - keyless Cosign signatures
 - Rekor transparency data in Sigstore bundles
+- post-signature verification of the release outputs
 
 This check does not need the GitHub attestation service.
 It still trusts the named GitHub release workflow identity.
@@ -108,21 +118,19 @@ It still trusts the named GitHub release workflow identity.
 ## GitHub attestation path
 
 The canonical public repository creates GitHub attestations.
-Its hosted-control policy requires both repository variables below to be `false`:
+The release workflow attests each reviewed subject without a condition.
+A guard before the build stops the release if the repository is not public.
 
-- `WORKCELL_RELEASE_NO_ATTEST`
-- `WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS`
-
-Do not set either variable to `true` in the canonical repository.
-The hosted-control check fails if a variable has a different value.
+The release workflow does not read a repository variable for this decision.
 Thus, a variable change alone cannot create an upstream release without attestations.
+The hosted-control policy still audits both variables at `false`.
 
 Do not use the old `WORKCELL_ENABLE_GITHUB_ATTESTATIONS` variable.
 The release workflow no longer uses that opt-in variable.
 
-A fork cannot enable an exception with a variable or policy-file change alone.
-It must first change and review both the hosted-control policy and its validator.
-This is a code-and-policy change, not an operator exception.
+A fork cannot enable an exception with a variable or policy-file change.
+It must first change and review the workflow and its validator.
+This is a code change, not an operator exception.
 A fork release without GitHub attestations has lower assurance.
 It must still create all Sigstore signatures.
 

--- a/docs/release-posture.md
+++ b/docs/release-posture.md
@@ -44,11 +44,11 @@ The `hosted-controls-audit` environment gates release preflight and final GitHub
 
 The workflow uses Cosign to create keyless Sigstore signatures.
 It signs the image, source archive, Homebrew formula, image-digest file, checksums, manifests, and software bills of materials.
-It also creates GitHub attestations when the reviewed hosted controls permit them.
+It creates GitHub attestations after a fixed public-repository guard.
 GitHub attestations are an additional verification surface.
 They do not replace Sigstore signatures.
 
-Forks can keep the GitHub attestation gates off.
-The upstream repository audits those gates as hosted control-plane state.
+Forks can remove the GitHub attestation steps with a reviewed code change.
+The upstream workflow does not accept a variable opt-out.
 
 See [provenance.md](provenance.md) and [github-workflows.md](github-workflows.md).


### PR DESCRIPTION
Unit 5 of the #650 series (superseded by #669). It documents what #669 (merged)
and #694 (unit 4, open) changed.

**Land this after #694.** The text describes attestations that run without a
condition, which is only true once that unit merges.

## What changes

`docs/ci-threat-model.md` residual risk 7 said
`WORKCELL_RELEASE_NO_ATTEST=true` disables GitHub attestations. No repository
variable does that any more, so the item now names the reviewed code change as
the only way to omit them.

`docs/github-workflows.md`, `docs/release-posture.md` and `docs/provenance.md`
said attestations run "when the reviewed hosted controls permit them". They now
describe the fixed public-repository guard and the unconditional attest steps.
The private-repository paragraph says the canonical workflow stops rather than
silently skipping.

The hosted-control policy still requires `WORKCELL_RELEASE_NO_ATTEST=false` and
`WORKCELL_ENABLE_PRIVATE_GITHUB_ATTESTATIONS=false`, and
`scripts/verify-github-hosted-controls.sh` still audits them, so both variable
lists stay. Each one now says the release workflow does not read them.

`docs/provenance.md` also gains the release output verification that #669
shipped and no document described: an independent read-only job verifies the
nine Sigstore bundles, the runtime image signature, the release tag and
`sha-<commit>` image tags, and ten GitHub attestations, and the final publisher
repeats those checks. Counts were read from
`scripts/verify-release-outputs.sh`: eight provenance subjects plus two SBOM
predicates.

## Deviation from the series plan

The plan listed four files and 145 lines, including the `repository_dispatch`
trigger, the `main` workflow identity, and the release-tag rulesets. That text
belongs to unit 3 (#682), which is still open, and the #650 branch's remaining
doc hunks also revert work that has since merged on `main`: the authority split
(#672), the advisory hostile-environment lanes (#687), the validator passwd
record, and the manual-workflow `main`-ref guards.

So this unit ships only the part that merged `main` plus #694 makes true, and
adds `docs/ci-threat-model.md`, which the plan missed and which #694 makes
factually wrong. `docs/releasing.md` and the dispatch, tag-identity and
ruleset text are deferred to a follow-up cut after #682 merges.

## Testing

- `codespell --config .codespellrc` over `docs/*.md` — clean
- `markdownlint docs/*.md` — clean
- `./scripts/check-doc-links.sh`, `check-doc-support-matrix-fields.sh`,
  `check-public-contract.sh`, `check-pinned-inputs.sh`,
  `check-public-repo-hygiene.sh` — all exit 0
- `./scripts/ci/job-docs.sh` reached the containerized spelling and manpage step
  and stopped there: the Colima daemon cannot bind this checkout's path. The
  spelling and Markdown checks that step runs were run directly on the host
  instead, with the repository's own `.codespellrc` and markdownlint config.
- Every claim was read back from the source it describes:
  `scripts/verify-release-outputs.sh` for the counts,
  `policy/github-hosted-controls.toml` for the audited variables.
- Review loop deferred.

Shape: 4 files, +33/-19 = 52 changed lines, 1 area.