### PR TITLE
Add the generated artifact check (S13)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -109,6 +109,7 @@ func subcommands() []subcommand {
 		{"check-pinned-inputs", "REPO_ROOT MAX_DEBIAN_SNAPSHOT_AGE_DAYS", 2, 2, cmdCheckPinnedInputs},
 		{"check-validator-anchoring", "REPO_ROOT", 1, 1, cmdCheckValidatorAnchoring},
 		{"check-doc-language", "REPO_ROOT", 1, 1, cmdCheckDocLanguage},
+		{"check-generated-artifacts", "REPO_ROOT", 1, 1, cmdCheckGeneratedArtifacts},
 		{"verify-reproducible-build", "OCI_EXPORT_A OCI_EXPORT_B REPRO_PLATFORMS REPRO_MANIFEST_PATH SOURCE_DATE_EPOCH", 5, 5, cmdVerifyReproducibleBuild},
 		{"generate-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS OUTPUT_PATH SOURCE_DATE_EPOCH", 4, 4, cmdGenerateReproducibleBuildManifest},
 		{"verify-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS MANIFEST_PATH", 3, 3, cmdVerifyReproducibleBuildManifest},
@@ -536,6 +537,10 @@ func cmdCheckValidatorAnchoring(args []string) error {
 
 func cmdCheckDocLanguage(args []string) error {
 	return metadatautil.CheckDocLanguage(args[0])
+}
+
+func cmdCheckGeneratedArtifacts(args []string) error {
+	return metadatautil.CheckGeneratedArtifacts(args[0])
 }
 
 func cmdCheckPinnedInputs(args []string) error {

--- a/internal/metadatautil/generated_artifacts_check.go
+++ b/internal/metadatautil/generated_artifacts_check.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CheckGeneratedArtifacts derives two gates from the generator list itself,
+// so a new generator cannot land without either of them.
+//
+//  1. Freshness. A generator that writes a tracked file declares that file.
+//     The check runs the generator into a scratch path and compares the bytes.
+//     A stale committed artifact fails.
+//  2. Orphan. A generator that writes no tracked file must have a caller. A
+//     generator that nothing runs is dead code that still reads as coverage.
+//
+// Both gates read the declaration that every generator carries in its header:
+//
+//	# generated-artifact: policy/workflow-lanes.json
+//	# generated-artifact: none (reason)
+//
+// The declaration is the only hand-written input, and it lives beside the
+// generator rather than in a central list that a new generator can miss.
+func CheckGeneratedArtifacts(rootDir string) error {
+	generators, err := filepath.Glob(filepath.Join(rootDir, generatorGlob))
+	if err != nil {
+		return err
+	}
+	if len(generators) == 0 {
+		return fmt.Errorf("no generator matches %s; refusing a vacuous pass", generatorGlob)
+	}
+	callers, err := shellSources(rootDir)
+	if err != nil {
+		return err
+	}
+	var failures []string
+	for _, generator := range generators {
+		name := filepath.Base(generator)
+		artifact, err := generatedArtifactDeclaration(generator)
+		if err != nil {
+			failures = append(failures, err.Error())
+			continue
+		}
+		if artifact == "" {
+			if err := requireGeneratorCaller(rootDir, name, callers); err != nil {
+				failures = append(failures, err.Error())
+			}
+			continue
+		}
+		if err := requireFreshArtifact(rootDir, generator, artifact); err != nil {
+			failures = append(failures, err.Error())
+		}
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	sort.Strings(failures)
+	return fmt.Errorf("generated artifact check failed:\n  %s", strings.Join(failures, "\n  "))
+}
+
+const (
+	generatorGlob        = "scripts/generate-*.sh"
+	generatedArtifactTag = "# generated-artifact:"
+	// generatorHeaderLines bounds the declaration to the header, so a mention
+	// of the tag deeper in the script cannot become the declaration.
+	generatorHeaderLines = 20
+)
+
+// generatedArtifactDeclaration returns the repository-relative artifact the
+// generator writes, or the empty string when the generator declares none.
+func generatedArtifactDeclaration(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	name := filepath.Base(path)
+	lines := strings.Split(string(content), "\n")
+	if len(lines) > generatorHeaderLines {
+		lines = lines[:generatorHeaderLines]
+	}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, generatedArtifactTag) {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(trimmed, generatedArtifactTag))
+		if value == "" {
+			return "", fmt.Errorf("%s: %s carries no value", name, generatedArtifactTag)
+		}
+		if value == "none" || strings.HasPrefix(value, "none ") {
+			return "", nil
+		}
+		if strings.ContainsAny(value, " \t") {
+			return "", fmt.Errorf("%s: %s must name one path or none, found %q", name, generatedArtifactTag, value)
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("%s: add a %s header line naming the tracked file the generator writes, or %s none (reason)",
+		name, generatedArtifactTag, generatedArtifactTag)
+}
+
+// requireFreshArtifact runs the generator into a scratch path and compares the
+// result with the committed file. The generator convention is that the first
+// argument is the output path.
+func requireFreshArtifact(rootDir, generator, artifact string) error {
+	name := filepath.Base(generator)
+	committed, err := os.ReadFile(filepath.Join(rootDir, artifact))
+	if err != nil {
+		return fmt.Errorf("%s: read the declared artifact %s: %v", name, artifact, err)
+	}
+	scratch, err := os.MkdirTemp("", "workcell-generated-artifact")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(scratch) //nolint:errcheck // scratch directory
+
+	// exec resolves a relative program name against the child's directory, so
+	// the generator path has to be absolute before Dir moves the child.
+	program, err := filepath.Abs(generator)
+	if err != nil {
+		return err
+	}
+	output := filepath.Join(scratch, filepath.Base(artifact))
+	command := exec.Command(program, output)
+	command.Dir = rootDir
+	if combined, runErr := command.CombinedOutput(); runErr != nil {
+		return fmt.Errorf("%s: run the generator: %v\n%s", name, runErr, combined)
+	}
+	regenerated, err := os.ReadFile(output)
+	if err != nil {
+		return fmt.Errorf("%s: the generator wrote no output at %s: %v", name, output, err)
+	}
+	if !bytes.Equal(committed, regenerated) {
+		return fmt.Errorf("%s: %s is stale; run the generator and commit the result", name, artifact)
+	}
+	return nil
+}
+
+func requireGeneratorCaller(rootDir, name string, callers []string) error {
+	for _, caller := range callers {
+		if filepath.Base(caller) == name {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(rootDir, caller))
+		if err != nil {
+			return err
+		}
+		if ValidateGeneratorCaller(string(content), name) == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: %s", name, errNoGeneratorCaller)
+}
+
+var errNoGeneratorCaller = errors.New("no tracked script invokes this generator; wire it into its caller, declare the tracked file it writes, or delete it")
+
+// ValidateGeneratorCaller reports whether script invokes the named generator.
+//
+// A line that names the generator is a caller unless the line is a comment or
+// a list entry. Both exclusions are the shapes the repository really carries:
+// scripts/validate-repo.sh holds the generator in its shell_files lint array
+// and scripts/verify-invariants.sh holds it in HOST_GATE_SCRIPTS, and neither
+// array runs anything. The reviewer found this exact defect: every reference
+// to scripts/generate-workflow-lane-manifest.sh was a list entry.
+//
+// ponytail: line shapes, not a shell parser. The shared shell-invocation
+// parser reads a list entry on its own line as a command word, so it reports
+// a lint array as a caller and cannot serve this check. Replace this function
+// with the parser when the parser learns array context.
+func ValidateGeneratorCaller(script, generator string) error {
+	for line := range strings.Lines(script) {
+		trimmed := strings.TrimSpace(strings.TrimSuffix(line, "\n"))
+		if !strings.Contains(trimmed, "scripts/"+generator) {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") || isListEntry(trimmed) {
+			continue
+		}
+		return nil
+	}
+	return errNoGeneratorCaller
+}
+
+// isListEntry reports a line that is one quoted word and nothing else, which
+// is an array element rather than a command.
+func isListEntry(line string) bool {
+	for _, quote := range []string{`"`, `'`} {
+		if len(line) > 1 && strings.HasPrefix(line, quote) && strings.HasSuffix(line, quote) &&
+			!strings.Contains(line[1:len(line)-1], quote) {
+			return true
+		}
+	}
+	return false
+}
+
+// shellSources lists the tracked shell scripts, which are the only files that
+// can invoke a generator directly.
+func shellSources(rootDir string) ([]string, error) {
+	command := exec.Command("git", "-C", rootDir, "ls-files", "-z", "*.sh")
+	listing, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list tracked shell scripts: %w", err)
+	}
+	var files []string
+	for _, path := range strings.Split(string(listing), "\x00") {
+		if path != "" {
+			files = append(files, path)
+		}
+	}
+	if len(files) == 0 {
+		return nil, errors.New("tracked shell script listing is empty; refusing a vacuous pass")
+	}
+	return files, nil
+}

--- a/internal/metadatautil/generated_artifacts_check_test.go
+++ b/internal/metadatautil/generated_artifacts_check_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckGeneratedArtifactsAcceptsThisRepository(t *testing.T) {
+	if err := metadatautil.CheckGeneratedArtifacts(filepath.Join("..", "..")); err != nil {
+		t.Fatalf("CheckGeneratedArtifacts() error = %v", err)
+	}
+}
+
+func TestCheckGeneratedArtifacts(t *testing.T) {
+	t.Parallel()
+	const fresh = "generated\n"
+	cases := []struct {
+		name      string
+		header    string
+		body      string
+		committed string
+		caller    string
+		wantErr   string
+	}{
+		{
+			name:      "fresh artifact passes",
+			header:    "# generated-artifact: policy/fixture.json\n",
+			body:      "printf 'generated\\n' >\"$1\"\n",
+			committed: fresh,
+		},
+		{
+			name:      "stale artifact fails",
+			header:    "# generated-artifact: policy/fixture.json\n",
+			body:      "printf 'generated\\n' >\"$1\"\n",
+			committed: "committed by hand\n",
+			wantErr:   "is stale",
+		},
+		{
+			name:    "orphan generator fails",
+			header:  "# generated-artifact: none (nothing to commit)\n",
+			body:    "true\n",
+			wantErr: "no tracked script invokes this generator",
+		},
+		{
+			name:   "called generator passes",
+			header: "# generated-artifact: none (nothing to commit)\n",
+			body:   "true\n",
+			caller: "#!/usr/bin/env bash\nset -euo pipefail\nROOT_DIR=\"$(pwd)\"\n\"${ROOT_DIR}/scripts/generate-fixture.sh\" out\n",
+		},
+		{
+			name:    "missing declaration fails",
+			header:  "",
+			body:    "true\n",
+			wantErr: "add a # generated-artifact: header line",
+		},
+		{
+			name:    "empty declaration fails",
+			header:  "# generated-artifact:\n",
+			body:    "true\n",
+			wantErr: "carries no value",
+		},
+		{
+			name:    "a path with a reason is not a path",
+			header:  "# generated-artifact: policy/fixture.json (maybe)\n",
+			body:    "true\n",
+			wantErr: "must name one path or none",
+		},
+		{
+			// A lint-list entry names the generator without running it. The
+			// reviewer found this exact shape: the only reference to
+			// scripts/generate-workflow-lane-manifest.sh was its row in the
+			// shell_files array of scripts/validate-repo.sh.
+			name:    "a lint-list entry is not a caller",
+			header:  "# generated-artifact: none (nothing to commit)\n",
+			body:    "true\n",
+			caller:  "#!/usr/bin/env bash\nshell_files=(\n  \"${ROOT_DIR}/scripts/generate-fixture.sh\"\n)\n",
+			wantErr: "no tracked script invokes this generator",
+		},
+		{
+			name:   "a comment is not a caller",
+			header: "# generated-artifact: none (nothing to commit)\n",
+			body:   "true\n",
+			caller: "#!/usr/bin/env bash\n# run \"${ROOT_DIR}/scripts/generate-fixture.sh\" by hand\n",
+			// The reference sits in a comment, so nothing runs the generator.
+			wantErr: "no tracked script invokes this generator",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeGeneratorFixture(t, filepath.Join(root, "scripts", "generate-fixture.sh"),
+				"#!/usr/bin/env bash\n"+testCase.header+"set -euo pipefail\n"+testCase.body)
+			if testCase.committed != "" {
+				writeFileFixture(t, filepath.Join(root, "policy", "fixture.json"), testCase.committed)
+			}
+			if testCase.caller != "" {
+				writeGeneratorFixture(t, filepath.Join(root, "scripts", "caller.sh"), testCase.caller)
+			}
+			initGitFixture(t, root)
+			err := metadatautil.CheckGeneratedArtifacts(root)
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected a clean result, found %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("expected an error containing %q, found %v", testCase.wantErr, err)
+			}
+		})
+	}
+}
+
+// An empty generator set must not pass: a gate derived from a list it never
+// read reports a clean result over generators it never saw.
+func TestCheckGeneratedArtifactsRejectsEmptyGeneratorSet(t *testing.T) {
+	t.Parallel()
+	if err := metadatautil.CheckGeneratedArtifacts(t.TempDir()); err == nil {
+		t.Fatal("expected an empty generator set to fail")
+	}
+}
+
+// Each row is a shape the repository really carries. A list entry and a
+// comment name the generator without running it; the reviewer found the first
+// shape in scripts/validate-repo.sh and it made the orphan invisible.
+func TestValidateGeneratorCaller(t *testing.T) {
+	t.Parallel()
+	const generator = "generate-workflow-lane-manifest.sh"
+	cases := []struct {
+		name   string
+		script string
+		want   bool
+	}{
+		{"root-relative invocation", "\"${ROOT_DIR}/scripts/" + generator + "\" \"${OUTPUT_PATH}\"\n", true},
+		{"working-directory invocation", "./scripts/" + generator + " dist/lanes.json\n", true},
+		{"shell_files lint array", "shell_files=(\n  \"${ROOT_DIR}/scripts/" + generator + "\"\n)\n", false},
+		{"HOST_GATE_SCRIPTS array", "HOST_GATE_SCRIPTS=(\n  \"${ROOT_DIR}/scripts/" + generator + "\"\n)\n", false},
+		{"single-quoted list entry", "files=(\n  'scripts/" + generator + "'\n)\n", false},
+		{"line comment", "# run scripts/" + generator + " by hand\n", false},
+		{"indented comment", "  # scripts/" + generator + "\n", false},
+		{"unrelated generator", "\"${ROOT_DIR}/scripts/generate-release-checksums.sh\" out\n", false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			err := metadatautil.ValidateGeneratorCaller(testCase.script, generator)
+			if (err == nil) != testCase.want {
+				t.Fatalf("ValidateGeneratorCaller() error = %v, want caller = %v", err, testCase.want)
+			}
+		})
+	}
+}
+
+func writeGeneratorFixture(t *testing.T, path, body string) {
+	t.Helper()
+	writeFileFixture(t, path, body)
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("mark the fixture executable: %v", err)
+	}
+}
+
+func writeFileFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create the fixture directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write the fixture: %v", err)
+	}
+}
+
+// initGitFixture makes the fixture tree a repository, because the caller
+// search reads the tracked shell scripts.
+func initGitFixture(t *testing.T, root string) {
+	t.Helper()
+	for _, args := range [][]string{{"init", "-q"}, {"add", "-A"}} {
+		command := exec.Command("git", append([]string{"-C", root}, args...)...)
+		command.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+}

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -199,6 +199,13 @@ var goHelperMutations = []mutationCase{
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestScanDocLanguageFlagsReviewedProse", "-count=1"),
 	},
 	{
+		relativePath: "internal/metadatautil/generated_artifacts_check.go",
+		original:     `	if !bytes.Equal(committed, regenerated) {`,
+		replacement:  `	if false && !bytes.Equal(committed, regenerated) {`,
+		label:        "generated artifact freshness comparison",
+		command:      goCmd("test", "./internal/metadatautil", "-run", "TestCheckGeneratedArtifacts$", "-count=1"),
+	},
+	{
 		relativePath: "internal/metadatautil/validator_anchoring.go",
 		original:     `	if anchors != corpus {`,
 		replacement:  `	if false && anchors != corpus {`,

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -358,7 +358,7 @@ func runValidatorJobOwnershipFixture(t *testing.T, job string, test validatorJob
 
 func writeValidatorValidateFixtureFiles(t *testing.T, root string) {
 	t.Helper()
-	for _, name := range []string{"verify-github-macos-release-test-runners.sh", "verify-build-input-manifest.sh", "verify-upstream-codex-release.sh", "verify-upstream-claude-release.sh", "verify-upstream-copilot-release.sh", "verify-upstream-gemini-release.sh", "verify-invariants.sh"} {
+	for _, name := range []string{"verify-github-macos-release-test-runners.sh", "verify-build-input-manifest.sh", "verify-upstream-codex-release.sh", "verify-upstream-claude-release.sh", "verify-upstream-copilot-release.sh", "verify-upstream-gemini-release.sh", "verify-invariants.sh", "check-generated-artifacts.sh"} {
 		writeExecutable(t, filepath.Join(root, "scripts"), name, "#!/bin/bash\nexit 0\n")
 	}
 	writeExecutable(t, filepath.Join(root, "scripts", "ci"), "run-validate-in-validator.sh", "#!/bin/bash\nexit \"${WORKCELL_TEST_WORKLOAD_STATUS}\"\n")

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 26
+  "expected_mutants": 27
 }

--- a/scripts/check-generated-artifacts.sh
+++ b/scripts/check-generated-artifacts.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -p
+# Derives two gates from the scripts/generate-*.sh list itself. A generator
+# that writes a tracked file declares it, and the check regenerates that file
+# into a scratch path and compares the bytes. A generator that writes no
+# tracked file must have a caller, so a dead generator cannot read as coverage.
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+# shellcheck disable=SC2312 # repo-wide bootstrap; the path is the running script's own directory
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "check-generated-artifacts-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GO_BIN="${WORKCELL_GO_BIN:-}"
+
+resolve_go_bin() {
+  if [[ -n "${GO_BIN}" && -x "${GO_BIN}" ]]; then
+    return 0
+  fi
+  if GO_BIN="$(command -v go 2>/dev/null)"; then
+    return 0
+  fi
+  for candidate in \
+    /opt/homebrew/bin/go \
+    /usr/local/go/bin/go \
+    /usr/local/bin/go \
+    /usr/bin/go; do
+    if [[ -x "${candidate}" ]]; then
+      GO_BIN="${candidate}"
+      return 0
+    fi
+  done
+  echo "Missing required tool: go" >&2
+  exit 1
+}
+
+resolve_go_bin
+
+(cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-citools check-generated-artifacts "${ROOT_DIR}")

--- a/scripts/ci/job-validate.sh
+++ b/scripts/ci/job-validate.sh
@@ -103,6 +103,9 @@ echo "[ci/validate] validator evasion corpus registration"
 echo "[ci/validate] GitHub macOS release test runners"
 "${ROOT_DIR}/scripts/verify-github-macos-release-test-runners.sh" macos-26 macos-15
 
+echo "[ci/validate] generated artifact freshness"
+"${ROOT_DIR}/scripts/check-generated-artifacts.sh"
+
 echo "[ci/validate] build input manifest determinism"
 "${ROOT_DIR}/scripts/verify-build-input-manifest.sh"
 

--- a/scripts/generate-build-input-manifest.sh
+++ b/scripts/generate-build-input-manifest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -p
+# generated-artifact: none (release artifact under dist/; scripts/verify-build-input-manifest.sh proves determinism)
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \

--- a/scripts/generate-builder-environment-manifest.sh
+++ b/scripts/generate-builder-environment-manifest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -p
+# generated-artifact: none (records the live builder environment at release time)
 readonly TRUSTED_HOST_PATH="/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/sbin:/sbin:/Applications/Docker.app/Contents/Resources/bin"
 if [[ "${WORKCELL_SANITIZED_ENTRYPOINT:-0}" != "1" ]]; then
   exec /usr/bin/env -i \

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -p
+# generated-artifact: none (release artifact under dist/; scripts/verify-control-plane-manifest.sh proves determinism)
 # shellcheck source=scripts/lib/trusted-entrypoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# generated-artifact: none (needs a release version and a bundle digest)
 set -euo pipefail
 
 usage() {

--- a/scripts/generate-release-checksums.sh
+++ b/scripts/generate-release-checksums.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -p
+# generated-artifact: none (needs the published release assets)
 # shellcheck source=scripts/lib/trusted-entrypoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 

--- a/scripts/generate-workflow-lane-manifest.sh
+++ b/scripts/generate-workflow-lane-manifest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S BASH_ENV= ENV= bash
+# generated-artifact: policy/workflow-lanes.json
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -162,6 +162,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/bootstrap-dev.sh"
   "${ROOT_DIR}/scripts/check-dead-code.sh"
   "${ROOT_DIR}/scripts/check-doc-language.sh"
+  "${ROOT_DIR}/scripts/check-generated-artifacts.sh"
   "${ROOT_DIR}/scripts/check-doc-links.sh"
   "${ROOT_DIR}/scripts/check-doc-support-matrix-fields.sh"
   "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"


### PR DESCRIPTION
## Summary

Adds a check that derives two gates from the `scripts/generate-*.sh` list
itself, so a new generator cannot land without either of them.

Codex review history shows 94 accepted findings of registry, contract and
manifest parity drift over 52 pull requests. This change covers the mechanical
half: a stale generated artifact, and a dead generator.

## Gates

1. **Freshness.** A generator that writes a tracked file declares it:

   ```
   # generated-artifact: policy/workflow-lanes.json
   ```

   The check runs the generator into a scratch path and compares the bytes
   with the committed file. A stale committed artifact fails.

2. **Orphan.** A generator that declares `none (<reason>)` must have a caller
   among the tracked shell scripts. A line that names the generator is a
   caller unless the line is a comment or a list entry.

The declaration is the only hand-written input, and it lives beside the
generator instead of in a central list that a new generator can miss.

## Empirical findings

| Generator | Declaration | Callers today |
|---|---|---|
| `generate-build-input-manifest.sh` | `none` | `verify-build-input-manifest.sh`, `verify-invariants.sh`, `verify-upstream-copilot-release.sh` |
| `generate-builder-environment-manifest.sh` | `none` | `verify-invariants.sh` |
| `generate-control-plane-manifest.sh` | `none` | `verify-control-plane-manifest.sh`, `verify-invariants.sh` |
| `generate-homebrew-formula.sh` | `none` | `dev-quick-check.sh` |
| `generate-release-checksums.sh` | `none` | `verify-invariants.sh` |
| `generate-workflow-lane-manifest.sh` | `policy/workflow-lanes.json` | none before this change |

`scripts/generate-workflow-lane-manifest.sh` was the orphan the review history
predicted. Its only reference was its row in the `shell_files` array of
`scripts/validate-repo.sh`, which runs nothing.

**Resolution: wired, not deleted.** It is the one generator whose output is a
tracked file, so the freshness gate is its natural caller. The gate now runs it
on every validate lane and proves `policy/workflow-lanes.json` is current. The
five other generators write release artifacts that need a release version, the
published assets, or a live builder environment, so they cannot be regenerated
in a validate lane; each declares `none` with that reason and each already has
a caller.

## Note on the shared shell-invocation parser

The caller search does not use `metadatautil.ShellInvocations`. Measured
behavior: the parser reads a quoted list entry on its own line as a command
word, so it reports the `shell_files` lint array as a caller and cannot serve
this check. The `ValidateGeneratorCaller` doc comment records the ceiling and
the upgrade path. No new `ShellInvocations` call site is added, so the
validator anchoring parity is unchanged.

## Negative fixtures

`internal/metadatautil/generated_artifacts_check_test.go` covers a stale
artifact, an orphan generator, a missing declaration, an empty declaration, a
path with a trailing reason, an empty generator set, and the two shapes that
name a generator without running it: the `shell_files` lint array and a
comment.

## Registration

- `cmd/workcell-citools` subcommand `check-generated-artifacts`.
- `scripts/validate-repo.sh` `shell_files`.
- `scripts/ci/job-validate.sh` beside `verify-build-input-manifest.sh`.
- One `internal/mutation/runner.go` row, with `policy/mutation-score-policy.json`
  raised from 26 to 27 mutants.
- The `job-validate` local parity fixture list.

## Evidence

- `WORKCELL_VALIDATE_REPO_PROFILE=repo-core ./scripts/validate-repo.sh` passes.
- `./scripts/check-generated-artifacts.sh` passes.
- `./scripts/check-validator-anchoring.sh` passes.
- `./scripts/check-doc-language.sh` passes.
- `./scripts/verify-workflow-lanes.sh` passes.
- `./verify/invariants/control-plane-lockstep.sh` passes.
- `./scripts/check-pr-shape.sh`: files=15 lines=484 areas=4.

Review loop deferred.