### PR TITLE
^B Execute the bytes the guard classified on the direct exec paths (race harness: the classified-benign/executed-refused window is won on 8 of 3000 attempts before and 0 of 3000 after; user-visible execution boundary)

### DIFF
--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::missing_safety_doc)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#[cfg(target_os = "linux")]
+use libc::c_uint;
 use libc::{c_char, c_int, c_long, c_void, pid_t};
 #[cfg(all(
     target_os = "linux",
@@ -14,7 +16,11 @@ use std::env;
 use std::ffi::{CStr, CString};
 use std::fs::{self, File};
 use std::io::Read;
+#[cfg(target_os = "linux")]
+use std::io::{Seek, SeekFrom, Write};
 use std::mem::{self, MaybeUninit};
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
@@ -159,6 +165,18 @@ const MAX_EXEC_PATH_BYTES: usize = MAX_EXEC_AGGREGATE_BYTES;
 const MAX_EXEC_PATH_SEGMENTS: usize = MAX_EXEC_ELEMENTS;
 const DEFAULT_SEARCH_PATH: &str = "/bin:/usr/bin";
 const AT_EMPTY_PATH_FLAG: c_int = 0x1000;
+/// The largest target the guard will copy into a sealed snapshot. Past this the
+/// exec is refused rather than served, so a caller cannot make the guard
+/// allocate without bound inside an interposed call.
+#[cfg(target_os = "linux")]
+const MAX_MUTABLE_EXEC_SNAPSHOT_BYTES: u64 = 64 * 1024 * 1024;
+#[cfg(target_os = "linux")]
+const MUTABLE_EXEC_COPY_CHUNK_BYTES: usize = 64 * 1024;
+/// `MFD_EXEC`, added in Linux 6.3. The `libc` crate this crate pins does not
+/// name it. A kernel that does not know the flag answers `EINVAL`, which
+/// `snapshot_mutable_file` retries without it.
+#[cfg(target_os = "linux")]
+const MFD_EXEC_FLAG: c_uint = 0x0010;
 
 #[cfg(target_os = "linux")]
 const SYS_EXECVE: c_long = libc::SYS_execve as c_long;
