### PR TITLE
^B Execute the bytes the guard classified on the descriptor and spawn paths (posix_spawn race won 52 of 2000 before and 0 of 2000 after, negative control 58 of 2000; user-visible execution boundary)

### DIFF
--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -2493,6 +2493,182 @@ fn execute_prepared_search_execve(
     }
 }
 
+/// The descriptor twin of `mutable_exec_preparation`.
+///
+/// A descriptor has no name to re-resolve, so a trusted one only needs to be
+/// held: the duplicate is the pin. An untrusted one still needs a snapshot,
+/// because its contents can change between this classification and the exec.
+#[cfg(target_os = "linux")]
+fn mutable_fd_preparation(fd: c_int, env_entries: &[String]) -> MutableExecPreparation {
+    if !current_mode_blocks_mutable_native_exec() || fd < 0 {
+        return MutableExecPreparation::NotMutable;
+    }
+    let untrusted = fd_target_is_untrusted_exec(fd);
+    let Some(pinned) = duplicate_owned_descriptor(fd) else {
+        return MutableExecPreparation::Block;
+    };
+    if !untrusted {
+        return MutableExecPreparation::Pinned(pinned);
+    }
+    let outcome = (|| {
+        let mut source = duplicate_fd_file(fd)?;
+        let metadata = source.metadata().ok()?;
+        if (metadata.mode() & file_type_bits()) != regular_file_mode() {
+            return None;
+        }
+        snapshot_mutable_file(&mut source, metadata.mode(), env_entries)
+    })();
+    close_prepared_fd(pinned);
+    outcome.map_or(
+        MutableExecPreparation::Block,
+        MutableExecPreparation::Execute,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn duplicate_owned_descriptor(fd: c_int) -> Option<c_int> {
+    // SAFETY: fd is only borrowed for fcntl, which returns a new descriptor the caller owns.
+    let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) };
+    (duplicate >= 0).then_some(duplicate)
+}
+
+/// Which half of `execveat` a call names.
+#[cfg(target_os = "linux")]
+enum ExecveatPreparationTarget {
+    /// A flag combination this preparation does not model; the caller's own
+    /// call stands, and every classifier above it has already run.
+    PassThrough,
+    /// The descriptor itself.
+    Descriptor,
+    /// A pathname resolved against the descriptor, with the open flags that
+    /// match the caller's resolution flags.
+    Path(c_int),
+}
+
+#[cfg(target_os = "linux")]
+fn execveat_preparation_target(path: &str, flags: c_int) -> ExecveatPreparationTarget {
+    if flags & !(libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW) != 0 {
+        return ExecveatPreparationTarget::PassThrough;
+    }
+    if path.is_empty() {
+        return if flags & libc::AT_EMPTY_PATH != 0 {
+            ExecveatPreparationTarget::Descriptor
+        } else {
+            ExecveatPreparationTarget::PassThrough
+        };
+    }
+    // Linux accepts AT_EMPTY_PATH beside a non-empty pathname, where it changes
+    // nothing about resolution, so the pathname is still what gets prepared.
+    ExecveatPreparationTarget::Path(if flags & libc::AT_SYMLINK_NOFOLLOW != 0 {
+        libc::O_NOFOLLOW
+    } else {
+        0
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn execute_prepared_execveat(
+    path: &str,
+    dirfd: c_int,
+    flags: c_int,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    env_entries: &[String],
+) -> Option<c_int> {
+    let prepared = match execveat_preparation_target(path, flags) {
+        ExecveatPreparationTarget::PassThrough => return None,
+        ExecveatPreparationTarget::Descriptor => mutable_fd_preparation(dirfd, env_entries),
+        ExecveatPreparationTarget::Path(open_flags) => {
+            mutable_exec_preparation(path, dirfd, open_flags, env_entries)
+        }
+    };
+    match prepared {
+        MutableExecPreparation::NotMutable => None,
+        MutableExecPreparation::Block => {
+            report_mutable_native_exec_block();
+            Some(-1)
+        }
+        MutableExecPreparation::Pinned(fd) | MutableExecPreparation::Execute(fd) => {
+            Some(execute_snapshot_execveat(fd, argv, envp))
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn execute_prepared_fexecve(
+    fd: c_int,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    env_entries: &[String],
+) -> Option<c_int> {
+    match mutable_fd_preparation(fd, env_entries) {
+        MutableExecPreparation::NotMutable => None,
+        MutableExecPreparation::Block => {
+            report_mutable_native_exec_block();
+            Some(-1)
+        }
+        MutableExecPreparation::Pinned(prepared) | MutableExecPreparation::Execute(prepared) => {
+            Some(execute_snapshot_execveat(prepared, argv, envp))
+        }
+    }
+}
+
+/// `posix_spawn` reports its failure as a return value rather than through
+/// errno, so this returns the errno to report instead of `-1`.
+///
+/// The spawned child resolves the prepared descriptor after the fork, which is
+/// why the descriptor is named by its `/proc/self/fd` path rather than exec'd
+/// directly: `posix_spawn` has no descriptor-taking form.
+#[cfg(target_os = "linux")]
+fn execute_prepared_spawn(
+    path: &str,
+    pid: *mut pid_t,
+    file_actions: *const libc::posix_spawn_file_actions_t,
+    attrp: *const libc::posix_spawnattr_t,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    env_entries: &[String],
+) -> Option<c_int> {
+    // File actions can change the child's working directory before glibc
+    // resolves a relative pathname, in the child, after this guard has
+    // returned. There is no name the guard can pin against that.
+    if current_mode_blocks_mutable_native_exec()
+        && !file_actions.is_null()
+        && !Path::new(path).is_absolute()
+    {
+        report_mutable_native_exec_block();
+        return Some(libc::EPERM);
+    }
+    match mutable_exec_preparation(path, libc::AT_FDCWD, 0, env_entries) {
+        MutableExecPreparation::NotMutable => None,
+        MutableExecPreparation::Block => {
+            report_mutable_native_exec_block();
+            Some(libc::EPERM)
+        }
+        MutableExecPreparation::Pinned(fd) | MutableExecPreparation::Execute(fd) => {
+            // File actions are opaque here: they can close or replace the very
+            // descriptor that names the prepared target before the child
+            // resolves it, so a prepared target and file actions cannot be
+            // served together.
+            if !file_actions.is_null() || !prepare_descriptor_for_exec(fd) {
+                close_prepared_fd(fd);
+                report_mutable_native_exec_block();
+                return Some(libc::EPERM);
+            }
+            let Some(fd_path) = fd_exec_path(fd) else {
+                close_prepared_fd(fd);
+                report_mutable_native_exec_block();
+                return Some(libc::EPERM);
+            };
+            // SAFETY: fd_path outlives the call and names the prepared descriptor, which stays open until posix_spawn returns; pid, attrp, argv and envp are the caller's own.
+            let result =
+                unsafe { posix_spawn_fn()(pid, fd_path.as_ptr(), file_actions, attrp, argv, envp) };
+            close_prepared_fd(fd);
+            Some(result)
+        }
+    }
+}
+
 // execvp, execvpe and posix_spawnp all search PATH from the caller's own
 // environment rather than the envp handed to the child, so the guard reads the
 // same source libc will. A name containing a slash is not searched at all, so
@@ -3168,6 +3344,13 @@ unsafe extern "C" fn guarded_execveat(
         return -1;
     }
 
+    #[cfg(target_os = "linux")]
+    if let Some(result) =
+        execute_prepared_execveat(&pathname_string, dirfd, flags, argv, envp, &env_entries)
+    {
+        return result;
+    }
+
     // SAFETY: forwards the caller's original, unmodified execveat arguments to the real libc execveat resolved via RTLD_NEXT.
     unsafe { execveat_fn()(dirfd, pathname, argv, envp, flags) }
 }
@@ -3224,6 +3407,11 @@ unsafe extern "C" fn guarded_fexecve(
         return -1;
     }
 
+    #[cfg(target_os = "linux")]
+    if let Some(result) = execute_prepared_fexecve(fd, argv, envp, &env_entries) {
+        return result;
+    }
+
     // SAFETY: forwards the caller's original, unmodified fexecve arguments to the real libc fexecve resolved via RTLD_NEXT.
     unsafe { fexecve_fn()(fd, argv, envp) }
 }
@@ -3272,6 +3460,19 @@ unsafe extern "C" fn guarded_posix_spawn(
     if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return libc::EPERM;
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(result) = execute_prepared_spawn(
+        &path_string,
+        pid,
+        file_actions,
+        attrp,
+        argv,
+        envp,
+        &env_entries,
+    ) {
+        return result;
     }
 
     // SAFETY: forwards the caller's original, unmodified posix_spawn arguments to the real libc posix_spawn resolved via RTLD_NEXT.
@@ -3336,6 +3537,19 @@ unsafe extern "C" fn guarded_posix_spawnp(
     if should_block_null_explicit_env(envp) || should_block_missing_guard_env(&env_entries) {
         report_missing_guard_env_block();
         return libc::EPERM;
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(result) = execute_prepared_spawn(
+        &effective_path,
+        pid,
+        file_actions,
+        attrp,
+        argv,
+        envp,
+        &env_entries,
+    ) {
+        return result;
     }
 
     // SAFETY: forwards the caller's original, unmodified posix_spawnp arguments to the real libc posix_spawnp resolved via RTLD_NEXT.
@@ -4583,6 +4797,152 @@ mod tests {
         let mut source = File::open(&allowed).expect("open allowed");
         let snapshot = snapshot_mutable_file(&mut source, 0o755, &[]).expect("snapshot");
         close_prepared_fd(snapshot);
+
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn descriptor_preparation_pins_or_snapshots_but_never_hands_the_name_back() {
+        let dir = create_temp_test_dir("fd-preparation");
+
+        // A trusted descriptor is held, not copied: the bytes are already
+        // trustworthy and there is no name to resolve a second time.
+        let trusted = File::open("/bin/true").expect("open /bin/true");
+        match mutable_fd_preparation(trusted.as_raw_fd(), &[]) {
+            MutableExecPreparation::Pinned(fd) => {
+                assert_ne!(
+                    fd,
+                    trusted.as_raw_fd(),
+                    "the pin must be its own descriptor"
+                );
+                close_prepared_fd(fd);
+            }
+            _ => panic!("a trusted descriptor must be pinned"),
+        }
+
+        // An untrusted script is served from a sealed copy of itself.
+        let script = dir.join("script");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write script");
+        let script_file = File::open(&script).expect("open script");
+        match mutable_fd_preparation(script_file.as_raw_fd(), &[]) {
+            MutableExecPreparation::Execute(fd) => close_prepared_fd(fd),
+            _ => panic!("an untrusted script descriptor must be snapshotted"),
+        }
+
+        // An untrusted native executable is refused rather than copied.
+        let elf = dir.join("elf");
+        fs::write(&elf, [0x7f, b'E', b'L', b'F', 2, 1, 1, 0]).expect("write elf");
+        let elf_file = File::open(&elf).expect("open elf");
+        assert!(matches!(
+            mutable_fd_preparation(elf_file.as_raw_fd(), &[]),
+            MutableExecPreparation::Block
+        ));
+
+        // A descriptor with no pathname and no regular file behind it cannot
+        // be served at all.
+        let (socket, _peer) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        assert!(matches!(
+            mutable_fd_preparation(socket.as_raw_fd(), &[]),
+            MutableExecPreparation::Block
+        ));
+
+        assert!(matches!(
+            mutable_fd_preparation(-1, &[]),
+            MutableExecPreparation::NotMutable
+        ));
+
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn execveat_names_its_target_by_flag_and_pathname() {
+        // The descriptor is the target only when the pathname is empty and the
+        // caller said so.
+        assert!(matches!(
+            execveat_preparation_target("", libc::AT_EMPTY_PATH),
+            ExecveatPreparationTarget::Descriptor
+        ));
+        assert!(matches!(
+            execveat_preparation_target("", 0),
+            ExecveatPreparationTarget::PassThrough
+        ));
+        // Linux accepts AT_EMPTY_PATH beside a pathname, where it changes
+        // nothing about resolution, so the pathname is still the target.
+        assert!(matches!(
+            execveat_preparation_target("tool", libc::AT_EMPTY_PATH),
+            ExecveatPreparationTarget::Path(0)
+        ));
+        assert!(matches!(
+            execveat_preparation_target("tool", libc::AT_SYMLINK_NOFOLLOW),
+            ExecveatPreparationTarget::Path(libc::O_NOFOLLOW)
+        ));
+        // A flag this preparation does not model leaves the call alone; every
+        // classifier above it has already run.
+        assert!(matches!(
+            execveat_preparation_target("tool", libc::AT_SYMLINK_FOLLOW),
+            ExecveatPreparationTarget::PassThrough
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn spawn_file_actions_and_a_prepared_target_cannot_be_served_together() {
+        let dir = create_temp_test_dir("spawn-preparation");
+        let script = dir.join("script");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        // The pointer is only ever tested against NULL here, never read.
+        let actions = MaybeUninit::<libc::posix_spawn_file_actions_t>::zeroed();
+        let actions = actions.as_ptr();
+
+        // A relative pathname plus file actions: the actions can change the
+        // child's working directory before glibc resolves the name, in the
+        // child, after this guard has returned.
+        assert_eq!(
+            execute_prepared_spawn(
+                "relative/tool",
+                std::ptr::null_mut(),
+                actions,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                &[]
+            ),
+            Some(libc::EPERM)
+        );
+
+        // A target that needs preparing cannot be served alongside file
+        // actions either: they can close or replace the descriptor that names
+        // it before the child resolves it.
+        assert_eq!(
+            execute_prepared_spawn(
+                script.to_str().expect("script path"),
+                std::ptr::null_mut(),
+                actions,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                &[]
+            ),
+            Some(libc::EPERM)
+        );
+
+        // A trusted absolute target needs no preparation, with or without them.
+        assert_eq!(
+            execute_prepared_spawn(
+                "/bin/true",
+                std::ptr::null_mut(),
+                actions,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                &[]
+            ),
+            None
+        );
 
         fs::remove_dir_all(&dir).expect("cleanup temp test dir");
     }


### PR DESCRIPTION
Unit 9 of the #652 series, and the last of it. Units 1-8 are #670, #676, #684,
#685, #697, #703 and the unit-7 and unit-8 PRs.

## The hole

Unit 8 made `execve`, `execv`, `execvp` and `execvpe` execute the bytes they
classified. `execveat`, `fexecve`, `posix_spawn` and `posix_spawnp` still
handed their target back for a second lookup, so the same check/use window that
unit 8 measured at 8 wins in 3000 attempts was still open on four entry points.

## What lands

**`mutable_fd_preparation`** is the descriptor twin of
`mutable_exec_preparation`. A descriptor has no name to re-resolve, so a
trusted one only needs holding and the duplicate is the pin; an untrusted one
still needs a sealed snapshot, because its contents can change between the
classification and the exec even though the inode cannot.

**`execveat_preparation_target`** decides which half of `execveat` a call
names: the descriptor when the pathname is empty and `AT_EMPTY_PATH` is set,
the pathname otherwise — Linux accepts the flag beside a pathname, where it
changes nothing about resolution, so the pathname is still what gets prepared.
A flag combination this preparation does not model passes through, with every
classifier above it already run.

**`execute_prepared_spawn`** refuses two shapes it cannot serve rather than
serving them unpinned:

- a relative pathname beside file actions, because the actions can change the
  child's working directory before glibc resolves the name — in the child,
  after this guard has returned;
- a prepared target beside file actions, because the actions are opaque here
  and can close or replace the very descriptor that names the target before
  the child resolves it. `posix_spawn` has no descriptor-taking form, so a
  prepared target is named by its `/proc/self/fd` path, which is exactly what
  arbitrary file actions can take away.

All four entry points are wired, and every one keeps its full refusal chain
ahead of the preparation, including the fail-closed missing-preload default
from #685.

## Race proof

Pinned toolchain image, guard built from the unit-8 state and from this branch.
The target alternates between a script the guard allows and one it refuses,
swapped by rename, and the caller spawns it repeatedly.

| entry point | guard | attempts | refused content executed | allowed content executed |
| --- | --- | --- | --- | --- |
| `posix_spawn` | unit 8 | 2000 | **52** | 749 |
| `posix_spawn` | this branch | 2000 | **0** | 786 |

The last column is the control: both sides really execute the target hundreds
of times, so the zero is a refusal rather than a dead harness.

**Negative control.** The same harness against a copy of this branch with only
the four wiring terms removed: **58 / 2000**. The preparation machinery is
present in that build and unused, so the number is the wiring and nothing else.

## What the harness could not show, and why it is reported anyway

The `fexecve` row was run and won nothing on **either** guard (0 of 2000). A
descriptor pins the inode, so the target has to be rewritten in place rather
than renamed, and that window is far narrower than the rename one. The
aggressive rewriting also makes most reads land on a truncated file, which this
branch correctly refuses — it executes what it read — so the branch's
allowed-content count collapses under the swapper. Neither number says anything
about the guard, and neither is offered as if it did.

The descriptor half is evidenced instead by a quiet control, with no swapper
running, on both guards:

| entry point | guard | allowed script | refused script |
| --- | --- | --- | --- |
| `fexecve` | unit 8 | EXECUTED | BLOCKED |
| `fexecve` | this branch | EXECUTED | BLOCKED |
| `posix_spawn` | unit 8 | EXECUTED | BLOCKED |
| `posix_spawn` | this branch | EXECUTED | BLOCKED |

so the descriptor path serves an ordinary untrusted script and refuses the one
it should, with no change from unit 8 outside the race.

`execveat` with a pathname is left out of the harness on purpose: this kernel
answers `ENOENT` for a shebang executed that way whatever the guard does, so
the row would report nothing. That path delegates to the same
`mutable_exec_preparation` unit 8 proved, and its descriptor half is what
`fexecve` drives.

## Testing

- macOS host: fmt clean; `cargo clippy --all-targets --offline --locked -- -D
  warnings` zero warnings; `cargo test --offline --locked` 29 + 17 + 1 pass.
- Pinned Linux image: fmt clean, clippy clean, `cargo build --release --locked
  --offline` links, `cargo test --offline --locked` **46 + 17 + 1** pass —
  **as root and as `--user 1001:1001`**. That second run is the lesson from
  #706, where a test passed under root and failed in CI's validator container
  for no reason but the uid; this unit was checked both ways before pushing.
- `scripts/container-smoke.sh` — green, from a bindable worktree.
- `go build ./...` clean.
- `grep -rnE 'unsafe extern( +"[^"]*")? *\{' runtime/container/rust/src` — two
  pre-existing hits, both already carrying a `// SAFETY:` comment. This unit
  adds no `unsafe extern` block; every new `unsafe` block carries its own
  `// SAFETY:` comment.
- Review loop deferred.

New tests: `descriptor_preparation_pins_or_snapshots_but_never_hands_the_name_back`,
`execveat_names_its_target_by_flag_and_pathname`,
`spawn_file_actions_and_a_prepared_target_cannot_be_served_together`.

Those tests call the preparation directly, so they pass with the wiring removed
too; the race harness above is what proves the wiring, and its negative control
is what proves the harness.

## Deliberate ceilings

- `posix_spawn` with file actions is refused for any target that needs
  preparing, rather than served. Serving it would mean reproducing the file
  actions' effect on the descriptor table before deciding, which is not
  something the opaque type allows. Nothing in the runtime image spawns with
  file actions onto an untrusted target.
- Nothing here reads pathname provenance, so the `/proc/<pid>/fd` ownership
  defect #706 fixed has no sibling in this unit: `mutable_fd_preparation`
  decides from the descriptor alone, and the pathname half of `execveat`
  delegates to the already-corrected `mutable_exec_preparation`.
- `RAW_SYSCALL_PENDING` in `tests/loader_forms.rs` stays pending. #703
  confirmed the reason empirically — `nm -D --defined-only` on the release
  cdylib lists `workcell_syscall_shim` and not `syscall`, despite the
  `global_asm!` trampoline in `lib.rs` — and nothing in this unit's spawn work
  changes that: the row needs the `syscall` symbol exported, which is an
  interposition question rather than a preparation one. It remains recorded for
  the trampoline unit.
- A magic exec **pathname** now goes through the preparation on every entry
  point rather than being classified and handed back, which is the ceiling
  #703 recorded as belonging to units 8 and 9. `mutable_exec_preparation`
  returns `Pinned` for a trusted target named that way and `Execute` or `Block`
  for an untrusted one, so the pathname is never resolved twice.

## Shape

1 file, +360 changed lines over unit 8, 1 area.

## Series

This is the last unit. `security/rust-exec-hardening` can be deleted once this
lands; every piece of it is now either merged, or recorded above and in the
earlier unit PRs as deliberately dropped.
