### PR TITLE
^B Decide a native exec descriptor target by provenance rather than by a root list (differential container proof: five descriptor forms escape the guard on main and are refused after; user-visible execution boundary)

### DIFF
--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -476,6 +476,14 @@ fn duplicate_fd_file(fd: c_int) -> Option<File> {
     File::open(proc_fd_path(fd)).ok()
 }
 
+/// The host build has no `/proc` and never runs the guard, so it keeps the
+/// root-list answer the descriptor classifiers used before provenance.
+#[cfg(not(target_os = "linux"))]
+fn fd_target_is_untrusted_exec(fd: c_int) -> bool {
+    fd_target_is_mutable_root(fd)
+}
+
+#[cfg(not(target_os = "linux"))]
 fn fd_target_is_mutable_root(fd: c_int) -> bool {
     let Ok(target) = fs::read_link(proc_fd_path(fd)) else {
         return false;
@@ -486,6 +494,77 @@ fn fd_target_is_mutable_root(fd: c_int) -> bool {
     }
 
     resolved_path_is_mutable_root(trim_deleted_suffix(&target.to_string_lossy()))
+}
+
+/// The descriptor's own `(dev, ino)`, read from the descriptor rather than from
+/// a pathname. `fstat` needs no read permission, so an exec-only target still
+/// answers.
+#[cfg(target_os = "linux")]
+fn fd_signature(fd: c_int) -> Option<StatSignature> {
+    let mut stat_buf = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: fd is only borrowed for this call and stat_buf is valid writable storage for one libc::stat.
+    if unsafe { libc::fstat(fd, stat_buf.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    // SAFETY: fstat returned 0, so the kernel fully initialized stat_buf.
+    let stat_buf = unsafe { stat_buf.assume_init() };
+    stat_signature_from_stat(&stat_buf)
+}
+
+/// The descriptor twin of `path_is_trusted_immutable`.
+///
+/// Provenance is a property of a pathname — who can replace what sits at that
+/// name — and a descriptor has no pathname of its own. `/proc/self/fd/N`
+/// recovers the name the descriptor was opened through, which is the only thing
+/// the path predicate can be asked about. That recovery is exactly where a
+/// check/use gap lives: the name can hold a different file now than the one the
+/// descriptor is open on, and the kernel executes the descriptor. So the answer
+/// is pinned by comparing the descriptor's own `(dev, ino)` against the name's.
+/// A mismatch means the name was replaced after the descriptor was opened, and
+/// the trusted answer belongs to a file this exec will not run.
+///
+/// Three shapes have no name to ask about at all and are untrusted outright: a
+/// descriptor the kernel reports as deleted, one on anonymous memory (`memfd:`,
+/// `anon_inode:`), and one whose link is not an absolute path (a pipe or a
+/// socket). None of them can be judged by provenance, and a memory descriptor
+/// is precisely what a caller reaches for to execute bytes it wrote itself.
+#[cfg(target_os = "linux")]
+fn fd_target_is_trusted_immutable(fd: c_int) -> bool {
+    let Ok(link) = fs::read_link(proc_fd_path(fd)) else {
+        return false;
+    };
+    let link = link.to_string_lossy();
+    if link.ends_with(" (deleted)")
+        || link.starts_with("memfd:")
+        || link.starts_with("/memfd:")
+        || link.starts_with("anon_inode:")
+        || link.starts_with("/anon_inode:")
+        || !link.starts_with('/')
+    {
+        return false;
+    }
+    let Ok(canonical) = fs::canonicalize(Path::new(link.as_ref())) else {
+        return false;
+    };
+    if !path_is_trusted_immutable(&canonical) {
+        return false;
+    }
+    let Some(descriptor) = fd_signature(fd) else {
+        return false;
+    };
+    fs::metadata(&canonical)
+        .map(|metadata| {
+            let named = metadata_signature_from_metadata(&metadata);
+            descriptor.dev == named.dev && descriptor.ino == named.ino
+        })
+        .unwrap_or(false)
+}
+
+/// The descriptor could have been planted or replaced by this process, so the
+/// exec it feeds is one the guard must classify rather than trust.
+#[cfg(target_os = "linux")]
+fn fd_target_is_untrusted_exec(fd: c_int) -> bool {
+    !fd_target_is_trusted_immutable(fd)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -733,20 +812,31 @@ fn resolve_command_via_path_value(
     }
 }
 
-fn file_descriptor_is_native_elf(fd: c_int) -> bool {
-    let Some(mut file) = duplicate_fd_file(fd) else {
-        return false;
-    };
-
-    let mut header = [0u8; 4];
-    matches!(file.read_exact(&mut header), Ok(())) && header == [0x7f, b'E', b'L', b'F']
-}
-
+/// The descriptor form of `path_is_mutable_native_exec`, and the same shape: a
+/// target this process could have planted or could still replace, whose
+/// contents the loader will run natively. A descriptor the guard cannot read
+/// stays unclassified and is refused, as the path side refuses one it cannot
+/// read.
 fn file_descriptor_is_mutable_native_exec(fd: c_int) -> bool {
-    current_mode_blocks_mutable_native_exec()
-        && fd >= 0
-        && fd_target_is_mutable_root(fd)
-        && file_descriptor_is_native_elf(fd)
+    if !current_mode_blocks_mutable_native_exec() || fd < 0 || !fd_target_is_untrusted_exec(fd) {
+        return false;
+    }
+    let Some(mut file) = duplicate_fd_file(fd) else {
+        return true;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return true;
+    };
+    // Only a regular file is executable at all; anything else keeps the
+    // kernel's own errno.
+    if (metadata.mode() & file_type_bits()) != regular_file_mode() {
+        return false;
+    }
+    let mut header = [0u8; 4];
+    if file.read_exact(&mut header).is_err() {
+        return true;
+    }
+    header == [0x7f, b'E', b'L', b'F']
 }
 
 fn next_shebang_token(cursor: &mut &str) -> Option<String> {
@@ -971,7 +1061,7 @@ fn file_descriptor_is_mutable_shebang_to_protected_runtime(
     env_entries: &[String],
 ) -> bool {
     fd >= 0
-        && fd_target_is_mutable_root(fd)
+        && fd_target_is_untrusted_exec(fd)
         && file_descriptor_targets_protected_runtime_via_shebang(fd, env_entries)
 }
 
@@ -3642,6 +3732,140 @@ mod tests {
             libc::AT_FDCWD
         ));
 
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn descriptor_provenance_answers_for_the_named_file_or_refuses() {
+        // A descriptor opened on a trusted-immutable pathname keeps that
+        // answer, so the ordinary case is not blanket-refused.
+        let trusted = File::open("/bin/true").expect("open /bin/true");
+        assert!(fd_target_is_trusted_immutable(trusted.as_raw_fd()));
+        assert!(!fd_target_is_untrusted_exec(trusted.as_raw_fd()));
+
+        let dir = create_temp_test_dir("fd-provenance");
+        let planted = dir.join("planted");
+        fs::write(&planted, "planted").expect("write planted");
+        let planted_file = File::open(&planted).expect("open planted");
+        assert!(fd_target_is_untrusted_exec(planted_file.as_raw_fd()));
+
+        // A deleted target has a name that no longer holds it, so there is
+        // nothing left to ask about.
+        let unlinked = dir.join("unlinked");
+        fs::write(&unlinked, "unlinked").expect("write unlinked");
+        let unlinked_file = File::open(&unlinked).expect("open unlinked");
+        fs::remove_file(&unlinked).expect("unlink");
+        assert!(fd_target_is_untrusted_exec(unlinked_file.as_raw_fd()));
+
+        // A descriptor with no pathname at all cannot be judged by provenance.
+        let (socket, _peer) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        assert!(fd_target_is_untrusted_exec(socket.as_raw_fd()));
+
+        // A descriptor the guard cannot read back is refused, not trusted.
+        assert!(fd_target_is_untrusted_exec(-1));
+
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    /// The check/use closure this unit exists for: the pathname a descriptor
+    /// was opened through can hold a different file by the time provenance is
+    /// read off it, and the kernel executes the descriptor rather than the
+    /// name. Building the case needs a trusted-immutable pathname to start
+    /// from, which only a root runtime can create; the pinned container lane
+    /// runs as root and a non-root host has nothing to build it out of, so the
+    /// body only runs where the premise holds.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_replaced_pathname_no_longer_matches_its_descriptor() {
+        let dir = Path::new("/opt/workcell-fd-check-use-test");
+        if fs::create_dir(dir).is_err() {
+            return;
+        }
+        let run = || -> Option<()> {
+            let named = dir.join("named");
+            fs::write(&named, "the file the descriptor is open on").ok()?;
+            let opened = File::open(&named).ok()?;
+            // The premise: without the replacement this descriptor is trusted.
+            if !fd_target_is_trusted_immutable(opened.as_raw_fd()) {
+                return None;
+            }
+
+            // Provenance is read from the directory, not from a root list:
+            // this fixture sits outside every mutable exec root and is still
+            // untrusted once anyone but its owner can write it. That is the
+            // whole difference between the root-list answer and this one, so
+            // the classifier is asserted here rather than on a temp-directory
+            // fixture the root list already covers.
+            let writable = dir.join("writable");
+            fs::write(&writable, [0x7f, b'E', b'L', b'F', 2, 1, 1, 0]).ok()?;
+            fs::set_permissions(&writable, fs::Permissions::from_mode(0o666)).ok()?;
+            let writable_file = File::open(&writable).ok()?;
+            let writable_fd = writable_file.as_raw_fd();
+            assert!(!resolved_path_is_mutable_root(&writable.to_string_lossy()));
+            assert!(fd_target_is_untrusted_exec(writable_fd));
+            assert!(file_descriptor_is_mutable_native_exec(writable_fd));
+            assert!(path_is_mutable_native_exec(&proc_fd_path(writable_fd)));
+
+            let replacement = dir.join("replacement");
+            fs::write(&replacement, "a different file").ok()?;
+            fs::rename(&replacement, &named).ok()?;
+            // The name still resolves to a trusted-immutable file, and the
+            // descriptor is still open on the original one.
+            assert!(path_is_trusted_immutable(&named));
+            assert!(fd_target_is_untrusted_exec(opened.as_raw_fd()));
+            Some(())
+        };
+        let outcome = run();
+        fs::remove_dir_all(dir).expect("cleanup the check/use fixture");
+        if outcome.is_none() {
+            println!("skipping: this runtime cannot own a trusted-immutable pathname");
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mutable_native_exec_classifies_a_descriptor_target() {
+        let dir = create_temp_test_dir("fd-native-exec");
+        let elf = dir.join("elf");
+        fs::write(&elf, [0x7f, b'E', b'L', b'F', 2, 1, 1, 0]).expect("write elf");
+        let elf_file = File::open(&elf).expect("open elf");
+        let elf_fd = elf_file.as_raw_fd();
+        assert!(file_descriptor_is_mutable_native_exec(elf_fd));
+        // And the `/proc/self/fd` pathname form reaches the same answer, which
+        // is how the path entry points hand a descriptor target over.
+        assert!(path_is_mutable_native_exec(&proc_fd_path(elf_fd)));
+
+        // A trusted-immutable native target is still allowed through.
+        let trusted = File::open("/bin/true").expect("open /bin/true");
+        assert!(!file_descriptor_is_mutable_native_exec(trusted.as_raw_fd()));
+
+        // Not a regular file: nothing the kernel would execute, so it keeps
+        // its own errno rather than this refusal.
+        let dir_file = File::open(&dir).expect("open the fixture directory");
+        assert!(!file_descriptor_is_mutable_native_exec(
+            dir_file.as_raw_fd()
+        ));
+
+        // Untrusted and unreadable is refused rather than passed through. Its
+        // contents are not an ELF, so a readable copy of the same file answers
+        // no and only the failed read can produce the refusal. A root runtime
+        // reads it regardless, so the case asserts where the read really fails.
+        let unreadable = dir.join("unreadable");
+        fs::write(&unreadable, "not an elf").expect("write unreadable");
+        let unreadable_file = File::open(&unreadable).expect("open unreadable");
+        let unreadable_fd = unreadable_file.as_raw_fd();
+        assert!(!file_descriptor_is_mutable_native_exec(unreadable_fd));
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000))
+            .expect("drop read permission");
+        if duplicate_fd_file(unreadable_fd).is_none() {
+            assert!(file_descriptor_is_mutable_native_exec(unreadable_fd));
+        }
+
+        assert!(!file_descriptor_is_mutable_native_exec(-1));
+
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644))
+            .expect("restore read permission");
         fs::remove_dir_all(&dir).expect("cleanup temp test dir");
     }
 

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -21,7 +21,7 @@
 //! mutable exec roots and the protected runtime signatures exist. Each pending
 //! reason names the lane that holds the form, or states that no lane holds it.
 
-use Call::{Execve, ExecveNullEnv, Execveat, Execvp};
+use Call::{Execve, ExecveNullEnv, Execveat, ExecveatMemfd, Execvp};
 use Expect::{NotRefused, Pending, Refused};
 use libc::c_int;
 use std::ffi::{CString, OsString};
@@ -107,6 +107,12 @@ enum Call {
         &'static [&'static str],
         &'static [&'static str],
     ),