@@ -2081,6 +2099,375 @@ fn should_block_mutable_native_exec(path: &str, args: &[String], env_entries: &[
         || path_is_untrusted_shebang_native_exec(path, env_entries)
 }
 
+/// What the guard will exec once it has decided a target.
+///
+/// Every classification so far reads a *name* and then hands the same name back
+/// to libc, which looks it up again. That second lookup is a second decision
+/// the guard does not make, and between the two the caller can replace what the
+/// name holds. These outcomes close that gap: the guard executes the bytes it
+/// classified, or refuses.
+#[cfg(target_os = "linux")]
+enum MutableExecPreparation {
+    /// Nothing about this target needs pinning; the caller's own call stands.
+    NotMutable,
+    /// The target cannot be served safely.
+    Block,
+    /// A trusted target reached through a name the guard cannot pin. The open
+    /// descriptor is the pin: the file is already trusted, so its contents need
+    /// no copy, but the name must not be resolved a second time.
+    Pinned(c_int),
+    /// A sealed snapshot of an untrusted target, to be executed in its place.
+    Execute(c_int),
+}
+
+/// Decides how to serve a target and, where it must be pinned, returns the
+/// descriptor to exec.
+///
+/// `O_PATH` is what opens the target: it gives stable identity even for an
+/// execute-only file, which an ordinary open would refuse. A readable duplicate
+/// is taken separately, and only when a snapshot is actually needed.
+#[cfg(target_os = "linux")]
+fn mutable_exec_preparation(
+    path: &str,
+    dirfd: c_int,
+    open_flags: c_int,
+    env_entries: &[String],
+) -> MutableExecPreparation {
+    if !current_mode_blocks_mutable_native_exec() || path.is_empty() {
+        return MutableExecPreparation::NotMutable;
+    }
+
+    let lexical_mutable = path_has_mutable_provenance(path, dirfd);
+    // A relative name resolves against a working directory this process can
+    // change, and a magic descriptor path against a table it can rewrite.
+    // Neither survives being handed back to libc, whatever it names now.
+    let pin_target = !Path::new(path).is_absolute() || path_is_magic_exec_target(path);
+
+    let Ok(c_path) = CString::new(path.as_bytes()) else {
+        return if lexical_mutable || pin_target {
+            MutableExecPreparation::Block
+        } else {
+            MutableExecPreparation::NotMutable
+        };
+    };
+    // SAFETY: c_path is a live NUL-terminated CString and dirfd is the caller's own directory descriptor; O_PATH opens a description that can neither read nor write.
+    let fd = unsafe {
+        libc::openat(
+            dirfd,
+            c_path.as_ptr(),
+            libc::O_PATH | libc::O_CLOEXEC | open_flags,
+        )
+    };
+    if fd < 0 {
+        // The guard cannot pin what it cannot open. A name with untrusted
+        // provenance is refused rather than handed back, since the caller can
+        // fill it in between here and the exec.
+        return if lexical_mutable
+            || path_resolves_to_mutable_root(path, dirfd)
+            || path_has_untrusted_provenance(path, dirfd)
+            || pin_target
+        {
+            MutableExecPreparation::Block
+        } else {
+            MutableExecPreparation::NotMutable
+        };
+    }
+
+    // SAFETY: fd was just opened by this function and is owned by the File from here on.
+    let path_file = unsafe { File::from_raw_fd(fd) };
+    let Ok(metadata) = path_file.metadata() else {
+        return MutableExecPreparation::Block;
+    };
+    if (metadata.mode() & file_type_bits()) != regular_file_mode() {
+        // Nothing that is not a regular file is executable at all, so the
+        // kernel's own errno is the right answer -- but only where the name
+        // cannot be swapped for something that is. An untrusted name is a
+        // lookup race whatever it holds now.
+        return if lexical_mutable || path_has_untrusted_provenance(path, dirfd) || pin_target {
+            MutableExecPreparation::Block
+        } else {
+            MutableExecPreparation::NotMutable
+        };
+    }
+
+    // The lexical decision stands beside the descriptor one. A mutable
+    // directory can alias a trusted inode, so a descriptor that looks trusted
+    // is not enough on its own.
+    let untrusted = lexical_mutable
+        || path_has_untrusted_provenance(path, dirfd)
+        || fd_target_is_untrusted_exec(fd);
+    if !untrusted {
+        return if pin_target {
+            MutableExecPreparation::Pinned(path_file.into_raw_fd())
+        } else {
+            MutableExecPreparation::NotMutable
+        };
+    }
+
+    let Some(mut source) = duplicate_fd_file(fd) else {
+        return MutableExecPreparation::Block;
+    };
+    let Ok(metadata) = source.metadata() else {
+        return MutableExecPreparation::Block;
+    };
+    snapshot_mutable_file(&mut source, metadata.mode(), env_entries).map_or(
+        MutableExecPreparation::Block,
+        MutableExecPreparation::Execute,
+    )
+}
+
+/// Copies a target into a sealed memfd, classifies the copy, and returns it.
+///
+/// The seals are the point: once they are set the bytes cannot change, so the
+/// classification below them holds until the exec. Everything is decided on the
+/// copy rather than on the original, because the original can still change.
+///
+/// A native ELF is never snapshotted. The classifiers refuse an untrusted
+/// native executable outright, and copying one would turn a refusal into an
+/// execution.
+#[cfg(target_os = "linux")]
+fn snapshot_mutable_file(source: &mut File, mode: u32, env_entries: &[String]) -> Option<c_int> {
+    if source.metadata().ok()?.len() > MAX_MUTABLE_EXEC_SNAPSHOT_BYTES {
+        return None;
+    }
+    source.seek(SeekFrom::Start(0)).ok()?;
+
+    // SAFETY: the name is a static NUL-terminated literal and the flags are valid memfd_create flags.
+    let mut fd = unsafe {
+        libc::memfd_create(
+            c"workcell-mutable-exec".as_ptr(),
+            libc::MFD_ALLOW_SEALING | libc::MFD_CLOEXEC | MFD_EXEC_FLAG,
+        )
+    };
+    if fd < 0 {
+        // A kernel older than 6.3 does not know MFD_EXEC and answers EINVAL.
+        // Retry only for that: a newer kernel refusing under its own memfd
+        // execution policy must keep refusing.
+        // SAFETY: errno_location returns this thread's valid errno slot.
+        if unsafe { *errno_location() } == libc::EINVAL {
+            // SAFETY: the name is a static NUL-terminated literal and the fallback flags are valid.
+            fd = unsafe {
+                libc::memfd_create(
+                    c"workcell-mutable-exec".as_ptr(),
+                    libc::MFD_ALLOW_SEALING | libc::MFD_CLOEXEC,
+                )
+            };
+        }
+    }
+    if fd < 0 {
+        return None;
+    }
+    // SAFETY: fd was just created by memfd_create and is owned by the File from here on.
+    let mut snapshot = unsafe { File::from_raw_fd(fd) };
+
+    // SAFETY: snapshot is an owned regular memfd and only permission bits are passed.
+    if unsafe { libc::fchmod(snapshot.as_raw_fd(), (mode & 0o777) as libc::mode_t) } != 0 {
+        return None;
+    }
+
+    let mut copied = 0u64;
+    let mut buffer = [0u8; MUTABLE_EXEC_COPY_CHUNK_BYTES];
+    loop {
+        let read = source.read(&mut buffer).ok()?;
+        if read == 0 {
+            break;
+        }
+        copied = copied.checked_add(read as u64)?;
+        if copied > MAX_MUTABLE_EXEC_SNAPSHOT_BYTES {
+            return None;
+        }
+        snapshot.write_all(&buffer[..read]).ok()?;
+    }
+
+    snapshot.seek(SeekFrom::Start(0)).ok()?;
+    let mut prefix = [0u8; 511];
+    let prefix_bytes = snapshot.read(&mut prefix).ok()?;
+    let prefix = &prefix[..prefix_bytes];
+    if prefix.starts_with(&[0x7f, b'E', b'L', b'F']) {
+        return None;
+    }
+    let text = String::from_utf8_lossy(prefix);
+    if buffer_targets_protected_runtime_via_shebang(&text, env_entries)
+        || buffer_targets_untrusted_native_via_shebang(&text, env_entries)
+        // A shebang starts a second, loader-interpreted exec that reaches no
+        // entry point of this guard, so a loader override in the child
+        // environment would arrive at it unchecked.
+        || (env_has_unsafe_loader_override(env_entries) && prefix.starts_with(b"#!"))
+    {
+        return None;
+    }
+
+    let seals = libc::F_SEAL_WRITE | libc::F_SEAL_SHRINK | libc::F_SEAL_GROW | libc::F_SEAL_SEAL;
+    // SAFETY: snapshot is an owned memfd created with MFD_ALLOW_SEALING and the seal set is valid.
+    if unsafe { libc::fcntl(snapshot.as_raw_fd(), libc::F_ADD_SEALS, seals) } != 0 {
+        return None;
+    }
+
+    // The descriptor has to survive the exec: a shebang snapshot is named
+    // through /proc/self/fd, and the interpreter opens that name afterwards.
+    // SAFETY: snapshot is an owned descriptor and F_GETFD reads its flags.
+    let descriptor_flags = unsafe { libc::fcntl(snapshot.as_raw_fd(), libc::F_GETFD) };
+    if descriptor_flags < 0 {
+        return None;
+    }
+    // SAFETY: snapshot is an owned descriptor and descriptor_flags came from F_GETFD.
+    if unsafe {
+        libc::fcntl(
+            snapshot.as_raw_fd(),
+            libc::F_SETFD,
+            descriptor_flags & !libc::FD_CLOEXEC,
+        )
+    } != 0
+    {
+        return None;
+    }
+
+    snapshot.seek(SeekFrom::Start(0)).ok()?;
+    Some(snapshot.into_raw_fd())
+}
+
+#[cfg(target_os = "linux")]
+fn close_prepared_fd(fd: c_int) {
+    // SAFETY: callers pass the descriptor mutable_exec_preparation handed them, which they own.
+    unsafe { libc::close(fd) };
+}
+
+/// The close must not overwrite the errno the failed exec reported.
+#[cfg(target_os = "linux")]
+fn close_prepared_fd_preserving_errno(fd: c_int, result: c_int) {
+    if result < 0 {
+        // SAFETY: errno_location returns this thread's valid errno slot.
+        let saved = unsafe { *errno_location() };
+        close_prepared_fd(fd);
+        // SAFETY: errno_location returns this thread's valid errno slot.
+        unsafe { *errno_location() = saved };
+    } else {
+        close_prepared_fd(fd);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn fd_exec_path(fd: c_int) -> Option<CString> {
+    CString::new(proc_fd_path(fd)).ok()
+}
+
+/// Executes the prepared descriptor itself, so the bytes that run are the bytes
+/// the guard classified.
+#[cfg(target_os = "linux")]
+fn execute_snapshot_execveat(
+    fd: c_int,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+) -> c_int {
+    // SAFETY: fd is the prepared descriptor owned by this call; argv and envp are the caller's own exec ABI pointers, unmodified.
+    let result = unsafe { execveat_fn()(fd, c"".as_ptr(), argv, envp, libc::AT_EMPTY_PATH) };
+    if result < 0
+        // A script executed through AT_EMPTY_PATH is answered ENOENT on some
+        // kernels, because the interpreter is handed a /dev/fd name it then
+        // resolves. Retry through the descriptor's own proc path, which names
+        // the same still-open snapshot.
+        // SAFETY: errno_location returns this thread's valid errno slot.
+        && unsafe { *errno_location() } == libc::ENOENT
+        && let Some(fd_path) = fd_exec_path(fd)
+    {
+        // SAFETY: fd_path names the still-open prepared descriptor, and argv and envp remain the caller's valid pointers.
+        let fallback = unsafe { execve_fn()(fd_path.as_ptr(), argv, envp) };
+        close_prepared_fd_preserving_errno(fd, fallback);
+        return fallback;
+    }
+    close_prepared_fd_preserving_errno(fd, result);
+    result
+}
+
+/// The `execvp` family form. glibc answers `ENOEXEC` by running `/bin/sh` on
+/// the target, from inside libc and without re-entering this guard, so the
+/// guard has to perform that fallback itself once it is executing a descriptor
+/// rather than a name.
+#[cfg(target_os = "linux")]
+fn execute_snapshot_execveat_with_shell_fallback(
+    fd: c_int,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    arg_count: usize,
+) -> c_int {
+    // SAFETY: fd is the prepared descriptor owned by this call; argv and envp are the caller's own exec ABI pointers, unmodified.
+    let mut result = unsafe { execveat_fn()(fd, c"".as_ptr(), argv, envp, libc::AT_EMPTY_PATH) };
+    // SAFETY: errno_location returns this thread's valid errno slot.
+    let mut exec_errno = unsafe { *errno_location() };
+    if result < 0
+        && exec_errno == libc::ENOENT
+        && let Some(fd_path) = fd_exec_path(fd)
+    {
+        // SAFETY: fd_path names the still-open prepared descriptor, and argv and envp remain the caller's valid pointers.
+        result = unsafe { execve_fn()(fd_path.as_ptr(), argv, envp) };
+        // SAFETY: errno_location returns this thread's valid errno slot.
+        exec_errno = unsafe { *errno_location() };
+    }
+    if result < 0 && exec_errno == libc::ENOEXEC {
+        let Ok(fd_path) = CString::new(proc_fd_path(fd)) else {
+            close_prepared_fd(fd);
+            set_errno(libc::ENOENT);
+            return -1;
+        };
+        let shell = c"/bin/sh";
+        let mut shell_argv = Vec::with_capacity(arg_count.saturating_add(2));
+        shell_argv.push(shell.as_ptr());
+        shell_argv.push(fd_path.as_ptr());
+        if arg_count > 1 && !argv.is_null() {
+            // SAFETY: collect_cstring_array already walked arg_count entries of argv in this call, so argv[1..arg_count] are readable pointers.
+            let original = unsafe { std::slice::from_raw_parts(argv.add(1), arg_count - 1) };
+            shell_argv.extend_from_slice(original);
+        }
+        shell_argv.push(std::ptr::null());
+
+        // SAFETY: shell, fd_path and shell_argv outlive the call; fd stays open so its proc path names the prepared descriptor.
+        let shell_result = unsafe { execve_fn()(shell.as_ptr(), shell_argv.as_ptr(), envp) };
+        close_prepared_fd_preserving_errno(fd, shell_result);
+        return shell_result;
+    }
+    close_prepared_fd_preserving_errno(fd, result);
+    result
+}
+
+#[cfg(target_os = "linux")]
+fn execute_prepared_execve(
+    path: &str,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    env_entries: &[String],
+) -> Option<c_int> {
+    match mutable_exec_preparation(path, libc::AT_FDCWD, 0, env_entries) {
+        MutableExecPreparation::NotMutable => None,
+        MutableExecPreparation::Block => {
+            report_mutable_native_exec_block();
+            Some(-1)
+        }
+        MutableExecPreparation::Pinned(fd) | MutableExecPreparation::Execute(fd) => {
+            Some(execute_snapshot_execveat(fd, argv, envp))
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn execute_prepared_search_execve(
+    path: &str,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    env_entries: &[String],
+    arg_count: usize,
+) -> Option<c_int> {
+    match mutable_exec_preparation(path, libc::AT_FDCWD, 0, env_entries) {
+        MutableExecPreparation::NotMutable => None,
+        MutableExecPreparation::Block => {
+            report_mutable_native_exec_block();
+            Some(-1)
+        }
+        MutableExecPreparation::Pinned(fd) | MutableExecPreparation::Execute(fd) => Some(
+            execute_snapshot_execveat_with_shell_fallback(fd, argv, envp, arg_count),
+        ),
+    }
+}
+
 // execvp, execvpe and posix_spawnp all search PATH from the caller's own
 // environment rather than the envp handed to the child, so the guard reads the
 // same source libc will. A name containing a slash is not searched at all, so
@@ -2385,6 +2772,11 @@ unsafe extern "C" fn guarded_execve(
         return -1;
     }
 
+    #[cfg(target_os = "linux")]
+    if let Some(result) = execute_prepared_execve(&path_string, argv, envp, &env_entries) {
+        return result;
+    }
+
     // SAFETY: forwards the caller's original, unmodified execve arguments to the real libc execve resolved via RTLD_NEXT.
     unsafe { execve_fn()(path, argv, envp) }
 }
@@ -2425,6 +2817,16 @@ unsafe extern "C" fn guarded_execv(path: *const c_char, argv: *const *const c_ch
     if should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: environ is libc-initialized and read in the calling thread with no concurrent setenv/putenv.
+        let current_env = unsafe { environ.cast() };
+        if let Some(result) = execute_prepared_execve(&path_string, argv, current_env, &env_entries)
+        {
+            return result;
+        }
     }
 
     // SAFETY: forwards the caller's original, unmodified execv arguments to the real libc execv resolved via RTLD_NEXT.
@@ -2490,6 +2892,21 @@ unsafe extern "C" fn guarded_execvp(file: *const c_char, argv: *const *const c_c
     if should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: environ is libc-initialized and read in the calling thread with no concurrent setenv/putenv.
+        let current_env = unsafe { environ.cast() };
+        if let Some(result) = execute_prepared_search_execve(
+            &effective_path,
+            argv,
+            current_env,
+            &env_entries,
+            args.len(),
+        ) {
+            return result;
+        }
     }
 
     // SAFETY: forwards the caller's original, unmodified execvp arguments to the real libc execvp resolved via RTLD_NEXT.
@@ -2559,6 +2976,13 @@ unsafe extern "C" fn guarded_execvpe(
     if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return -1;
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(result) =
+        execute_prepared_search_execve(&effective_path, argv, envp, &env_entries, args.len())
+    {
+        return result;
     }
 
     // SAFETY: forwards the caller's original, unmodified execvpe arguments to the real libc execvpe resolved via RTLD_NEXT.
@@ -4027,6 +4451,170 @@ mod tests {
 
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644))
             .expect("restore read permission");
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_snapshot_is_sealed_and_carries_only_what_was_classified() {
+        let dir = create_temp_test_dir("snapshot");
+        let script = dir.join("script");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write script");
+
+        let mut source = File::open(&script).expect("open script");
+        let snapshot = snapshot_mutable_file(&mut source, 0o750, &[]).expect("snapshot the script");
+
+        // Sealed against every kind of change, so the classification holds
+        // until the exec.
+        // SAFETY: snapshot is the owned descriptor just returned; F_GET_SEALS only reads it.
+        let seals = unsafe { libc::fcntl(snapshot, libc::F_GET_SEALS) };
+        for seal in [
+            libc::F_SEAL_WRITE,
+            libc::F_SEAL_SHRINK,
+            libc::F_SEAL_GROW,
+            libc::F_SEAL_SEAL,
+        ] {
+            assert_eq!(seals & seal, seal, "missing seal {seal:#x}");
+        }
+        // The interpreter opens the snapshot by name after the exec, so the
+        // descriptor has to survive it.
+        // SAFETY: snapshot is the owned descriptor just returned; F_GETFD only reads its flags.
+        let descriptor_flags = unsafe { libc::fcntl(snapshot, libc::F_GETFD) };
+        assert_eq!(descriptor_flags & libc::FD_CLOEXEC, 0);
+
+        let mut copy = duplicate_fd_file(snapshot).expect("reopen the snapshot");
+        let mut bytes = String::new();
+        copy.read_to_string(&mut bytes).expect("read the snapshot");
+        assert_eq!(bytes, "#!/bin/sh\nexit 0\n");
+        assert_eq!(
+            copy.metadata().expect("snapshot metadata").mode() & 0o777,
+            0o750
+        );
+        close_prepared_fd(snapshot);
+
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_snapshot_is_refused_for_everything_the_guard_would_not_run() {
+        let dir = create_temp_test_dir("snapshot-refusals");
+        let interpreter = dir.join("tool");
+        fs::write(&interpreter, [0x7f, b'E', b'L', b'F', 2, 1, 1, 0]).expect("write interpreter");
+
+        let refuse = |name: &str, contents: &[u8], env: &[String]| {
+            let file = dir.join(name);
+            fs::write(&file, contents).expect("write fixture");
+            let mut source = File::open(&file).expect("open fixture");
+            assert!(
+                snapshot_mutable_file(&mut source, 0o755, env).is_none(),
+                "{name} should not be snapshotted"
+            );
+        };
+
+        // A native executable is refused outright by the classifiers, so
+        // copying one would turn a refusal into an execution.
+        refuse("elf", &[0x7f, b'E', b'L', b'F', 2, 1, 1, 0], &[]);
+        // A shebang the guard would refuse if it were read from the original.
+        refuse(
+            "protected",
+            b"#!/usr/local/libexec/workcell/real/node\n",
+            &[],
+        );
+        refuse(
+            "untrusted-interpreter",
+            format!("#!{}\n", interpreter.display()).as_bytes(),
+            &[],
+        );
+        // The interpreter is a second, loader-interpreted exec that reaches no
+        // entry point, so a loader override in the child environment would
+        // arrive at it unchecked.
+        refuse(
+            "loader-override",
+            b"#!/bin/sh\nexit 0\n",
+            &["LD_AUDIT=/tmp/audit.so".to_string()],
+        );
+
+        // Past the copy limit the exec is refused rather than served.
+        let oversized = dir.join("oversized");
+        fs::write(&oversized, "#!/bin/sh\n").expect("write oversized");
+        File::options()
+            .write(true)
+            .open(&oversized)
+            .expect("open oversized")
+            .set_len(MAX_MUTABLE_EXEC_SNAPSHOT_BYTES + 1)
+            .expect("grow past the limit");
+        let mut source = File::open(&oversized).expect("reopen oversized");
+        assert!(snapshot_mutable_file(&mut source, 0o755, &[]).is_none());
+
+        // The control: an ordinary script is still served.
+        let allowed = dir.join("allowed");
+        fs::write(&allowed, "#!/bin/sh\nexit 0\n").expect("write allowed");
+        let mut source = File::open(&allowed).expect("open allowed");
+        let snapshot = snapshot_mutable_file(&mut source, 0o755, &[]).expect("snapshot");
+        close_prepared_fd(snapshot);
+
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn exec_preparation_pins_only_what_it_has_to() {
+        let dir = create_temp_test_dir("preparation");
+        let script = dir.join("script");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+        // An untrusted script is served from a sealed copy of itself.
+        match mutable_exec_preparation(
+            script.to_str().expect("script path"),
+            libc::AT_FDCWD,
+            0,
+            &[],
+        ) {
+            MutableExecPreparation::Execute(fd) => close_prepared_fd(fd),
+            _ => panic!("an untrusted script must be snapshotted"),
+        }
+
+        // A trusted absolute name needs no pin: nothing can replace what it
+        // resolves to, so the caller's own call stands.
+        assert!(matches!(
+            mutable_exec_preparation("/bin/true", libc::AT_FDCWD, 0, &[]),
+            MutableExecPreparation::NotMutable
+        ));
+
+        // A trusted target named through a descriptor table is pinned rather
+        // than copied: the bytes are already trustworthy, the name is not.
+        let trusted = File::open("/bin/true").expect("open /bin/true");
+        let magic = proc_fd_path(trusted.as_raw_fd());
+        match mutable_exec_preparation(&magic, libc::AT_FDCWD, 0, &[]) {
+            MutableExecPreparation::Pinned(fd) => close_prepared_fd(fd),
+            _ => panic!("a magic name for a trusted target must be pinned"),
+        }
+
+        // A directory under a name this process can replace is a lookup race,
+        // whatever it holds now.
+        assert!(matches!(
+            mutable_exec_preparation(dir.to_str().expect("dir path"), libc::AT_FDCWD, 0, &[]),
+            MutableExecPreparation::Block
+        ));
+        // A directory nothing can replace keeps the kernel's own errno.
+        assert!(matches!(
+            mutable_exec_preparation("/bin", libc::AT_FDCWD, 0, &[]),
+            MutableExecPreparation::NotMutable
+        ));
+        // A name that does not exist under a writable directory can be filled
+        // in between here and the exec.
+        assert!(matches!(
+            mutable_exec_preparation(
+                dir.join("absent").to_str().expect("absent path"),
+                libc::AT_FDCWD,
+                0,
+                &[]
+            ),
+            MutableExecPreparation::Block
+        ));
+
         fs::remove_dir_all(&dir).expect("cleanup temp test dir");
     }
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -2138,10 +2138,18 @@ fn mutable_exec_preparation(
     }
 
     let lexical_mutable = path_has_mutable_provenance(path, dirfd);
+    // A magic descriptor path has no directory chain worth asking about:
+    // `/proc/<pid>/fd` is owned by the process itself, so a provenance walk
+    // over it answers "this process" for every such name under an ordinary uid
+    // and "trusted" for every one under root. Neither answer is about the
+    // target. What the name resolves to is asked of the descriptor below, and
+    // pinning is what stops the name being resolved a second time.
+    let magic_target = path_is_magic_exec_target(path);
     // A relative name resolves against a working directory this process can
     // change, and a magic descriptor path against a table it can rewrite.
     // Neither survives being handed back to libc, whatever it names now.
-    let pin_target = !Path::new(path).is_absolute() || path_is_magic_exec_target(path);
+    let pin_target = !Path::new(path).is_absolute() || magic_target;
+    let name_provenance_untrusted = !magic_target && path_has_untrusted_provenance(path, dirfd);
 
     let Ok(c_path) = CString::new(path.as_bytes()) else {
         return if lexical_mutable || pin_target {
@@ -2164,7 +2172,7 @@ fn mutable_exec_preparation(
         // fill it in between here and the exec.
         return if lexical_mutable
             || path_resolves_to_mutable_root(path, dirfd)
-            || path_has_untrusted_provenance(path, dirfd)
+            || name_provenance_untrusted
             || pin_target
         {
             MutableExecPreparation::Block
@@ -2183,7 +2191,7 @@ fn mutable_exec_preparation(
         // kernel's own errno is the right answer -- but only where the name
         // cannot be swapped for something that is. An untrusted name is a
         // lookup race whatever it holds now.
-        return if lexical_mutable || path_has_untrusted_provenance(path, dirfd) || pin_target {
+        return if lexical_mutable || name_provenance_untrusted || pin_target {
             MutableExecPreparation::Block
         } else {
             MutableExecPreparation::NotMutable
@@ -2193,9 +2201,7 @@ fn mutable_exec_preparation(
     // The lexical decision stands beside the descriptor one. A mutable
     // directory can alias a trusted inode, so a descriptor that looks trusted
     // is not enough on its own.
-    let untrusted = lexical_mutable
-        || path_has_untrusted_provenance(path, dirfd)
-        || fd_target_is_untrusted_exec(fd);
+    let untrusted = lexical_mutable || name_provenance_untrusted || fd_target_is_untrusted_exec(fd);
     if !untrusted {
         return if pin_target {
             MutableExecPreparation::Pinned(path_file.into_raw_fd())
@@ -4609,11 +4615,21 @@ mod tests {
 
         // A trusted target named through a descriptor table is pinned rather
         // than copied: the bytes are already trustworthy, the name is not.
+        //
+        // Both of these answer from the descriptor, and that is the point:
+        // `/proc/<pid>/fd` is owned by the running process, so a provenance
+        // walk over a magic name would answer "untrusted" for every one of
+        // them under an ordinary uid and "trusted" for every one under root.
+        // The pair fails under one uid or the other if that walk comes back.
         let trusted = File::open("/bin/true").expect("open /bin/true");
-        let magic = proc_fd_path(trusted.as_raw_fd());
-        match mutable_exec_preparation(&magic, libc::AT_FDCWD, 0, &[]) {
+        match mutable_exec_preparation(&proc_fd_path(trusted.as_raw_fd()), libc::AT_FDCWD, 0, &[]) {
             MutableExecPreparation::Pinned(fd) => close_prepared_fd(fd),
             _ => panic!("a magic name for a trusted target must be pinned"),
+        }
+        let planted = File::open(&script).expect("open script");
+        match mutable_exec_preparation(&proc_fd_path(planted.as_raw_fd()), libc::AT_FDCWD, 0, &[]) {
+            MutableExecPreparation::Execute(fd) => close_prepared_fd(fd),
+            _ => panic!("a magic name for an untrusted target must be snapshotted"),
         }
 
         // A directory under a name this process can replace is a lookup race,

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -2303,27 +2303,36 @@ fn snapshot_mutable_file(source: &mut File, mode: u32, env_entries: &[String]) -
         return None;
     }
 
-    // The descriptor has to survive the exec: a shebang snapshot is named
-    // through /proc/self/fd, and the interpreter opens that name afterwards.
-    // SAFETY: snapshot is an owned descriptor and F_GETFD reads its flags.
-    let descriptor_flags = unsafe { libc::fcntl(snapshot.as_raw_fd(), libc::F_GETFD) };
-    if descriptor_flags < 0 {
-        return None;
-    }
-    // SAFETY: snapshot is an owned descriptor and descriptor_flags came from F_GETFD.
-    if unsafe {
-        libc::fcntl(
-            snapshot.as_raw_fd(),
-            libc::F_SETFD,
-            descriptor_flags & !libc::FD_CLOEXEC,
-        )
-    } != 0
-    {
-        return None;
-    }
-
     snapshot.seek(SeekFrom::Start(0)).ok()?;
     Some(snapshot.into_raw_fd())
+}
+
+/// The kernel hands a shebang interpreter the script as a `/proc/self/fd` name
+/// and the interpreter opens it *after* the exec, so a close-on-exec descriptor
+/// is gone by the time it looks. Clearing the flag is only right for a shebang:
+/// a native target is mapped before the close-on-exec descriptors go, and
+/// leaving one open would hand every child a descriptor on its own image.
+#[cfg(target_os = "linux")]
+fn descriptor_is_shebang(fd: c_int) -> bool {
+    let Some(mut file) = duplicate_fd_file(fd) else {
+        return false;
+    };
+    let mut prefix = [0u8; 2];
+    file.read_exact(&mut prefix).is_ok() && prefix == *b"#!"
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_descriptor_for_exec(fd: c_int) -> bool {
+    if !descriptor_is_shebang(fd) {
+        return true;
+    }
+    // SAFETY: fd is the prepared descriptor owned by the caller and F_GETFD reads its flags.
+    let descriptor_flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if descriptor_flags < 0 {
+        return false;
+    }
+    // SAFETY: fd is the prepared descriptor owned by the caller and descriptor_flags came from F_GETFD.
+    unsafe { libc::fcntl(fd, libc::F_SETFD, descriptor_flags & !libc::FD_CLOEXEC) == 0 }
 }
 
 #[cfg(target_os = "linux")]
@@ -2359,6 +2368,11 @@ fn execute_snapshot_execveat(
     argv: *const *const c_char,
     envp: *const *const c_char,
 ) -> c_int {
+    if !prepare_descriptor_for_exec(fd) {
+        close_prepared_fd(fd);
+        set_errno(libc::EPERM);
+        return -1;
+    }
     // SAFETY: fd is the prepared descriptor owned by this call; argv and envp are the caller's own exec ABI pointers, unmodified.
     let result = unsafe { execveat_fn()(fd, c"".as_ptr(), argv, envp, libc::AT_EMPTY_PATH) };
     if result < 0
@@ -2390,6 +2404,11 @@ fn execute_snapshot_execveat_with_shell_fallback(
     envp: *const *const c_char,
     arg_count: usize,
 ) -> c_int {
+    if !prepare_descriptor_for_exec(fd) {
+        close_prepared_fd(fd);
+        set_errno(libc::EPERM);
+        return -1;
+    }
     // SAFETY: fd is the prepared descriptor owned by this call; argv and envp are the caller's own exec ABI pointers, unmodified.
     let mut result = unsafe { execveat_fn()(fd, c"".as_ptr(), argv, envp, libc::AT_EMPTY_PATH) };
     // SAFETY: errno_location returns this thread's valid errno slot.
@@ -4476,11 +4495,16 @@ mod tests {
         ] {
             assert_eq!(seals & seal, seal, "missing seal {seal:#x}");
         }
-        // The interpreter opens the snapshot by name after the exec, so the
-        // descriptor has to survive it.
+        // The interpreter opens the snapshot by name after the exec, so a
+        // shebang descriptor has to survive it -- and only a shebang one, which
+        // is why the snapshot arrives close-on-exec and is prepared separately.
         // SAFETY: snapshot is the owned descriptor just returned; F_GETFD only reads its flags.
-        let descriptor_flags = unsafe { libc::fcntl(snapshot, libc::F_GETFD) };
-        assert_eq!(descriptor_flags & libc::FD_CLOEXEC, 0);
+        let before = unsafe { libc::fcntl(snapshot, libc::F_GETFD) };
+        assert_ne!(before & libc::FD_CLOEXEC, 0);
+        assert!(prepare_descriptor_for_exec(snapshot));
+        // SAFETY: snapshot is the owned descriptor just returned; F_GETFD only reads its flags.
+        let after = unsafe { libc::fcntl(snapshot, libc::F_GETFD) };
+        assert_eq!(after & libc::FD_CLOEXEC, 0);
 
         let mut copy = duplicate_fd_file(snapshot).expect("reopen the snapshot");
         let mut bytes = String::new();

--- a/runtime/container/rust/tests/loader_forms.rs
+++ b/runtime/container/rust/tests/loader_forms.rs
@@ -76,6 +76,11 @@ const UNKNOWN_OPTION: &str = "--workcell-not-a-real-option";
 /// under test rather than for where its target lives. It is never the exec path
 /// of a row, only an argument, so no row can execute it.
 const TARGET: &str = "/bin/true";
+/// A directory nothing can execute, reached through a name nothing can replace.
+/// The kernel's own errno answers for it, which is what the row asserts; a
+/// directory under a name this process could swap is a lookup race and gets
+/// the native-exec refusal instead.
+const TRUSTED_DIRECTORY: &str = "/bin";
 const TARGET_ARGV: &[&str] = &["target"];
 /// A bare name for the PATH-search rows. No search root holds it.
 const PROBE: &str = "workcell-loader-form-probe";
@@ -495,7 +500,7 @@ const FORMS: &[Form] = &[
     form(
         "a directory target cannot reach the loader",
         Execve(
-            FIXTURE,
+            TRUSTED_DIRECTORY,
             TARGET_ARGV,
             &[GUARD_PRELOAD, "LD_AUDIT=/state/evil.so"],
         ),
@@ -523,6 +528,12 @@ const FORMS: &[Form] = &[
             GUARDED_ENV,
         ),
         NotRefused,
+        LINUX,
+    ),
+    form(
+        "a directory under a name this process can replace",
+        Execve(FIXTURE, TARGET_ARGV, GUARDED_ENV),
+        Refused(MUTABLE_NATIVE),
         LINUX,
     ),
     // Shebang resolution, which the kernel performs after the guard returns.


### PR DESCRIPTION
Unit 8 of the #652 series. Units 1-7 are #670, #676, #684, #685, #697, #703 and
the unit-7 PR.

## The hole

Every classification in the series so far reads a *name*, decides, and then
hands the same name back to libc, which looks it up again. That second lookup
is a second decision the guard does not make, and between the two the caller
can replace what the name holds. So a caller can have the guard classify
content it allows and the kernel execute content it refuses.

This is the check/use gap #684 dispositioned and #685 recorded as "needs
descriptor discipline the entry points do not have yet". #703 closed it for the
one case that could be pinned by comparing a descriptor's identity. This unit
closes it by executing the bytes.

## What lands

`mutable_exec_preparation` decides how a target must be served and, where the
name cannot be trusted to resolve twice to the same thing, returns the
descriptor to exec instead:

- **`NotMutable`** — a trusted absolute name resolves to the same file whoever
  looks it up, so the caller's own call stands.
- **`Pinned`** — a trusted target reached through a name the guard cannot pin
  (a relative name, or a descriptor-table path). The bytes are already
  trustworthy; only the name is not, so the open descriptor is the pin and no
  copy is made.
- **`Execute`** — an untrusted target, served from `snapshot_mutable_file`: a
  copy in a sealed memfd, classified *after* the copy and sealed against every
  kind of change, so the classification holds until the exec.
- **`Block`** — anything that cannot be served safely.

`O_PATH` opens the target, so an execute-only file gets stable identity where
an ordinary open would be refused; the readable duplicate is taken separately,
and only when a snapshot is actually needed.

A snapshot is refused, not served, for everything the guard would not run: a
native ELF (copying one would turn a refusal into an execution), a shebang
naming a protected runtime or an untrusted native interpreter, any shebang
under a child environment carrying a loader override, and anything past
`MAX_MUTABLE_EXEC_SNAPSHOT_BYTES` (64 MiB) — so a caller cannot make the guard
allocate without bound inside an interposed call.

`execute_prepared_execve` and `execute_prepared_search_execve` wire this into
`guarded_execve`, `guarded_execv`, `guarded_execvp` and `guarded_execvpe`,
after every refusal so a more specific reason still answers first — including
the fail-closed missing-preload default from #685. The search form carries
glibc's `ENOEXEC` fallback itself: libc answers `ENOEXEC` by running `/bin/sh`
on the target from inside libc, without re-entering this guard, which a
descriptor exec would otherwise lose.

`MFD_EXEC` is requested and retried without it only on `EINVAL`, which is what
a kernel older than 6.3 answers. A newer kernel refusing under its own memfd
execution policy keeps refusing.

## Race proof

Pinned toolchain image. The target alternates between a script the guard allows
(`#!/bin/sh`) and one it refuses (a shebang naming an untrusted native
interpreter), swapped by rename so every open sees a whole file and only the
choice of file is racy. A guard that classifies a name and hands the name back
can be made to classify the allowed content and execute the refused one.

| guard | attempts | executions of the refused content | executions of the allowed content |
| --- | --- | --- | --- |
| unit 7 | 3000 | **8** | 999 |
| this branch | 3000 | **0** | 1241 |

The last column is the control: both sides really execute the target thousands
of times, so the zero is a refusal rather than a dead harness. The count in the
third column is a race and varies between runs; what does not vary is that the
window is reachable before and closed after.

The fixture directory is one the guard treats as untrusted. That is the shape
of the attack rather than a convenience: a target under a name only root can
replace is not one an unprivileged caller can race in the first place, and the
guard leaves it alone.

## The second commit

The kernel hands a shebang interpreter the script as a `/proc/self/fd` name and
the interpreter opens that name **after** the exec. Both prepared descriptors
arrive close-on-exec — the snapshot from `memfd_create(MFD_CLOEXEC)`, the
pinned one from `openat(O_CLOEXEC)` — so the interpreter found nothing there.
Reproduced in the pinned image against a unit-7 guard and this one: a
root-owned `#!/bin/sh` script executed under a relative name is `Pinned`, and
the first revision reported

    /bin/sh: 0: cannot open /proc/self/fd/3: No such file

while a native target beside it ran. `prepare_descriptor_for_exec` clears the
flag, and only for a shebang: a native target is mapped before the
close-on-exec descriptors go, so clearing it there would hand every child a
descriptor on its own image for nothing. One place decides it for both kinds of
prepared descriptor.

## One matrix row moved

`a directory target cannot reach the loader` executed the fixture directory,
which sits under a name this process owns. A directory under a replaceable name
is a lookup race whatever it holds now, so it is refused rather than left to the
kernel's `EACCES`. The row keeps its claim by naming `/bin`, a directory nothing
can replace — `mutable_exec_preparation` returns `NotMutable` for a non-regular
file under a trusted name, so #684's "directories keep their ordinary errno"
still holds where it is safe. A new row pins the refusal for the replaceable
case.

## Testing

- macOS host: fmt clean; `cargo clippy --all-targets --offline --locked -- -D
  warnings` zero warnings; `cargo test --offline --locked` 29 + 17 + 1 pass.
- Pinned Linux image: fmt clean, clippy clean, `cargo build --release --locked
  --offline` links, `cargo test --offline --locked` **43 + 17 + 1** pass.
- `scripts/container-smoke.sh` — green, from a bindable worktree.
- `go build ./...` clean.
- `grep -rnE 'unsafe extern( +"[^"]*")? *\{' runtime/container/rust/src` — two
  pre-existing hits, both already carrying a `// SAFETY:` comment. This unit
  adds no `unsafe extern` block; every new `unsafe` block carries its own
  `// SAFETY:` comment, which the crate's `undocumented_unsafe_blocks = deny`
  enforces.
- Review loop deferred.

New tests: `a_snapshot_is_sealed_and_carries_only_what_was_classified`,
`a_snapshot_is_refused_for_everything_the_guard_would_not_run`,
`exec_preparation_pins_only_what_it_has_to`.

## Deliberate ceilings

- A snapshot costs a full copy of the target on every untrusted exec, bounded
  at 64 MiB. Untrusted targets are scripts, since an untrusted ELF is refused
  rather than copied, so the copy is small in every path the runtime actually
  takes.
- `mutable_exec_preparation` runs after the classifiers on every exec, so a
  trusted absolute target pays one `openat(O_PATH)` and one provenance walk
  more than before. The classifiers already walk the same ancestors.
- `execveat`, `fexecve`, `posix_spawn` and `posix_spawnp` still hand their
  target back for a second lookup. That is unit 9, which shares all of this
  machinery.

## Shape

2 files, +625 changed lines over unit 7, 1 area.

## Remaining units

9 — memfd snapshot execution, descriptor and spawn paths (needs 8).

`security/rust-exec-hardening` stays as the extraction source until the series
lands.
