### PR TITLE
^b URGENT main-red fix: bind the startup socket test fixture under a short directory

### DIFF
--- a/cmd/workcell-apt-broker-server/startup_linux_test.go
+++ b/cmd/workcell-apt-broker-server/startup_linux_test.go
@@ -232,10 +232,20 @@ func startupBody(body string) startupReader {
 // boundStartupSocket stands in for the socket a launched server binds. Close
 // must not unlink it, or the test could not tell the starter's cleanup apart
 // from the listener's own.
+//
+// The directory is not tb.TempDir(): that path is TMPDIR plus the full subtest
+// name, which overruns the AF_UNIX sun_path limit under the TMPDIR CI exports
+// and makes bind() fail with a bare EINVAL. internal/aptbroker keeps its own
+// short-directory helpers for the same reason.
 func boundStartupSocket(tb testing.TB) string {
 	tb.Helper()
 
-	path := filepath.Join(tb.TempDir(), "socket")
+	directory, err := os.MkdirTemp("/tmp", "wcbs-")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(directory) })
+	path := filepath.Join(directory, "socket")
 	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
 	if err != nil {
 		tb.Fatal(err)


### PR DESCRIPTION
**URGENT: fixes a red `main`.** PR #699 merged with the required `Validate repository` check failing. Review is deferred; the intent is to get `main` green.

## Root cause

Not a semantic conflict with #697, and not a `claimSocketPath` behaviour problem. It is a test-fixture defect in `boundStartupSocket`, which #699 added.

The helper derived its AF_UNIX bind path from `tb.TempDir()`. That path is `TMPDIR` plus the full subtest name:

```
/tmp/workcell-home-1001/.tmp/TestFinishStartupTransfersOnlyValidatedServerempty_readiness3039847854/001/socket
```

That is 110 bytes. `sun_path` holds 108 including the NUL, so `bind()` returns a bare `EINVAL` that surfaces as `bind: invalid argument`.

`scripts/ci/run-validate-in-validator.sh` exports `TMPDIR=/tmp/workcell-home-<uid>/.tmp` (28 bytes). A local run with a plain `TMPDIR=/tmp` yields 82 bytes and passes, which is why #699's author saw green locally.

The length arithmetic explains exactly which subtests failed. The fixed prefix and suffix cost 94 bytes, leaving 13 for the subtest name:

| Subtest | Name bytes | Path bytes | CI result |
|---|---|---|---|
| `success` | 7 | 101 | pass |
| `read_timeout` | 12 | 106 | pass |
| `empty_readiness` | 15 | 109 | **fail** |
| `deadline_failure` | 16 | 110 | **fail** |
| `socket_metadata` | 15 | 109 | **fail** |
| `acknowledgement` | 15 | 109 | **fail** |
| `duplicate_readiness` | 18 (truncated) | 112 | **fail** |

The two short names passing and the five long ones failing matches the CI log exactly.

## Fix

Take the socket directory from `os.MkdirTemp("/tmp", "wcbs-")` instead of `tb.TempDir()`, with a `tb.Cleanup` that removes it. This is the approach `internal/aptbroker` already uses for its own bound sockets (`shortSocketDir` in `server_test.go`, `unixConnectionPair` in `helper_linux_test.go`), so the repository pattern is reused rather than reinvented.

Six code lines plus a comment recording why `tb.TempDir()` is wrong here.

**Production is unaffected.** The server binds the fixed `/run/workcell/apt-broker/socket` (31 bytes), and `internal/aptbroker.checkSocketPathLength` already guards that path at 103 bytes. No production code changed.

## Evidence

Reproduced and verified in a Linux container under the validator's conditions: uid 1001, `HOME=/tmp/workcell-home-1001`, `TMPDIR=$HOME/.tmp`, synthesized `/etc/passwd` record.

- **Before:** identical failure to CI, same five subtests, same `bind: invalid argument` message.
- **After:** `go test ./cmd/workcell-apt-broker-server/... ./internal/aptbroker/... -count=30` passes.
- **Full suite:** `go test ./...` passes with no failures.
- **Hostile axes:** `cmd/workcell-apt-broker-server` passes under both the `tmpdir` axis (the ~80-character padding `run-validate-in-validator.sh` documents as targeting exactly this `sun_path` surface) and the `root` axis.
- **Mutation control:** dropping `removeAbandonedSocket(socketPath)` from `stopStartupProcess` fails all six error subtests with `socket removed = false, want true`. The assertion is live, and it now runs on six subtests where five previously aborted at `bind()` before reaching it.

## Pre-existing issue, not fixed here

`internal/aptbroker/client_test.go:59` calls `os.MkdirTemp("", "wcbr")`, which resolves to `TMPDIR` and overruns `sun_path` under the `tmpdir` hostile axis. It predates #699 (commit `c2b3dfc`), affects only the advisory hostile lane rather than the required check, and is left out to keep this urgent fix surgical. Worth a separate PR.