+    /// `execveat(memfd, "", argv, envp, AT_EMPTY_PATH)`. The target has no
+    /// pathname at all: it is bytes this process wrote into anonymous memory,
+    /// which is the shape a caller reaches for to execute something it built
+    /// itself. Only the descriptor names it, so only descriptor provenance can
+    /// answer for it.
+    ExecveatMemfd(&'static [&'static str]),
     /// `execvp(file, argv)` with `PATH` and one more variable set on the
     /// caller. `execvp` reads the caller's own environment for both the search
     /// and the loader-override check, never the child environment. An empty
@@ -503,6 +509,12 @@ const FORMS: &[Form] = &[
         NotRefused,
         LINUX,
     ),
+    form(
+        "execveat of an anonymous memory descriptor",
+        ExecveatMemfd(GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        LINUX,
+    ),
     // PATH resolution, read from the caller's own environment.
     form(
         "relative PATH entry is refused rather than searched",
@@ -723,6 +735,52 @@ fn run(call: &Call, fixture: &Path) -> String {
             // SAFETY: dirfd was opened above, is still open, and is closed once.
             unsafe { libc::close(dirfd) };
             stderr
+        }
+        ExecveatMemfd(env) => {
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = env;
+                unreachable!("the memfd row is Linux-only");
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let name = c_string("workcell-loader-form-memfd", fixture);
+                // SAFETY: name is a live NUL-terminated CString; memfd_create only reads it and returns an owned descriptor.
+                let memfd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+                assert!(memfd >= 0, "create the anonymous memory descriptor");
+                // ELF magic so the native-exec classifier reaches its
+                // provenance answer, followed by bytes no kernel will load, so
+                // an unrefused row cannot replace this process.
+                let mut payload: Vec<u8> = vec![0x7f, b'E', b'L', b'F'];
+                payload.extend_from_slice(b"not a loadable image");
+                // SAFETY: memfd is open and owned here; payload is a live buffer of the stated length.
+                let written = unsafe { libc::write(memfd, payload.as_ptr().cast(), payload.len()) };
+                assert_eq!(
+                    written,
+                    payload.len() as isize,
+                    "fill the memory descriptor"
+                );
+                let empty = c_string("", fixture);
+                let argv = c_strings(TARGET_ARGV, fixture);
+                let env = c_strings(env, fixture);
+                let argv = c_pointers(&argv);
+                let env = c_pointers(&env);
+                let stderr = capture_stderr(|| {
+                    // SAFETY: memfd is an open descriptor; empty, argv and env are live and NULL-terminated for the call.
+                    unsafe {
+                        workcell_exec_guard::execveat(
+                            memfd,
+                            empty.as_ptr(),
+                            argv.as_ptr(),
+                            env.as_ptr(),
+                            libc::AT_EMPTY_PATH,
+                        );
+                    }
+                });
+                // SAFETY: memfd was opened above, is still open, and is closed once.
+                unsafe { libc::close(memfd) };
+                stderr
+            }
         }
         Execvp(file, path_value, extra_env) => {
             let (extra_key, extra_value) = extra_env.split_once('=').unwrap_or(("", ""));

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -3204,6 +3204,15 @@ run_container_stdin codex bash -c 'exec 3<&0; exec </dev/null; source /dev/fd/3'
   assert_refused_at_or_before_target() {
     grep -Eq "$1|Workcell blocked child execution without the approved exec guard preload" "$2"
   }
+  # A deleted target cannot always be reopened through its /proc/self/fd link:
+  # a virtiofs-backed workspace answers ENOENT for the reopen. The guard refuses
+  # a descriptor it cannot read rather than leaving the target to the kernel, so
+  # the same row reports the shebang classification where the reopen works and
+  # the native-exec refusal where it does not. Either refusal, and the kernel's
+  # own error, proves the launch does not happen.
+  assert_deleted_fd_shebang_refused() {
+    grep -Eq "Workcell blocked direct protected runtime execution|Workcell blocked direct native executable launch from mutable runtime paths on the strict profile\.|cannot execute: required file not found|No such file or directory" "$1"
+  }
   codex_user_script=/run/workcell/container-smoke-codex-user.sh
   cat >"${codex_user_script}" <<'CODEX_USER_SCRIPT'
     set -Eeuo pipefail
@@ -4053,12 +4062,12 @@ EOF
     exit 1
   fi
   exec 4<&-
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-fd.out
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-devfd.out
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-dotfd.out
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-threadself.out
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-taskfd.out
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-stdin.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-fd.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-devfd.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-dotfd.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-threadself.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-taskfd.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-stdin.out
   cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-pidfd" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell pid fd deleted shebang bypass");
@@ -4072,7 +4081,7 @@ EOF
     echo "expected strict profile to reject deleted-fd mutable shebang execution via /proc/\$\$/fd of the real Node payload" >&2
     exit 1
   fi
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-pidfd.out
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-pidfd.out
   cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-stdout" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell stdout deleted shebang bypass");
