### PR TITLE
^B Classify the native interpreter a shebang line names (differential container proof: a one-line script launches a refused binary on main and is refused after; user-visible execution boundary)

### DIFF
--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1063,6 +1063,115 @@ fn buffer_targets_protected_runtime_via_shebang(buffer: &str, env_entries: &[Str
     classify_protected_runtime_path(&target) != ProtectedRuntime::None
 }
 
+/// Decides whether a shebang interpreter is one this process could have planted
+/// or could still replace.
+///
+/// The kernel reads the shebang line and resolves the interpreter itself, after
+/// this guard has returned. So the interpreter is a second exec target the
+/// guard never sees an entry point for, and a one-line script is all it takes
+/// to launch a native binary the guard would refuse if it were named directly.
+/// A relative name resolves against a working directory this process can
+/// change, and a magic descriptor path against a table it can rewrite; neither
+/// can be approved for what it names now.
+fn shebang_path_is_untrusted_native_exec(path: &str) -> bool {
+    if !current_mode_blocks_mutable_native_exec() || path.is_empty() {
+        return false;
+    }
+
+    #[cfg(target_os = "linux")]
+    if !Path::new(path).is_absolute() || path_is_magic_exec_target(path) {
+        return true;
+    }
+
+    #[cfg(target_os = "linux")]
+    if path_has_untrusted_provenance(path, libc::AT_FDCWD) {
+        return true;
+    }
+
+    path_is_mutable_native_exec(path)
+}
+
+fn env_command_targets_untrusted_native_exec(cursor: &str, env_entries: &[String]) -> bool {
+    let (command, mut scan) = match scan_env_command(cursor, env_entries) {
+        EnvCommand::Refused => return true,
+        EnvCommand::None => return false,
+        EnvCommand::Command(command, rest) => (command, rest),
+    };
+
+    if is_dynamic_loader_path(&command) {
+        // The loader reads its own target out of the rest of the line, so the
+        // decision belongs to that target rather than to the loader.
+        return next_shebang_token(&mut scan)
+            .is_some_and(|target| loader_arg_targets_mutable_native_exec(&target));
+    }
+
+    shebang_path_is_untrusted_native_exec(&command)
+}
+
+fn buffer_targets_untrusted_native_via_shebang(buffer: &str, env_entries: &[String]) -> bool {
+    if !buffer.starts_with("#!") {
+        return false;
+    }
+
+    let mut cursor = &buffer[2..];
+    let Some(interpreter) = next_shebang_token(&mut cursor) else {
+        return false;
+    };
+
+    if token_uses_env_interpreter(&interpreter) {
+        return env_command_targets_untrusted_native_exec(cursor, env_entries);
+    }
+
+    if is_dynamic_loader_path(&interpreter) {
+        return next_shebang_token(&mut cursor)
+            .is_some_and(|target| loader_arg_targets_mutable_native_exec(&target));
+    }
+
+    shebang_path_is_untrusted_native_exec(&interpreter)
+}
+
+/// A descriptor the guard cannot read is not judged here: the native classifier
+/// beside this one already refuses an untrusted descriptor it cannot read, and
+/// a trusted one must not be refused for a shebang line nobody could see.
+fn file_descriptor_is_untrusted_shebang_native_exec(fd: c_int, env_entries: &[String]) -> bool {
+    if fd < 0 {
+        return false;
+    }
+    let Some(mut file) = duplicate_fd_file(fd) else {
+        return false;
+    };
+    let mut buffer = [0u8; 511];
+    let Ok(bytes) = file.read(&mut buffer) else {
+        return false;
+    };
+    buffer_targets_untrusted_native_via_shebang(
+        &String::from_utf8_lossy(&buffer[..bytes]),
+        env_entries,
+    )
+}
+
+/// A name that does not open is left to the native classifier beside this one,
+/// which already refuses an untrusted target whether or not it exists.
+fn path_is_untrusted_shebang_native_exec(path: &str, env_entries: &[String]) -> bool {
+    if !current_mode_blocks_mutable_native_exec() || path.is_empty() {
+        return false;
+    }
+    if let Some(proc_fd) = path_is_current_process_fd_path(path) {
+        return file_descriptor_is_untrusted_shebang_native_exec(proc_fd, env_entries);
+    }
+    let Ok(mut file) = File::open(path) else {
+        return false;
+    };
+    let mut buffer = [0u8; 511];
+    let Ok(bytes) = file.read(&mut buffer) else {
+        return false;
+    };
+    buffer_targets_untrusted_native_via_shebang(
+        &String::from_utf8_lossy(&buffer[..bytes]),
+        env_entries,
+    )
+}
+
 fn file_descriptor_targets_protected_runtime_via_shebang(
     fd: c_int,
     env_entries: &[String],
@@ -1948,13 +2057,16 @@ fn should_block_protected_runtime_exec(
     path_is_mutable_shebang_to_protected_runtime(path, env_entries)
 }
 
-fn should_block_mutable_native_exec(path: &str, args: &[String]) -> bool {
+fn should_block_mutable_native_exec(path: &str, args: &[String], env_entries: &[String]) -> bool {
     if let Some(proc_fd) = path_is_current_process_fd_path(path) {
         return file_descriptor_is_mutable_native_exec(proc_fd)
-            || loader_fd_targets_mutable_native_exec(proc_fd, args);
+            || loader_fd_targets_mutable_native_exec(proc_fd, args)
+            || file_descriptor_is_untrusted_shebang_native_exec(proc_fd, env_entries);
     }
 
-    path_is_mutable_native_exec(path) || loader_targets_mutable_native_exec(path, args)
+    path_is_mutable_native_exec(path)
+        || loader_targets_mutable_native_exec(path, args)
+        || path_is_untrusted_shebang_native_exec(path, env_entries)
 }
 
 // execvp, execvpe and posix_spawnp all search PATH from the caller's own
@@ -2241,7 +2353,7 @@ unsafe extern "C" fn guarded_execve(
         report_protected_runtime_block();
         return -1;
     }
-    if should_block_mutable_native_exec(&path_string, &args) {
+    if should_block_mutable_native_exec(&path_string, &args, &env_entries) {
         report_mutable_native_exec_block();
         return -1;
     }
@@ -2283,7 +2395,7 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
         report_protected_runtime_block();
         return -1;
     }
-    if should_block_mutable_native_exec(&path_string, &args) {
+    if should_block_mutable_native_exec(&path_string, &args, &env_entries) {
         report_mutable_native_exec_block();
         return -1;
     }
@@ -2348,7 +2460,7 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
         report_protected_runtime_block();
         return -1;
     }
-    if should_block_mutable_native_exec(&effective_path, &args) {
+    if should_block_mutable_native_exec(&effective_path, &args, &env_entries) {
         report_mutable_native_exec_block();
         return -1;
     }
@@ -2417,7 +2529,7 @@ unsafe extern "C" fn guarded_execvpe(
         report_protected_runtime_block();
         return -1;
     }
-    if should_block_mutable_native_exec(&effective_path, &args) {
+    if should_block_mutable_native_exec(&effective_path, &args, &env_entries) {
         report_mutable_native_exec_block();
         return -1;
     }
@@ -2474,7 +2586,8 @@ unsafe extern "C" fn guarded_execveat(
         (
             protected_target,
             file_descriptor_is_mutable_native_exec(dirfd)
-                || loader_fd_targets_mutable_native_exec(dirfd, &args),
+                || loader_fd_targets_mutable_native_exec(dirfd, &args)
+                || file_descriptor_is_untrusted_shebang_native_exec(dirfd, &env_entries),
             file_descriptor_is_mutable_shebang_to_protected_runtime(dirfd, &env_entries),
             fd_matches_workcell_native_launcher(dirfd),
             should_block_loader_env_for_fd(dirfd, &env_entries),
@@ -2518,6 +2631,12 @@ unsafe extern "C" fn guarded_execveat(
                     if !mutable_native_target {
                         mutable_native_target =
                             loader_fd_targets_mutable_native_exec(candidate_fd, &args);
+                    }
+                    if !mutable_native_target {
+                        mutable_native_target = file_descriptor_is_untrusted_shebang_native_exec(
+                            candidate_fd,
+                            &env_entries,
+                        );
                     }
                     if !mutable_native_target {
                         mutable_shebang_target =
@@ -2621,6 +2740,7 @@ unsafe extern "C" fn guarded_fexecve(
     }
     if file_descriptor_is_mutable_native_exec(fd)
         || loader_fd_targets_mutable_native_exec(fd, &args)
+        || file_descriptor_is_untrusted_shebang_native_exec(fd, &env_entries)
     {
         report_mutable_native_exec_block();
         return -1;
@@ -2673,7 +2793,7 @@ unsafe extern "C" fn guarded_posix_spawn(
         report_protected_runtime_block();
         return libc::EPERM;
     }
-    if should_block_mutable_native_exec(&path_string, &args) {
+    if should_block_mutable_native_exec(&path_string, &args, &env_entries) {
         report_mutable_native_exec_block();
         return libc::EPERM;
     }
@@ -2737,7 +2857,7 @@ unsafe extern "C" fn guarded_posix_spawnp(
         report_protected_runtime_block();
         return libc::EPERM;
     }
-    if should_block_mutable_native_exec(&effective_path, &args) {
+    if should_block_mutable_native_exec(&effective_path, &args, &env_entries) {
         report_mutable_native_exec_block();
         return libc::EPERM;
     }
@@ -3895,6 +4015,76 @@ mod tests {
 
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644))
             .expect("restore read permission");
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn untrusted_shebang_interpreters_are_refused() {
+        let dir = create_temp_test_dir("shebang-native");
+        // The interpreter is a native binary this process planted. The script
+        // is not an ELF, so the native classifier finds nothing in it; the
+        // shebang line is the only place the interpreter appears.
+        let interpreter = dir.join("tool");
+        fs::write(&interpreter, [0x7f, b'E', b'L', b'F', 2, 1, 1, 0]).expect("write interpreter");
+        fs::set_permissions(&interpreter, fs::Permissions::from_mode(0o755))
+            .expect("make the interpreter executable");
+        let script = dir.join("wrapper");
+        fs::write(&script, format!("#!{}\n", interpreter.display())).expect("write script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("make the script executable");
+        let script_path = script.display().to_string();
+
+        assert!(!path_is_mutable_native_exec(&script_path));
+        assert!(path_is_untrusted_shebang_native_exec(&script_path, &[]));
+        assert!(should_block_mutable_native_exec(&script_path, &[], &[]));
+
+        // A trusted interpreter is left alone, so an ordinary script still
+        // runs and the refusal is about the interpreter rather than the script.
+        let trusted = dir.join("trusted-shebang");
+        fs::write(&trusted, "#!/bin/sh\nexit 0\n").expect("write trusted shebang");
+        let trusted_path = trusted.display().to_string();
+        assert!(!path_is_untrusted_shebang_native_exec(&trusted_path, &[]));
+        assert!(!should_block_mutable_native_exec(&trusted_path, &[], &[]));
+
+        // The interpreter env would run is judged the same way, through the
+        // shared env(1) walk.
+        assert!(env_command_targets_untrusted_native_exec(
+            &format!(" {}", interpreter.display()),
+            &[]
+        ));
+        assert!(!env_command_targets_untrusted_native_exec(" /bin/sh", &[]));
+        // The loader-environment controls still answer first in that walk.
+        assert!(env_command_targets_untrusted_native_exec(
+            " -S /bin/sh",
+            &[]
+        ));
+
+        // A name the kernel resolves after this guard returns cannot be pinned.
+        assert!(shebang_path_is_untrusted_native_exec("relative-tool"));
+        assert!(shebang_path_is_untrusted_native_exec("/proc/self/fd/9"));
+        assert!(shebang_path_is_untrusted_native_exec("/dev/stdin"));
+        assert!(!shebang_path_is_untrusted_native_exec("/bin/sh"));
+        // No interpreter is not an untrusted one.
+        assert!(!shebang_path_is_untrusted_native_exec(""));
+        assert!(!buffer_targets_untrusted_native_via_shebang(
+            "not a shebang\n",
+            &[]
+        ));
+
+        // The descriptor form reaches the same answers.
+        let script_file = File::open(&script).expect("open script");
+        assert!(file_descriptor_is_untrusted_shebang_native_exec(
+            script_file.as_raw_fd(),
+            &[]
+        ));
+        let trusted_file = File::open(&trusted).expect("open trusted script");
+        assert!(!file_descriptor_is_untrusted_shebang_native_exec(
+            trusted_file.as_raw_fd(),
+            &[]
+        ));
+        assert!(!file_descriptor_is_untrusted_shebang_native_exec(-1, &[]));
+
         fs::remove_dir_all(&dir).expect("cleanup temp test dir");
     }
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -1130,11 +1130,17 @@ fn buffer_targets_untrusted_native_via_shebang(buffer: &str, env_entries: &[Stri
     shebang_path_is_untrusted_native_exec(&interpreter)
 }
 
-/// A descriptor the guard cannot read is not judged here: the native classifier
-/// beside this one already refuses an untrusted descriptor it cannot read, and
-/// a trusted one must not be refused for a shebang line nobody could see.
+/// Only a script this process could have written names an interpreter it chose.
+/// A trusted-immutable script's shebang line is the image's, and the runtime's
+/// own wrappers are written that way, so scanning them would refuse the image's
+/// own choices rather than the caller's. This is the same precondition
+/// `file_descriptor_is_mutable_shebang_to_protected_runtime` carries.
+///
+/// A descriptor the guard cannot read is not judged here either: the native
+/// classifier beside this one already refuses an untrusted descriptor it cannot
+/// read, and a trusted one must not be refused for a line nobody could see.
 fn file_descriptor_is_untrusted_shebang_native_exec(fd: c_int, env_entries: &[String]) -> bool {
-    if fd < 0 {
+    if fd < 0 || !fd_target_is_untrusted_exec(fd) {
         return false;
     }
     let Some(mut file) = duplicate_fd_file(fd) else {
@@ -1158,6 +1164,12 @@ fn path_is_untrusted_shebang_native_exec(path: &str, env_entries: &[String]) -> 
     }
     if let Some(proc_fd) = path_is_current_process_fd_path(path) {
         return file_descriptor_is_untrusted_shebang_native_exec(proc_fd, env_entries);
+    }
+    // See the descriptor form: only a script this process could have written
+    // names an interpreter it chose.
+    #[cfg(target_os = "linux")]
+    if !path_has_untrusted_provenance(path, libc::AT_FDCWD) {
+        return false;
     }
     let Ok(mut file) = File::open(path) else {
         return false;
@@ -4038,6 +4050,15 @@ mod tests {
         assert!(!path_is_mutable_native_exec(&script_path));
         assert!(path_is_untrusted_shebang_native_exec(&script_path, &[]));
         assert!(should_block_mutable_native_exec(&script_path, &[], &[]));
+
+        // The image's own wrappers are trusted-immutable scripts written with
+        // `#!/usr/bin/env -S ...`, which the scan cannot follow past. Their
+        // shebang line is the image's rather than the caller's, so a trusted
+        // script is not scanned at all.
+        let trusted_script = "/usr/local/libexec/workcell/development-wrapper.sh";
+        if Path::new(trusted_script).exists() {
+            assert!(!path_is_untrusted_shebang_native_exec(trusted_script, &[]));
+        }
 
         // A trusted interpreter is left alone, so an ordinary script still
         // runs and the refusal is about the interpreter rather than the script.

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -922,7 +922,26 @@ fn shell_option_executes_command(option: &str) -> bool {
     option.starts_with('-') && option[1..].contains('c')
 }
 
-fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -> bool {
+/// What an `env(1)` shebang line comes to once its options have been walked the
+/// way env walks them.
+enum EnvCommand<'a> {
+    /// env rewrites the loader environment before the target starts, or names a
+    /// command the guard cannot resolve. Either way the line is refused without
+    /// reading a target.
+    Refused,
+    /// The command env would execute, and the rest of the line after it.
+    Command(String, &'a str),
+    /// The line names no command at all.
+    None,
+}
+
+/// Walks an `env(1)` shebang line to the command env would run.
+///
+/// Every classifier that reads a shebang asks the same question of this prefix
+/// and differs only in what it makes of the command the walk yields. One walk
+/// is the point: every defect in this class has been a syntactic form one
+/// scanner handled and its sibling did not.
+fn scan_env_command<'a>(cursor: &'a str, env_entries: &[String]) -> EnvCommand<'a> {
     let mut scan = cursor;
     let mut path_override: Option<String> = None;
 
@@ -931,7 +950,7 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
         // options that add, drop or replace it end the scan with a refusal.
         if let Some(name) = env_long_option_name(&token) {
             if "split-string".starts_with(name) || "ignore-environment".starts_with(name) {
-                return true;
+                return EnvCommand::Refused;
             }
             if "unset".starts_with(name) {
                 let unset = token
@@ -939,27 +958,27 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
                     .map(|(_, value)| value.to_owned())
                     .or_else(|| next_shebang_token(&mut scan));
                 if unset.is_some_and(|name| token_is_loader_environment_name(&name)) {
-                    return true;
+                    return EnvCommand::Refused;
                 }
                 continue;
             }
         }
         if token == "-" || token_clusters_loader_environment_control(&token) {
-            return true;
+            return EnvCommand::Refused;
         }
         if token == "-u" {
             if next_shebang_token(&mut scan)
                 .is_some_and(|name| token_is_loader_environment_name(&name))
             {
-                return true;
+                return EnvCommand::Refused;
             }
             continue;
         }
         if token_is_loader_environment_unset_option(&token) {
-            return true;
+            return EnvCommand::Refused;
         }
         if token_is_loader_environment_assignment(&token) {
-            return true;
+            return EnvCommand::Refused;
         }
 
         if let Some(path) = token.strip_prefix("PATH=") {
@@ -978,32 +997,42 @@ fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -
         ) {
             Ok(Some(path)) => path,
             Ok(None) => token.clone(),
-            // Fail closed: an unclassifiable interpreter is treated as blocked.
-            Err(_) => return true,
+            // Fail closed: an unclassifiable command is treated as blocked.
+            Err(_) => return EnvCommand::Refused,
         };
 
-        if token_is_shell_interpreter(&token_path)
-            && let Some(target) = next_shebang_token(&mut scan)
-            && shell_option_executes_command(&target)
-        {
-            return true;
-        }
-
-        if classify_protected_runtime_path(&token_path) != ProtectedRuntime::None {
-            return true;
-        }
-
-        if !is_dynamic_loader_path(&token_path) {
-            return false;
-        }
-
-        let Some(target) = next_shebang_token(&mut scan) else {
-            return false;
-        };
-        return classify_protected_runtime_path(&target) != ProtectedRuntime::None;
+        return EnvCommand::Command(token_path, scan);
     }
 
-    false
+    EnvCommand::None
+}
+
+fn env_command_targets_protected_runtime(cursor: &str, env_entries: &[String]) -> bool {
+    let (command, mut scan) = match scan_env_command(cursor, env_entries) {
+        EnvCommand::Refused => return true,
+        EnvCommand::None => return false,
+        EnvCommand::Command(command, rest) => (command, rest),
+    };
+
+    if token_is_shell_interpreter(&command)
+        && let Some(target) = next_shebang_token(&mut scan)
+        && shell_option_executes_command(&target)
+    {
+        return true;
+    }
+
+    if classify_protected_runtime_path(&command) != ProtectedRuntime::None {
+        return true;
+    }
+
+    if !is_dynamic_loader_path(&command) {
+        return false;
+    }
+
+    let Some(target) = next_shebang_token(&mut scan) else {
+        return false;
+    };
+    classify_protected_runtime_path(&target) != ProtectedRuntime::None
 }
 
 fn buffer_targets_protected_runtime_via_shebang(buffer: &str, env_entries: &[String]) -> bool {

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -83,6 +83,22 @@ const PROBE: &str = "workcell-loader-form-probe";
 /// answers ENOEXEC for it, and glibc's execvp runs /bin/sh from inside libc,
 /// which does not re-enter the guard, so the guard must classify it first.
 const ENOEXEC_TARGET: &str = "enoexec-fallback-target";
+/// A native interpreter in the fixture directory, and a one-line script naming
+/// it. The kernel resolves a shebang interpreter after the guard returns, so
+/// the script is the only thing an entry point sees and the interpreter is a
+/// second exec target that reaches no entry point at all.
+const SHEBANG_INTERPRETER: &str = "shebang-native-interpreter";
+const SHEBANG_SCRIPT_NAME: &str = "shebang-native-wrapper";
+const SHEBANG_SCRIPT: &str = "{fixture}/shebang-native-wrapper";
+/// The same interpreter reached through `env`, which resolves it after its own
+/// option walk rather than reading it from the shebang line directly. The env
+/// binary the row names is a fixture rather than `/usr/bin/env`: an interpreter
+/// that really runs would replace this test process before any row after it,
+/// and the scanner recognises env by basename, so a fixture reaches the same
+/// walk while staying unexecutable.
+const ENV_NAME: &str = "env";
+const ENV_SHEBANG_SCRIPT_NAME: &str = "env-shebang-native-wrapper";
+const ENV_SHEBANG_SCRIPT: &str = "{fixture}/env-shebang-native-wrapper";
 /// Bytes past `MAX_EXEC_PATH_SEGMENT_BYTES` in `src/lib.rs`.
 const OVERLONG_SEGMENT_BYTES: usize = 128 * 1024 + 1;
 
@@ -509,6 +525,25 @@ const FORMS: &[Form] = &[
         NotRefused,
         LINUX,
     ),
+    // Shebang resolution, which the kernel performs after the guard returns.
+    form(
+        "shebang naming an untrusted native interpreter",
+        Execve(SHEBANG_SCRIPT, TARGET_ARGV, GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        LINUX,
+    ),
+    form(
+        "shebang naming an untrusted native interpreter, by descriptor",
+        Execveat(SHEBANG_SCRIPT_NAME, TARGET_ARGV, GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        LINUX,
+    ),
+    form(
+        "env(1) shebang naming an untrusted native interpreter",
+        Execve(ENV_SHEBANG_SCRIPT, TARGET_ARGV, GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
+        LINUX,
+    ),
     form(
         "execveat of an anonymous memory descriptor",
         ExecveatMemfd(GUARDED_ENV),
@@ -645,6 +680,44 @@ fn prepare_fixture() -> PathBuf {
     // The PATH search only yields a candidate that answers X_OK.
     fs::set_permissions(&enoexec, fs::Permissions::from_mode(0o755))
         .expect("make the ENOEXEC fixture executable");
+    // A script whose interpreter is a native binary in this directory, which
+    // this process owns. The interpreter carries ELF magic so the shebang scan
+    // reaches its provenance answer, and bytes no kernel will load, so an
+    // unrefused row cannot replace this process.
+    fs::write(
+        fixture.join(SHEBANG_INTERPRETER),
+        [0x7f, b'E', b'L', b'F', 2, 1, 1, 0],
+    )
+    .expect("write the shebang interpreter fixture");
+    fs::set_permissions(
+        fixture.join(SHEBANG_INTERPRETER),
+        fs::Permissions::from_mode(0o755),
+    )
+    .expect("make the shebang interpreter executable");
+    let script = fixture.join(SHEBANG_SCRIPT_NAME);
+    fs::write(
+        &script,
+        format!("#!{}/{SHEBANG_INTERPRETER}\n", fixture.display()),
+    )
+    .expect("write the shebang script fixture");
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+        .expect("make the shebang script executable");
+    fs::write(fixture.join(ENV_NAME), [0x7f, b'E', b'L', b'F', 2, 1, 1, 0])
+        .expect("write the env fixture");
+    fs::set_permissions(fixture.join(ENV_NAME), fs::Permissions::from_mode(0o755))
+        .expect("make the env fixture executable");
+    let env_script = fixture.join(ENV_SHEBANG_SCRIPT_NAME);
+    fs::write(
+        &env_script,
+        format!(
+            "#!{}/{ENV_NAME} {}/{SHEBANG_INTERPRETER}\n",
+            fixture.display(),
+            fixture.display()
+        ),
+    )
+    .expect("write the env shebang script fixture");
+    fs::set_permissions(&env_script, fs::Permissions::from_mode(0o755))
+        .expect("make the env shebang script executable");
     fixture
 }
 


### PR DESCRIPTION
Unit 7 of the #652 series. Units 1-6 are #670, #676, #684, #685, #697 and
#703, all merged.

## The hole

The guard refuses a native executable it cannot trust. A one-line script walked
around that refusal.

The kernel reads a shebang line and resolves the interpreter itself, after this
guard has returned. So the interpreter is a second exec target that reaches no
entry point at all, and the script naming it is not an ELF, so the native
classifier finds nothing in it. Writing

    #!/some/writable/tool

into a file the caller can write, and executing that file, launched
`/some/writable/tool` — a target the guard refuses outright when it is named
directly.

## What lands

**`shebang_path_is_untrusted_native_exec`** decides an interpreter the way #697
and #703 decide any other native target, and refuses two shapes outright
because the kernel resolves them after this guard returns: a relative name,
which resolves against a working directory this process can change, and a magic
descriptor path, which resolves against a table it can rewrite.

**`buffer_targets_untrusted_native_via_shebang`** reads the line — through the
`env(1)` walk when the interpreter is env, and through the loader's own
argument scan when it is the dynamic loader.
**`path_is_untrusted_shebang_native_exec`** and
**`file_descriptor_is_untrusted_shebang_native_exec`** are the two readers, and
`should_block_mutable_native_exec` carries both. All eight `guarded_*` entry
points are wired, including the two descriptor branches inside
`guarded_execveat` and the descriptor branch in `guarded_fexecve`.

Neither reader fails closed on a target it cannot read, and that is deliberate:
the native classifier beside it already refuses an untrusted target it cannot
read, and a trusted one must not be refused for a shebang line nobody could
see.

## The env(1) walk is now shared, not copied

The first commit is a mechanical split, and it is the point of the unit rather
than tidying: every defect in this class has been one syntactic form a scanner
handled and its sibling did not. `scan_env_command` is the option walk
`env_command_targets_protected_runtime` already had, statement for statement,
returning `Refused` / `Command(command, rest)` / `None`; both scanners now read
that one result and differ only in what they make of the command. The two
focused tests over the walk pass unchanged.

## The gate that took a second commit

The first revision scanned *every* script's shebang. The runtime's own wrappers
are written

    #!/usr/bin/env -S BASH_ENV= ENV= bash

and `-S` re-splits the rest of the line into tokens the scan cannot follow, so
the walk refuses it — correctly, for a line the caller wrote. Applied to the
image's own wrappers it refused them instead, and container smoke stopped at
the first `sudo` request:

    Workcell blocked direct native executable launch from mutable runtime paths
    bash: /usr/local/bin/sudo: /usr/bin/env: bad interpreter: Operation not permitted

Reproduced one request at a time against the image built from unit 6 and from
that revision: unit 6 reports the broker's own "malformed privileged package
request", the revision reports the guard refusing `/usr/local/bin/sudo`.

A shebang names an interpreter the **caller** chose only when the caller could
have written the script. A trusted-immutable script's shebang line is the
image's, and the image's interpreter choices are not a bypass of this guard. So
both readers carry the precondition
`file_descriptor_is_mutable_shebang_to_protected_runtime` already carried:
untrusted provenance on the path side, an untrusted descriptor on the other.
That is also the shape of the attack in the first place — a script the caller
planted, naming a binary the caller planted.

## Differential proof

Pinned toolchain image, guard built from the unit-6 state (which is what `main`
became) and from this branch, one caller under `LD_PRELOAD` against each.

| case | unit 6 | this branch |
| --- | --- | --- |
| control: known-blocked ELF in `/tmp` | BLOCKED mutable-native | BLOCKED mutable-native |
| control: trusted ELF, ordinary `execve` | TARGET-EXECUTED | TARGET-EXECUTED |
| control: script with a trusted `/bin/sh` interpreter | TARGET-EXECUTED | TARGET-EXECUTED |
| shebang naming an untrusted native interpreter | **TARGET-EXECUTED** | **BLOCKED mutable-native** |
| shebang naming a relative interpreter | **TARGET-EXECUTED** | **BLOCKED mutable-native** |
| same script through `execveat`, dirfd-relative | BLOCKED, ENOENT | BLOCKED mutable-native |
| `env(1)` shebang naming the same interpreter | BLOCKED mutable-native | BLOCKED mutable-native |

The last two rows are not differentials and are not meant to be. The kernel
answers `ENOENT` for a shebang executed through a dirfd on both sides; the
`env(1)` row is refused on both, because env is itself a guarded process whose
own `execvp` of the interpreter is refused at the second hop. This unit refuses
it at the first hop, where the script is, which is the hop that exists whether
or not the next one is guarded — the direct shebang row above is the case where
there is no second hop at all.

The third control matters: an ordinary script with a trusted interpreter still
runs under both guards, so the branch is not blanket-refusing scripts.

## Negative controls

Against a copy of this branch with the three wiring terms removed:

- `untrusted_shebang_interpreters_are_refused` fails at
  `should_block_mutable_native_exec`.
- all three new `tests/loader_forms.rs` rows fail — each checked on its own,
  by pending the rows ahead of it: *expected "…mutable runtime paths…", saw ""*.

## Loader form matrix

Three rows: the shebang form through `execve`, the same script through
`execveat` by descriptor, and the `env(1)` form. The interpreter fixture
carries ELF magic followed by bytes no kernel will load, so an unrefused row
cannot replace the test process.

The `env(1)` row names a fixture called `env` rather than `/usr/bin/env`, and
that is load-bearing: an earlier revision used the real one, and an unrefused
row then replaced the test binary with `env` — the run reported nothing at all
rather than a failed row. The scanner recognises env by basename, so a fixture
reaches the same walk while staying unexecutable.

## Testing

- macOS host: `cargo fmt --all --check` clean; `cargo clippy --all-targets
  --offline --locked -- -D warnings` zero warnings; `cargo test --offline
  --locked` 29 + 17 + 1 pass.
- Pinned Linux image (`rust:1.97.1-slim-trixie`, the digest the Dockerfile
  pins): fmt clean, clippy clean, `cargo build --release --locked --offline`
  links, `cargo test --offline --locked` **40 + 17 + 1** pass.
- `scripts/container-smoke.sh` — green, from a bindable worktree.
- `go build ./...` clean.
- `grep -rnE 'unsafe extern( +"[^"]*")? *\{' runtime/container/rust/src` — two
  pre-existing hits, both already carrying a `// SAFETY:` comment. This unit
  adds no `unsafe` block.
- Review loop deferred.

New test: `untrusted_shebang_interpreters_are_refused`, which also pins the
image wrapper as a negative case, guarded on its presence so it asserts inside
the runtime image and skips on a host without it.

## Deliberate ceilings

- A trusted script naming an untrusted interpreter is not refused, by the gate
  above. Closing that would need the image's own `env -S` wrappers taught to
  the scanner, and it is not a caller-reachable bypass: the caller cannot write
  a trusted script.
- The interpreter is still only *classified*; the kernel resolves the name
  again after this guard returns. Executing the bytes that were classified is
  units 8 and 9.

## Shape

2 files, +349/-36 = 385 changed lines over unit 6, 1 area.

## Remaining units

8 — memfd snapshot execution, direct exec paths (needs 5-7). 9 — memfd
snapshot execution, descriptor and spawn paths (needs 8).

`security/rust-exec-hardening` stays as the extraction source until the series
lands.
