### PR TITLE
^B Probe the pinned Go toolchain the hosted-controls audit actually builds with

### DIFF
--- a/internal/metadatautil/pinnedinputs_shell.go
+++ b/internal/metadatautil/pinnedinputs_shell.go
@@ -17,7 +17,7 @@ import (
 // former mvdan.cc/sh AST audit (command allowlist, call counts, and
 // canonical function bodies): every structural drift those checks caught
 // also changes the file bytes.
-const canonicalHostedShellFileSHA256 = "dcb4bb32cb48ca2411d004f905ff90f5f1508d0b959e339f939c277e45c65cc0"
+const canonicalHostedShellFileSHA256 = "7597c524bbd92c2190fb25c7e427a4f4389d413309cdbd60d0b2e52277e4ed0f"
 
 var errHostedShellRouting = errors.New("scripts/verify-github-hosted-controls.sh must use the exact reviewed command graph and versioned github_api wrapper")
 

--- a/scripts/verify-github-hosted-controls.sh
+++ b/scripts/verify-github-hosted-controls.sh
@@ -89,7 +89,12 @@ resolve_trusted_go_bin() {
     "/opt/hostedtoolcache/go/${expected_toolchain#go}/${toolchain_arch}/bin/go" \
     /opt/homebrew/bin/go /usr/local/go/bin/go /usr/local/bin/go /usr/bin/go; do
     [[ -x "${candidate}" ]] || continue
-    actual_toolchain="$(GOTOOLCHAIN=local "${candidate}" env GOVERSION 2>/dev/null)" || continue
+    # Probe the toolchain the build will actually run under, not the version
+    # this candidate happens to be: hosted runners cache only older Go
+    # releases, so the pinned toolchain is reached the way every other lane
+    # reaches it, through the checksum-verified toolchain switch driven from
+    # a binary on a trusted path.
+    actual_toolchain="$(GOTOOLCHAIN="${expected_toolchain}" "${candidate}" env GOVERSION 2>/dev/null)" || continue
     if [[ "${actual_toolchain}" == "${expected_toolchain}" ]]; then
       printf '%s\n' "${candidate}"
       return 0


### PR DESCRIPTION
## Problem

The `Hosted controls` workflow has failed on **every** `main` push for 30 consecutive runs. Each run dies after ~10s with a single line:

```
The exact Go toolchain from go.mod is unavailable at a trusted path.
```

## Root cause

`resolve_trusted_go_bin()` in `scripts/verify-github-hosted-controls.sh` walks a list of trusted-path `go` binaries and accepts one only if its **own** version already equals the `toolchain` line in `go.mod`, probing with `GOTOOLCHAIN=local`.

`go.mod` pins `toolchain go1.27.1`. The `ubuntu-24.04` runner image (`20260831.293`) caches only Go **1.24.13, 1.25.14, 1.26.7** — and `hosted-controls.yml` has no Go setup step. So `/opt/hostedtoolcache/go/1.27.1/x64/bin/go` does not exist, every remaining candidate reports a non-matching version under `GOTOOLCHAIN=local`, the function returns 1, and the audit exits before doing any work.

The gate was asking the wrong question. The build that follows (`build_go_tool_in_repo` → `resolve_go_bin`) runs under the default `GOTOOLCHAIN=auto`, which honours the `go.mod` toolchain line and fetches the exact pinned, checksum-verified toolchain — the same mechanism every other Go lane in the repo relies on. Only the pre-flight probe insisted the ambient binary already *be* 1.27.1.

## Fix

Probe with `GOTOOLCHAIN="${expected_toolchain}"` instead of `GOTOOLCHAIN=local`, so the check reflects the toolchain the build will actually use. The candidate list stays restricted to trusted paths, so the trust boundary is unchanged: the toolchain switch is still driven from a binary on a trusted path, and the fetched toolchain is checksum-verified. A binary that already is 1.27.1 still matches, so the previously-working local/dev case is preserved.

`internal/metadatautil/pinnedinputs_shell.go` pins the script's raw-byte SHA256 and its comment requires the digest be updated in the same change; that constant is updated here.

## First bad commit

`f35f5dfa37` — "Merge pull request #660 from omkhar/security/f046-hosted-token-isolation". That PR introduced `resolve_trusted_go_bin` and the Go build step; the script required no Go at all before it. The run on the preceding commit `92e773d81f` (#656) was the last green one.

## Validation

- Reproduced the failure and verified the fix in isolation: with a pinned toolchain that differs from the ambient binary, the old probe returns exit 1 (the exact CI symptom) and the new probe resolves a trusted-path binary and returns 0.
- `GOTOOLCHAIN=<version> go env GOVERSION` confirmed to report the *requested* toolchain, not the ambient one.
- `./scripts/run-hosted-controls-audit.sh omkhar/workcell` runs end to end against the live repository: exit 0.
- `./scripts/check-pinned-inputs.sh` passes (confirms the updated digest).
- `./scripts/check-workflows.sh` passes.
- `go test ./internal/metadatautil/ ./internal/testkit/` passes.
- `shellcheck -x` and `shfmt -ln=bash -i 2 -ci -d` clean on the changed script.

Note: `hosted-controls.yml` is gated on `if: github.ref == 'refs/heads/main'`, so this lane cannot execute on a PR branch. The verification above is the strongest available before merge; the workflow should be watched on the post-merge `main` push.

## Not included

The same `main` run also showed a red `CI` run from a flaky `Reproducible build (arm64)` job (a digest mismatch after a Debian snapshot CDN retry storm; `amd64` passed on identical source). Rerunning those jobs turned them green with no code change, so nothing here addresses it.

The `Hostile environment (root/uidmap/tmpdir)` jobs are also red, but they carry `continue-on-error: true`, are deliberately excluded from required checks, and were already red on the preceding commit — out of scope for this change.

---

Review deferred: opened for the maintainer's review; not merged.