@@ -4087,7 +4096,7 @@ EOF
     echo "expected strict profile to reject deleted-fd mutable shebang execution via /dev/stdout of the real Node payload" >&2
     exit 1
   fi
-  grep -Eq "Workcell blocked direct protected runtime execution|cannot execute: required file not found|No such file or directory" /tmp/workspace-node-shebang-deleted-stdout.err
+  assert_deleted_fd_shebang_refused /tmp/workspace-node-shebang-deleted-stdout.err
   cat >"${workspace_exec_scratch}/.workcell-node-shebang-deleted-stderr" <<EOF
 #!/usr/local/libexec/workcell/real/node
 console.log("workcell stderr deleted shebang bypass");


### PR DESCRIPTION
Unit 6 of the #652 series. Units 1-5 are #670, #676, #684, #685 and #697, all
merged. This is the descriptor side of the trusted-immutable predicate #697
landed for pathnames.

## The hole

`file_descriptor_is_mutable_native_exec` asked `fd_target_is_mutable_root`:
does the descriptor's `/proc/self/fd` link resolve into a mutable root? Two
kinds of target answered no and ran unclassified.

- A native executable in **any writable directory outside the root list**. #697
  closed that on the path side; a descriptor on the same file still passed.
- A descriptor on **anonymous memory**. A memfd link canonicalises to nothing,
  so `resolved_path_is_mutable_root` answered no for it, and `fexecve` or
  `execveat(AT_EMPTY_PATH)` on bytes the caller wrote itself reached the kernel
  with no policy check at all.

