### PR TITLE
Add the shell portability banlist (S14)

### DIFF
--- a/cmd/workcell-citools/main.go
+++ b/cmd/workcell-citools/main.go
@@ -110,6 +110,7 @@ func subcommands() []subcommand {
 		{"check-validator-anchoring", "REPO_ROOT", 1, 1, cmdCheckValidatorAnchoring},
 		{"check-doc-language", "REPO_ROOT", 1, 1, cmdCheckDocLanguage},
 		{"check-generated-artifacts", "REPO_ROOT", 1, 1, cmdCheckGeneratedArtifacts},
+		{"check-shell-portability", "REPO_ROOT", 1, 1, cmdCheckShellPortability},
 		{"verify-reproducible-build", "OCI_EXPORT_A OCI_EXPORT_B REPRO_PLATFORMS REPRO_MANIFEST_PATH SOURCE_DATE_EPOCH", 5, 5, cmdVerifyReproducibleBuild},
 		{"generate-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS OUTPUT_PATH SOURCE_DATE_EPOCH", 4, 4, cmdGenerateReproducibleBuildManifest},
 		{"verify-reproducible-build-manifest", "OCI_EXPORT REPRO_PLATFORMS MANIFEST_PATH", 3, 3, cmdVerifyReproducibleBuildManifest},
@@ -541,6 +542,10 @@ func cmdCheckDocLanguage(args []string) error {
 
 func cmdCheckGeneratedArtifacts(args []string) error {
 	return metadatautil.CheckGeneratedArtifacts(args[0])
+}
+
+func cmdCheckShellPortability(args []string) error {
+	return metadatautil.CheckShellPortability(args[0])
 }
 
 func cmdCheckPinnedInputs(args []string) error {

--- a/internal/metadatautil/portability_check.go
+++ b/internal/metadatautil/portability_check.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// CheckShellPortability rejects a GNU-only or Bash-4-only construct in a
+// tracked shell script.
+//
+// The host baseline is macOS: /bin/bash 3.2 and a BSD userland. A script that
+// uses mapfile, declare -A, sha256sum, stat -c or readlink -f runs on the
+// Linux validator image and fails on the operator host, and the failure only
+// appears where no CI lane looks. scripts/check-doc-links.sh already states
+// the contract in a header comment; nothing enforced it.
+//
+// The runtime tree is out of scope: it only runs inside the image. A script
+// outside it that still only runs there declares that once:
+//
+//	# portability-exempt: linux-only (reason)
+//
+// A single line that the reviewer accepted carries the same tag at its end.
+func CheckShellPortability(rootDir string) error {
+	files, err := trackedShellScripts(rootDir)
+	if err != nil {
+		return err
+	}
+	var failures []string
+	for _, rel := range files {
+		if strings.HasPrefix(rel, runtimeTreePrefix) {
+			// The runtime tree only ever runs inside the Debian image, where
+			// bash 5 and the GNU userland are present. Its scripts are also
+			// digest-bound by runtime/container/control-plane-manifest.json,
+			// so a comment added to one of them is a manifest change.
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(rootDir, rel))
+		if err != nil {
+			return err
+		}
+		failures = append(failures, ShellPortabilityFindings(string(content), rel)...)
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	sort.Strings(failures)
+	return fmt.Errorf("shell portability check failed (%d finding(s)); the host baseline is macOS bash 3.2 with a BSD userland:\n  %s",
+		len(failures), strings.Join(failures, "\n  "))
+}
+
+const (
+	portabilityExemptTag = "# portability-exempt:"
+
+	// runtimeTreePrefix holds the scripts that run inside the Linux image.
+	runtimeTreePrefix = "runtime/"
+)
+
+// portabilityRule is one construct the host baseline does not carry.
+type portabilityRule struct {
+	name        string
+	pattern     *regexp.Regexp
+	replacement string
+	// bashVersion marks a rule that only the shell version decides. A script
+	// that re-executes itself under bash 4 has already proved the feature is
+	// present, so the rule does not apply to it.
+	bashVersion bool
+}
+
+// modernBashAssertion is the helper a script calls to re-execute itself under
+// bash 4 or newer. scripts/lib/canonical-build-env.sh defines it.
+const modernBashAssertion = "workcell_require_modern_privileged_bash"
+
+// heredocDelimiter returns the word that ends the heredoc a line opens, or the
+// empty string when the line opens none. Quotes around the word are part of
+// the redirection, not of the delimiter.
+func heredocDelimiter(line string) string {
+	match := heredocOpener.FindStringSubmatch(line)
+	if match == nil {
+		return ""
+	}
+	return strings.Trim(match[1], `"\'`+"`")
+}
+
+var heredocOpener = regexp.MustCompile("<<-?[ \t]*([\"'`]?[A-Za-z_][A-Za-z0-9_]*[\"'`]?)")
+
+// portabilityRules holds one row per defect the reviewer found, plus the
+// constructs of the same two families that the tree does not carry yet.
+var portabilityRules = []portabilityRule{
+	{bashVersion: true, name: "mapfile", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*mapfile\b`), replacement: "bash 4; read the lines in a while loop"},
+	{bashVersion: true, name: "readarray", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*readarray\b`), replacement: "bash 4; read the lines in a while loop"},
+	{bashVersion: true, name: "wait -n", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*wait\s+-n\b`), replacement: "bash 5; wait for each recorded process identifier"},
+	{bashVersion: true, name: "declare -A", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*(declare|local|typeset)\s+-A\b`), replacement: "bash 4; use a temporary file or parallel arrays"},
+	{bashVersion: true, name: "case conversion expansion", pattern: regexp.MustCompile(`\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?(\^\^|,,)`), replacement: "bash 4; use tr"},
+	{name: "sha256sum", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*sha256sum\b`), replacement: "GNU coreutils; use shasum -a 256"},
+	{name: "stat -c", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*stat\s+(-[A-Za-z]+\s+)*-c\b`), replacement: "GNU; BSD stat uses -f"},
+	{name: "date -d", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*date\s+(-[A-Za-z]+\s+)*-d\b`), replacement: "GNU; BSD date uses -v or -j -f"},
+	{name: "grep -P", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*grep\s+(-[A-Za-z]+\s+)*-P\b`), replacement: "GNU; use grep -E"},
+	{name: "find -printf", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*find\b[^\n]*\s-printf\b`), replacement: "GNU; use -print0 and read the names"},
+	{name: "sed -i without a suffix", pattern: regexp.MustCompile(`(^|[;&|(]|\$\()\s*sed\s+(-[A-Za-z]+\s+)*-i\s`), replacement: "BSD sed requires a backup suffix, such as -i.bak"},
+}
+
+// ShellPortabilityFindings reports one finding per banned construct in script.
+//
+// It skips a comment line, a heredoc body, a line or a file that declares the
+// exemption tag, and every bash-4 rule in a script that first re-executes
+// itself under a modern bash. A heredoc body is text this script hands to
+// another interpreter, most often bash 5 inside the Linux image, so its
+// contents are not commands this script runs on the host.
+func ShellPortabilityFindings(script, name string) []string {
+	if fileExemptsPortability(script) {
+		return nil
+	}
+	modernBash := strings.Contains(script, modernBashAssertion)
+	var findings []string
+	number := 0
+	pending := ""
+	for line := range strings.Lines(script) {
+		number++
+		text := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if pending != "" {
+			if strings.TrimSpace(text) == pending {
+				pending = ""
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(text)
+		if delimiter := heredocDelimiter(text); delimiter != "" {
+			pending = delimiter
+		}
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(text, portabilityExemptTag) {
+			continue
+		}
+		for _, rule := range portabilityRules {
+			if rule.bashVersion && modernBash {
+				continue
+			}
+			if !rule.pattern.MatchString(text) {
+				continue
+			}
+			findings = append(findings, fmt.Sprintf("%s:%d: %s is not on the host baseline (%s)",
+				name, number, rule.name, rule.replacement))
+		}
+	}
+	return findings
+}
+
+// fileExemptsPortability reports a script that declares it only runs inside
+// the Linux image. The declaration has to sit in the header, so a mention
+// deeper in the script cannot exempt the whole file.
+func fileExemptsPortability(script string) bool {
+	lines := strings.Split(script, "\n")
+	if len(lines) > portabilityHeaderLines {
+		lines = lines[:portabilityHeaderLines]
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), portabilityExemptTag+" linux-only") {
+			return true
+		}
+	}
+	return false
+}
+
+const portabilityHeaderLines = 20
+
+func trackedShellScripts(rootDir string) ([]string, error) {
+	command := exec.Command("git", "-C", rootDir, "ls-files", "-z", "*.sh")
+	listing, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list tracked shell scripts: %w", err)
+	}
+	var files []string
+	for _, path := range strings.Split(string(listing), "\x00") {
+		if path != "" {
+			files = append(files, path)
+		}
+	}
+	if len(files) == 0 {
+		return nil, errors.New("tracked shell script listing is empty; refusing a vacuous pass")
+	}
+	return files, nil
+}

--- a/internal/metadatautil/portability_check_test.go
+++ b/internal/metadatautil/portability_check_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package metadatautil_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/metadatautil"
+)
+
+func TestCheckShellPortabilityAcceptsThisRepository(t *testing.T) {
+	if err := metadatautil.CheckShellPortability(filepath.Join("..", "..")); err != nil {
+		t.Fatalf("CheckShellPortability() error = %v", err)
+	}
+}
+
+// Each row carries a construct the reviewer flagged, or one of the same two
+// families. Every "flag" row was measured on macOS 26 with the system path
+// /usr/bin:/bin and the system /bin/bash 3.2: the command or the builtin
+// fails there.
+func TestShellPortabilityFindings(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		script string
+		flag   bool
+	}{
+		{"mapfile", "mapfile -t lines <input\n", true},
+		{"readarray", "readarray -t lines <input\n", true},
+		{"wait -n", "wait -n\n", true},
+		{"declare -A", "declare -A table=()\n", true},
+		{"local -A", "  local -A table=()\n", true},
+		{"upper-case expansion", `printf '%s' "${name^^}"` + "\n", true},
+		{"lower-case expansion", `printf '%s' "${name,,}"` + "\n", true},
+		{"sha256sum", `digest="$(sha256sum "${path}")"` + "\n", true},
+		{"stat -c", "stat -c '%a' \"${path}\"\n", true},
+		{"date -d", "date -u -d '-1 day' +%Y\n", true},
+		{"grep -P", "grep -P 'x' file\n", true},
+		{"find -printf", "find . -type f -printf '%p'\n", true},
+		{"sed -i without a suffix", "sed -i 's/a/b/' file\n", true},
+		{"pipeline position", "cat file | mapfile -t lines\n", true},
+
+		{"shasum is the portable form", `digest="$(shasum -a 256 "${path}")"` + "\n", false},
+		{"stat -f is the BSD form", "stat -f '%Lp' \"${path}\"\n", false},
+		{"sed -i with a suffix", "sed -i.bak 's/a/b/' file\n", false},
+		{"a comment names the construct", "# do not call sha256sum here\n", false},
+		{"an argument is not a command", "require_tool sha256sum\n", false},
+		{"a longer name is not the command", "workcell_sha256sum file\n", false},
+		{"the line declares the exemption", "stat -c '%a' f # portability-exempt: the BSD form is tried first\n", false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			findings := metadatautil.ShellPortabilityFindings(testCase.script, "fixture.sh")
+			if (len(findings) > 0) != testCase.flag {
+				t.Fatalf("ShellPortabilityFindings() = %v, want a finding = %v", findings, testCase.flag)
+			}
+		})
+	}
+}
+
+// A heredoc body is text this script hands to another interpreter, and the
+// interpreter is bash 5 inside the Linux image for every such body in the
+// tree. The reviewer's own class-D lesson applies: read the commands the
+// script runs, not the text it carries.
+func TestShellPortabilityIgnoresHeredocBodies(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{"quoted heredoc", "docker exec c bash -s <<'SCRIPT'\nstat -c '%a' /etc/hosts\nSCRIPT\n"},
+		{"unquoted heredoc", "cat >f <<EOF\nsha256sum x\nEOF\n"},
+		{"indented heredoc", "\tcat >f <<-EOF\n\tmapfile -t a <x\n\tEOF\n"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if findings := metadatautil.ShellPortabilityFindings(testCase.script, "fixture.sh"); len(findings) != 0 {
+				t.Fatalf("expected no finding, found %v", findings)
+			}
+		})
+	}
+	// The same construct outside a heredoc still fails.
+	if findings := metadatautil.ShellPortabilityFindings("stat -c '%a' /etc/hosts\n", "fixture.sh"); len(findings) != 1 {
+		t.Fatalf("expected one finding outside a heredoc, found %v", findings)
+	}
+}
+
+// A script that re-executes itself under bash 4 has proved the builtin is
+// present. scripts/validate-repo.sh does exactly this and then uses
+// declare -A, which is correct and must not be reported.
+func TestShellPortabilityHonoursTheModernBashAssertion(t *testing.T) {
+	t.Parallel()
+	body := "declare -A table=()\nmapfile -t lines <input\n"
+	if findings := metadatautil.ShellPortabilityFindings(body, "fixture.sh"); len(findings) != 2 {
+		t.Fatalf("expected two findings without the assertion, found %v", findings)
+	}
+	asserted := "workcell_require_modern_privileged_bash \"$@\"\n" + body
+	if findings := metadatautil.ShellPortabilityFindings(asserted, "fixture.sh"); len(findings) != 0 {
+		t.Fatalf("expected no bash-version finding after the assertion, found %v", findings)
+	}
+	// The userland rules do not depend on the shell version.
+	withUserland := "workcell_require_modern_privileged_bash \"$@\"\nstat -c '%a' f\n"
+	if findings := metadatautil.ShellPortabilityFindings(withUserland, "fixture.sh"); len(findings) != 1 {
+		t.Fatalf("expected the userland finding to survive the assertion, found %v", findings)
+	}
+}
+
+func TestShellPortabilityHonoursTheFileExemption(t *testing.T) {
+	t.Parallel()
+	script := "#!/usr/bin/env bash\n# portability-exempt: linux-only (runs inside the Debian runtime image)\nstat -c '%a' f\n"
+	if findings := metadatautil.ShellPortabilityFindings(script, "fixture.sh"); len(findings) != 0 {
+		t.Fatalf("expected no finding, found %v", findings)
+	}
+	// The declaration has to sit in the header, so a mention further down
+	// cannot exempt the file.
+	deep := "#!/usr/bin/env bash\n" + strings.Repeat("true\n", 30) +
+		"# portability-exempt: linux-only (late)\nstat -c '%a' f\n"
+	if findings := metadatautil.ShellPortabilityFindings(deep, "fixture.sh"); len(findings) != 1 {
+		t.Fatalf("expected one finding, found %v", findings)
+	}
+}
+
+func TestCheckShellPortabilityRejectsEmptyInventory(t *testing.T) {
+	t.Parallel()
+	if err := metadatautil.CheckShellPortability(t.TempDir()); err == nil {
+		t.Fatal("expected an empty shell script inventory to fail")
+	}
+}

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -199,6 +199,13 @@ var goHelperMutations = []mutationCase{
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestScanDocLanguageFlagsReviewedProse", "-count=1"),
 	},
 	{
+		relativePath: "internal/metadatautil/portability_check.go",
+		original:     `			if rule.bashVersion && modernBash {`,
+		replacement:  `			if false && rule.bashVersion && modernBash {`,
+		label:        "portability banlist modern-bash exemption",
+		command:      goCmd("test", "./internal/metadatautil", "-run", "TestShellPortabilityHonoursTheModernBashAssertion", "-count=1"),
+	},
+	{
 		relativePath: "internal/metadatautil/generated_artifacts_check.go",
 		original:     `	if !bytes.Equal(committed, regenerated) {`,
 		replacement:  `	if false && !bytes.Equal(committed, regenerated) {`,

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -358,7 +358,7 @@ func runValidatorJobOwnershipFixture(t *testing.T, job string, test validatorJob
 
 func writeValidatorValidateFixtureFiles(t *testing.T, root string) {
 	t.Helper()
-	for _, name := range []string{"verify-github-macos-release-test-runners.sh", "verify-build-input-manifest.sh", "verify-upstream-codex-release.sh", "verify-upstream-claude-release.sh", "verify-upstream-copilot-release.sh", "verify-upstream-gemini-release.sh", "verify-invariants.sh", "check-generated-artifacts.sh"} {
+	for _, name := range []string{"verify-github-macos-release-test-runners.sh", "verify-build-input-manifest.sh", "verify-upstream-codex-release.sh", "verify-upstream-claude-release.sh", "verify-upstream-copilot-release.sh", "verify-upstream-gemini-release.sh", "verify-invariants.sh", "check-generated-artifacts.sh", "check-shell-portability.sh"} {
 		writeExecutable(t, filepath.Join(root, "scripts"), name, "#!/bin/bash\nexit 0\n")
 	}
 	writeExecutable(t, filepath.Join(root, "scripts", "ci"), "run-validate-in-validator.sh", "#!/bin/bash\nexit \"${WORKCELL_TEST_WORKLOAD_STATUS}\"\n")

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 27
+  "expected_mutants": 28
 }

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -p
+# Rejects a GNU-only or Bash-4-only construct in a tracked shell script. The
+# host baseline is macOS: /bin/bash 3.2 and a BSD userland, so mapfile,
+# declare -A, sha256sum, stat -c and date -d fail there. A script that runs
+# only inside the Linux image declares "# portability-exempt: linux-only
+# (reason)" in its header, and a reviewed line carries the same tag at its end.
+# shellcheck source=scripts/lib/trusted-entrypoint.sh
+# shellcheck disable=SC2312 # repo-wide bootstrap; the path is the running script's own directory
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
+
+if [[ "${1:-}" == "--self-entrypoint-probe" ]]; then
+  head -n 1 "$0" >/dev/null
+  echo "check-shell-portability-entrypoint-ok"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GO_BIN="${WORKCELL_GO_BIN:-}"
+
+resolve_go_bin() {
+  if [[ -n "${GO_BIN}" && -x "${GO_BIN}" ]]; then
+    return 0
+  fi
+  if GO_BIN="$(command -v go 2>/dev/null)"; then
+    return 0
+  fi
+  for candidate in \
+    /opt/homebrew/bin/go \
+    /usr/local/go/bin/go \
+    /usr/local/bin/go \
+    /usr/bin/go; do
+    if [[ -x "${candidate}" ]]; then
+      GO_BIN="${candidate}"
+      return 0
+    fi
+  done
+  echo "Missing required tool: go" >&2
+  exit 1
+}
+
+resolve_go_bin
+
+(cd "${ROOT_DIR}" && "${GO_BIN}" run ./cmd/workcell-citools check-shell-portability "${ROOT_DIR}")

--- a/scripts/ci/cost-report.sh
+++ b/scripts/ci/cost-report.sh
@@ -24,7 +24,7 @@ if ! [[ "${DAYS}" =~ ^[1-9][0-9]*$ ]]; then
   exit 2
 fi
 
-since="$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)"
+since="$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)" # portability-exempt: runs only in the Linux CI lane
 generated="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 printf '## CI cost report (last %s days)\n\n' "${DAYS}"

--- a/scripts/ci/flaky-report.sh
+++ b/scripts/ci/flaky-report.sh
@@ -28,7 +28,7 @@ if ! [[ "${DAYS}" =~ ^[1-9][0-9]*$ ]]; then
   exit 2
 fi
 
-since="$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)"
+since="$(date -u -d "${DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)" # portability-exempt: runs only in the Linux CI lane
 generated="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 printf '## Flaky-test report (last %s days)\n\n' "${DAYS}"

--- a/scripts/ci/job-validate.sh
+++ b/scripts/ci/job-validate.sh
@@ -103,6 +103,9 @@ echo "[ci/validate] validator evasion corpus registration"
 echo "[ci/validate] GitHub macOS release test runners"
 "${ROOT_DIR}/scripts/verify-github-macos-release-test-runners.sh" macos-26 macos-15
 
+echo "[ci/validate] shell portability banlist"
+"${ROOT_DIR}/scripts/check-shell-portability.sh"
+
 echo "[ci/validate] generated artifact freshness"
 "${ROOT_DIR}/scripts/check-generated-artifacts.sh"
 
@@ -197,7 +200,7 @@ if [[ "${PROFILE}" != "repo-core" ]]; then
         --prefix="${BUNDLE_PREFIX}" \
         "${ARCHIVE_REF}" | gzip -n -9
     ' >"${bundle_path}"
-  bundle_sha="$(sha256sum "${bundle_path}" | awk '{print $1}')"
+  bundle_sha="$(sha256sum "${bundle_path}" | awk '{print $1}')" # portability-exempt: runs only in the Linux CI lane
   "${ROOT_DIR}/scripts/generate-homebrew-formula.sh" \
     "ci-${ARCHIVE_REF}" \
     "${bundle_sha}" \
@@ -211,7 +214,7 @@ if [[ "${PROFILE}" != "repo-core" ]]; then
   # check rather than as a silent install over a different bundle.
   (
     cd "${ARTIFACT_DIR}"
-    sha256sum "${bundle_name}" >SHA256SUMS
+    sha256sum "${bundle_name}" >SHA256SUMS # portability-exempt: runs only in the Linux CI lane
   )
 fi
 

--- a/scripts/ci/run-docs-in-validator.sh
+++ b/scripts/ci/run-docs-in-validator.sh
@@ -65,7 +65,7 @@ workcell_ci_docker run --rm \
   -lc '
     set -euo pipefail
     mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"
-    mapfile -d "" doc_files < <(
+    mapfile -d "" doc_files < <( # portability-exempt: the validator image runs this command string
       find /workspace \
         -path /workspace/.git -prune -o \
         -path /workspace/dist -prune -o \

--- a/scripts/generate-release-checksums.sh
+++ b/scripts/generate-release-checksums.sh
@@ -51,7 +51,7 @@ trap cleanup EXIT
 
 printf '%s\n' "$@" | LC_ALL=C sort | while IFS= read -r path; do
   base_name="$(basename "${path}")"
-  digest="$(sha256sum "${path}" | awk '{print $1}')"
+  digest="$(sha256sum "${path}" | awk '{print $1}')" # portability-exempt: runs only in the Linux release lane
   printf '%s  %s\n' "${digest}" "${base_name}"
 done >"${tmp_output}"
 

--- a/scripts/update-upstream-pins.sh
+++ b/scripts/update-upstream-pins.sh
@@ -227,7 +227,7 @@ file_mode_octal() {
   if stat -f '%Lp' "${path}" >/dev/null 2>&1; then
     stat -f '%Lp' "${path}"
   else
-    stat -c '%a' "${path}"
+    stat -c '%a' "${path}" # portability-exempt: the BSD stat form is tried first
   fi
 }
 
@@ -303,7 +303,7 @@ date_stamp_for_offset() {
     if [[ "${offset}" == "0" ]]; then
       date -u +%Y%m%dT000000Z
     else
-      date -u -d "-${offset} day" +%Y%m%dT000000Z
+      date -u -d "-${offset} day" +%Y%m%dT000000Z # portability-exempt: the GNU date form is probed first
     fi
     return
   fi

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -163,6 +163,7 @@ shell_files=(
   "${ROOT_DIR}/scripts/check-dead-code.sh"
   "${ROOT_DIR}/scripts/check-doc-language.sh"
   "${ROOT_DIR}/scripts/check-generated-artifacts.sh"
+  "${ROOT_DIR}/scripts/check-shell-portability.sh"
   "${ROOT_DIR}/scripts/check-doc-links.sh"
   "${ROOT_DIR}/scripts/check-doc-support-matrix-fields.sh"
   "${ROOT_DIR}/scripts/check-public-repo-hygiene.sh"

--- a/scripts/verify-invariants.sh
+++ b/scripts/verify-invariants.sh
@@ -550,7 +550,7 @@ file_mode_octal() {
   if stat -f '%Lp' "${path}" >/dev/null 2>&1; then
     stat -f '%Lp' "${path}"
   else
-    stat -c '%a' "${path}"
+    stat -c '%a' "${path}" # portability-exempt: the BSD stat form is tried first
   fi
 }
 

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -100,7 +100,7 @@ fail() {
 sha256_of() {
   local path="$1"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${path}" | awk '{print $1}'
+    sha256sum "${path}" | awk '{print $1}' # portability-exempt: the shasum fallback follows
   elif command -v shasum >/dev/null 2>&1; then
     shasum -a 256 "${path}" | awk '{print $1}'
   else

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -186,7 +186,7 @@ build_bundle_locally() {
   gzip -n -9 <"${tar_path}" >"${destination}"
   rm -f "${tar_path}"
   rm -rf "${clone_dir}"
-  (cd "${destination_dir}" && sha256sum "${BUNDLE_NAME}" >SHA256SUMS)
+  (cd "${destination_dir}" && sha256sum "${BUNDLE_NAME}" >SHA256SUMS) # portability-exempt: runs only in the Linux CI and release lanes
 }
 
 build_bundle_in_validator() {
@@ -256,7 +256,7 @@ git -C "${clone_dir}" archive \
   --prefix="${BUNDLE_PREFIX}" \
   "${ARCHIVE_REF}" | gzip -n -9
 SCRIPT
-  (cd "${destination_dir}" && sha256sum "${BUNDLE_NAME}" >SHA256SUMS)
+  (cd "${destination_dir}" && sha256sum "${BUNDLE_NAME}" >SHA256SUMS) # portability-exempt: runs only in the Linux CI and release lanes
 }
 
 if [[ -n "${BUNDLE_MANIFEST_PATH}" ]]; then

--- a/scripts/verify-release-outputs.sh
+++ b/scripts/verify-release-outputs.sh
@@ -87,7 +87,7 @@ require_regular_file() {
 }
 
 sha256_of() {
-  sha256sum "$1" | awk '{print $1}'
+  sha256sum "$1" | awk '{print $1}' # portability-exempt: runs only in the Linux release lane
 }
 
 run_cosign() {

--- a/scripts/verify-upstream-claude-release.sh
+++ b/scripts/verify-upstream-claude-release.sh
@@ -52,7 +52,7 @@ verify_asset() {
 
   mkdir -p "${work_dir}"
   download_large_asset "${CLAUDE_RELEASE_ROOT}/${CLAUDE_VERSION}/${platform}/claude" "${binary_path}"
-  echo "${expected_sha}  ${binary_path}" | sha256sum -c - >/dev/null
+  echo "${expected_sha}  ${binary_path}" | sha256sum -c - >/dev/null # portability-exempt: require_tool sha256sum fails closed when it is absent
 }
 
 manifest_sha() {

--- a/scripts/verify-upstream-codex-release.sh
+++ b/scripts/verify-upstream-codex-release.sh
@@ -62,7 +62,7 @@ verify_asset() {
   download_large_asset "${asset_root}/${tarball_name}" "${work_dir}/${tarball_name}"
   download_large_asset "${asset_root}/${bundle_name}" "${work_dir}/${bundle_name}"
 
-  echo "${codex_sha}  ${work_dir}/${tarball_name}" | sha256sum -c - >/dev/null
+  echo "${codex_sha}  ${work_dir}/${tarball_name}" | sha256sum -c - >/dev/null # portability-exempt: require_tool sha256sum fails closed when it is absent
   tar -xzf "${work_dir}/${tarball_name}" -C "${work_dir}"
 
   cosign verify-blob "${work_dir}/${asset_prefix}-${codex_arch}" \

--- a/scripts/verify-upstream-copilot-release.sh
+++ b/scripts/verify-upstream-copilot-release.sh
@@ -354,7 +354,7 @@ verify_asset() {
     exit 1
   fi
   github_asset_get "${asset_url}" "${work_dir}/${tarball_name}"
-  echo "${expected_sha}  ${work_dir}/${tarball_name}" | sha256sum -c - >/dev/null
+  echo "${expected_sha}  ${work_dir}/${tarball_name}" | sha256sum -c - >/dev/null # portability-exempt: require_tool sha256sum fails closed when it is absent
   tar -tzf "${work_dir}/${tarball_name}" copilot >/dev/null
   [[ "${COPILOT_HELP_MODE}" == "checksum" ]] && return 0
   tar -xzf "${work_dir}/${tarball_name}" -C "${work_dir}" copilot

--- a/tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh
+++ b/tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh
@@ -69,7 +69,10 @@ jq -e '(.Reservations | length == 1) and (.Reservations[0].Instances | length ==
 [[ "$(jq -r '.Reservations[0].Instances[0].State.Name' "${TMP_DIR}/instance.json")" == "running" ]] ||
   fail "EC2 target ${TARGET_ID} is not running."
 
-mapfile -t SECURITY_GROUP_IDS < <(jq -r '.Reservations[0].Instances[0].SecurityGroups[].GroupId' "${TMP_DIR}/instance.json")
+SECURITY_GROUP_IDS=()
+while IFS= read -r security_group_id; do
+  [[ -n "${security_group_id}" ]] && SECURITY_GROUP_IDS+=("${security_group_id}")
+done < <(jq -r '.Reservations[0].Instances[0].SecurityGroups[].GroupId' "${TMP_DIR}/instance.json")
 ((${#SECURITY_GROUP_IDS[@]} > 0)) || fail "EC2 target ${TARGET_ID} has no security groups."
 for sg_id in "${SECURITY_GROUP_IDS[@]}"; do
   aws_json ec2 describe-security-groups --group-ids "${sg_id}" >"${TMP_DIR}/security-group-${sg_id}.json"

--- a/tests/scenarios/shared/test-publish-github-release.sh
+++ b/tests/scenarios/shared/test-publish-github-release.sh
@@ -104,7 +104,7 @@ done
 set +e
 malformed_output="$(HOME="${HOST_HOME}" XDG_CONFIG_HOME="${HOST_XDG_CONFIG_HOME}" "${ROOT_DIR}/scripts/check-release-tag-signature.sh" \
   --repo-root "${FIXTURE}" \
-  --tag v9.9.9 --expected-commit "${commit_sha^^}" 2>&1)"
+  --tag v9.9.9 --expected-commit "$(printf '%s' "${commit_sha}" | tr '[:lower:]' '[:upper:]')" 2>&1)"
 malformed_rc=$?
 set -e
 test "${malformed_rc}" -eq 2


### PR DESCRIPTION
## Summary

Adds a banlist for the GNU-only and Bash-4-only constructs that fail on the
host baseline. `scripts/check-doc-links.sh:5` already declares the contract
("Kept bash-3.2 compatible ... because the host baseline is macOS /bin/bash
3.2"), and nothing enforced it. Codex review history shows 29 accepted
findings of this class before pull request 600.

## Every rule was measured, not assumed

Measured on macOS 26.6.2 with the system path `/usr/bin:/bin` and the system
`/bin/bash` 3.2.57:

| Construct | Result | On the list |
|---|---|---|
| `mapfile`, `readarray`, `wait -n`, `declare -A`, `${x^^}` | fails on bash 3.2 | yes |
| `stat -c` | fails | yes |
| `date -d` | fails | yes |
| `grep -P` | fails | yes |
| `find -printf` | fails | yes |
| `sed -i` without a suffix | fails | yes |
| `sha256sum` | fails on `/usr/bin:/bin` | yes |
| `readlink -f` | **works** | no |
| `mktemp` and `mktemp -d` without a template | **works** | no |

Measurement removed two candidates the report proposed. A `mktemp` rule alone
would have produced 32 findings that are not defects on this baseline.

Honest caveat on `sha256sum`: macOS 26 ships `/sbin/sha256sum`, and the
repository's trusted path includes `/sbin`, so the command resolves there
today. The rule stays because four accepted review findings name it and
because `scripts/verify-release-artifact.sh:102` already carries a `shasum`
fallback for a host that lacks it.

## Three discriminators

1. **The runtime tree is out of scope.** `runtime/**` only runs inside the
   Debian image. Its scripts are also digest-bound by
   `runtime/container/control-plane-manifest.json`, so a comment added to one
   of them is a manifest change.
2. **A heredoc body is skipped.** It is text the script hands to another
   interpreter, which is bash 5 inside the image for every such body in the
   tree. This is the reviewer's own class-D lesson: read the commands the
   script runs, not the text it carries. It clears 8 `stat -c` lines in
   `scripts/container-smoke.sh` that run inside a container.
3. **A modern-bash assertion clears the bash-version rules.** A script that
   calls `workcell_require_modern_privileged_bash` re-executes itself under
   bash 4, which is why `scripts/validate-repo.sh` may use `declare -A`. Five
   scripts do this. The userland rules still apply to them.

## Repairs, not exemptions

Two host-side scripts are repaired:

- `tests/scenarios/shared/test-aws-ec2-ssm-launch-smoke.sh:72`: `mapfile`
  becomes a `while read` loop.
- `tests/scenarios/shared/test-publish-github-release.sh:107`:
  `"${commit_sha^^}"` becomes `tr '[:lower:]' '[:upper:]'`.

`scripts/ci/run-docs-in-validator.sh:68` was flagged for review rather than
exemption. Review result: the `mapfile` sits inside the `bash -lc` command
string that `docker run` hands to the validator image, so it runs on bash 5
inside the image. It carries an inline exemption naming that.

The `runtime/container/apt-broker.sh` item from the report is gone: pull
request 699 deleted that file.

Sixteen other reviewed lines carry an inline exemption with its reason:
the BSD form is tried first (3), the shasum fallback follows (1),
`require_tool sha256sum` fails closed (3), the Linux CI or release lane (8),
and the validator image command string (1).

## Not done, with the reason

The report also asked for a `BASH_VERSINFO[0] -ge 3` assertion in the shared
library. Skipped: every bash is 3 or newer, so the assertion can never fire.
The repository already carries the assertion that matters,
`workcell_require_modern_privileged_bash`, and this check now reads it.

## Follow-up found while measuring

`scripts/generate-control-plane-manifest.sh` declares
`# generated-artifact: none` after pull request 707, but it also writes the
tracked `runtime/container/control-plane-manifest.json`. Its declaration
should name that file so the freshness gate covers it. Not changed here to
keep this change to one subject.

## Evidence

- `WORKCELL_VALIDATE_REPO_PROFILE=repo-core ./scripts/validate-repo.sh` passes.
- `./scripts/check-shell-portability.sh` passes.
- `./scripts/check-generated-artifacts.sh` passes.
- `./scripts/check-doc-language.sh` passes.
- `./scripts/check-validator-anchoring.sh` passes.
- `./scripts/verify-control-plane-manifest.sh` passes.
- `bash -n` passes on every edited script.
- `./scripts/check-pr-shape.sh`: files=23 lines=429 areas=5.

Review loop deferred.