## What a trusted descriptor is now

`fd_target_is_trusted_immutable` asks #697's question, pinned to the descriptor
the kernel will execute:

- the descriptor must have a pathname to ask about. A target the kernel reports
  as deleted, a `memfd:` or `anon_inode:` link, and a link that is not an
  absolute path each have no name for provenance to be read from, and are
  untrusted outright.
- that pathname must be trusted immutable, by #697's predicate.
- the descriptor's own `(dev, ino)` must still match the pathname's.

The third condition is the **check/use closure** #684 dispositioned and #685
recorded as "needs descriptor discipline the entry points do not have yet".
Recovering a pathname from a descriptor is exactly where the gap lives: the
name can hold a different file by the time provenance is read off it, and it is
the descriptor that gets executed. The signature comparison makes the trusted
answer belong to the file this exec will actually run. `fstat` reads it from
the descriptor, so an exec-only target answers too.

`file_descriptor_is_mutable_native_exec` and
`file_descriptor_is_mutable_shebang_to_protected_runtime` both read the new
answer, so all eight `guarded_*` entry points are wired without further change
— every one already routed a descriptor target through them.

The native classifier also takes the path side's shape: a regular-file
requirement, and a fail-closed refusal for a descriptor the guard cannot read.
`path_is_mutable_native_exec` refuses an untrusted target it cannot read; the
descriptor form now does the same rather than passing it through.

`file_descriptor_is_native_elf` is folded into the classifier and
`fd_target_is_mutable_root` becomes the host-build answer only. Both were
orphaned by this change rather than being pre-existing dead code.

## Differential proof

Guard built from `origin/main` and from this branch in the pinned toolchain
image (`rust:1.97.1-slim-trixie`, the digest the Dockerfile pins, aarch64),
installed at the approved preload path in turn, one C caller run under
`LD_PRELOAD` against each.

| case | target | main | this branch |
| --- | --- | --- | --- |
| control: known-blocked ELF in `/tmp` | `/tmp/payload` | BLOCKED mutable-native | BLOCKED mutable-native |
| control: trusted ELF, ordinary `execve` | `/bin/true` | TARGET-EXECUTED | TARGET-EXECUTED |
| control: trusted ELF by descriptor | `/bin/true` | TARGET-EXECUTED | TARGET-EXECUTED |
| `fexecve`, ELF in a writable non-root directory | `/opt/probe-writable/tool` | **TARGET-EXECUTED** | **BLOCKED mutable-native** |
| `execveat` `AT_EMPTY_PATH`, same target | `/opt/probe-writable/tool` | **TARGET-EXECUTED** | **BLOCKED mutable-native** |
| `execve` via `/proc/self/fd`, same target | `/opt/probe-writable/tool` | **TARGET-EXECUTED** | **BLOCKED mutable-native** |
| `fexecve` of a memfd copy of a trusted ELF | anonymous memory | **TARGET-EXECUTED** | **BLOCKED mutable-native** |
| `execveat` `AT_EMPTY_PATH` of a memfd copy | anonymous memory | **TARGET-EXECUTED** | **BLOCKED mutable-native** |

The first control is the harness lesson from #685 applied first: a case the
guard is known to refuse on both sides, so the table is believed only after the
harness has been shown to observe a block at all. The two pass-through controls
show the branch does not blanket-refuse a descriptor. `/opt/probe-writable/tool`
is world-writable and outside every entry in `MUTABLE_EXEC_ROOTS`, so main's
root-list answer is "not mutable" and only provenance can refuse it.

## Negative controls

Both new assertions were re-run against a copy of this branch with the
descriptor answer reverted to `fd_target_is_mutable_root`, and both fail:

- `a_replaced_pathname_no_longer_matches_its_descriptor` fails at the
  classifier assertion on the world-writable fixture.
- `tests/loader_forms.rs` fails the memfd row: *expected "…mutable runtime
  paths…", saw ""*.

## Loader form matrix

`tests/loader_forms.rs` gains the descriptor-source axis this unit introduces:
`execveat(memfd, "", argv, envp, AT_EMPTY_PATH)`, refused for the mutable-native
classification. The payload carries ELF magic followed by bytes no kernel will
load, so an unrefused row cannot replace the test process. No `PENDING_FORMS`
entry becomes answerable here — see below for the raw-syscall row.

## Container smoke

Green, after one assertion change, and `origin/main` was run through the same
lane on the same host first as the control (exit 0) so the one row that moved
could be attributed rather than guessed at.

Eight rows execute a deleted `/workspace` shebang script through its descriptor.
Reading the shebang needs the target reopened through its `/proc/self/fd` link,
and a **virtiofs-backed workspace answers ENOENT for that reopen** — so on main
those rows passed on the kernel's "required file not found" rather than on a
guard decision. With the classifier failing closed on a descriptor it cannot
read, the guard now refuses the exec itself and reports the native-exec
classification. The rows share `assert_deleted_fd_shebang_refused`, which
accepts either guard refusal alongside the kernel errors; the shebang
classification is still what fires wherever the reopen works, which is every
filesystem the runtime image is built and shipped on. Each row's claim — that
the launch does not happen — is unchanged, and the new answer is a stronger one
than the kernel error it replaces.

Both outcomes were reproduced directly, one row at a time, against a
main-built and a branch-built image in the same workspace.

## Testing

- macOS host: `cargo fmt --all --check` clean; `cargo clippy --all-targets
  --offline --locked -- -D warnings` zero warnings (this crate denies
  `undocumented_unsafe_blocks`); `cargo test --offline --locked` 29 + 17 + 1
  pass.
- Pinned Linux image: `cargo fmt --all --check` clean; `cargo clippy
  --all-targets --offline --locked -- -D warnings` zero warnings; `cargo build
  --release --locked --offline` links; `cargo test --offline --locked`
  **39 + 17 + 1** pass. The 39 includes the Linux-gated cases.
- `bash -n`, `shellcheck -x`, `shfmt -ln=bash -i 2 -ci -d` on
  `scripts/container-smoke.sh` — clean.
- `go build ./...`; `go test ./internal/workcellhardening/ ./internal/testkit/
  ./internal/metadatautil/ -count=1` — ok. These assert on
  `container-smoke.sh` contents.
- `./scripts/check-validator-anchoring.sh` — exit 0.
- `grep -rnE 'unsafe extern( +"[^"]*")? *\{' runtime/container/rust/src` — two
  pre-existing hits, both already carrying a `// SAFETY:` comment. This unit
  adds one `unsafe` block, the `fstat` call, which carries its own.
- Review loop deferred.

New tests: `descriptor_provenance_answers_for_the_named_file_or_refuses`,
`a_replaced_pathname_no_longer_matches_its_descriptor`,
`mutable_native_exec_classifies_a_descriptor_target`.

The check/use test needs a trusted-immutable pathname to start from, which only
a root runtime can create. It builds its fixture under `/opt`, and skips with a
printed reason where the premise does not hold, so it asserts in the pinned
container lane and does not report a false pass on a non-root host.

## Deviations from the source branch

- `fd_target_is_trusted_immutable` also refuses a link that is not an absolute
  path. The source checks only the deleted, `memfd:` and `anon_inode:` prefixes;
  a pipe or a socket reports `pipe:[…]` / `socket:[…]`, which those prefixes do
  not name.
- `file_descriptor_is_mutable_native_exec` stays one function with the
  provenance answer `#[cfg]`-split, rather than the source's two full copies.
  `file_descriptor_is_native_elf` is folded in and deleted; the source leaves
  it.
- The source's shebang-to-native-interpreter work in the same functions is unit
  7 and is not pulled forward.

## Deliberate ceilings

- A magic exec **pathname** (`execve("/proc/self/fd/N", …)`) is still
  classified by reading the descriptor, and the kernel re-resolves the pathname
  after this guard returns, so a `dup2` between the two wins the race. #697
  refuses a *loader* named through a magic path for exactly this reason, and
  `should_block_mutable_native_exec` routes a `/proc/self/fd/N` target to the
  descriptor branch before that rule is reached, so the rule does not currently
  cover that one form. Closing it means executing the descriptor rather than
  the pathname, which is units 8 and 9; refusing every magic exec pathname
  instead would refuse the `/dev/stdin` and `/proc/self/fd` forms the runtime
  legitimately uses. It is left whole for the unit that can offer the
  alternative.
- Reading a descriptor still goes through its `/proc/self/fd` link rather than
  a `pread` on a duplicate, which is what makes the deleted-target reopen
  filesystem-dependent. Every existing descriptor reader on `main` does the
  same; changing it is a separate refactor, and the classifier fails closed
  where the read does not answer.
- `RAW_SYSCALL_PENDING` stays pending, and its reason is now confirmed rather
  than inherited: `nm -D --defined-only` on the release cdylib built from this
  branch lists `execl`, `execle`, `execlp`, `execv`, `execve`, `execveat`,
  `execvp`, `execvpe`, `fexecve`, `posix_spawn`, `posix_spawnp`, the eight
  `guarded_*` names and `workcell_syscall_shim` — and **not** `syscall`, even
  though `lib.rs` carries a `global_asm!` trampoline defining it. Nothing
  interposes a raw `syscall(SYS_execve, …)`, so a row over it would report a
  false pass. Pre-existing on `main`, untouched here, still recorded for the
  trampoline unit.

## Shape

3 files, +312/-21 = 333 changed lines, 2 areas.

## Remaining units

7 — untrusted shebang to native interpreter (needs 5 and 6). 8 — memfd
snapshot execution, direct exec paths (needs 5-7, and carries the magic-pathname
ceiling above). 9 — memfd snapshot execution, descriptor and spawn paths (needs
8).

`security/rust-exec-hardening` stays as the extraction source until the series
lands.
