### PR TITLE
Add the shared hostile-field corpus (S15)

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -16,6 +16,7 @@ harness invariant.
 | `internal/tomlsubset` | `FuzzParse` | Policy TOML subset |
 | `internal/injection` | `FuzzIsAllowedSystemSymlink` | Direct-mount source chains |
 | `internal/injection` | `FuzzParseSSHDirective` | SSH configuration directives |
+| `internal/applecontainer` | `FuzzAuditPathValueRoundTrip` | Untrusted audit field values |
 
 The seed corpus includes repository configuration and invalid forms. The
 `go test ./...` pull-request lane replays each saved seed.

--- a/internal/applecontainer/hostilefields_test.go
+++ b/internal/applecontainer/hostilefields_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package applecontainer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/testkit"
+)
+
+// auditFieldSeparators lists the bytes that end one field of an audit line.
+// An equals sign is not one of them: the reader splits a field at its first
+// equals sign, so a later one stays inside the value.
+const auditFieldSeparators = " \t\n\r\x00"
+
+func encodeAuditPathField(value string) (string, error) {
+	return encodeAuditPathValue(value), nil
+}
+
+func decodeAuditPathField(value string) (string, error) {
+	return decodeAuditPathValue(value), nil
+}
+
+// The audit path encoder claims that it recovers the exact original byte
+// string for any input. The shared corpus is the assertion of that claim.
+func TestAuditPathValueRoundTripsHostileFields(t *testing.T) {
+	t.Parallel()
+	testkit.RequireRoundTripOrReject(t, encodeAuditPathField, decodeAuditPathField, testkit.HostileFields())
+}
+
+// A round trip alone does not prove the encoded form is safe to interpolate:
+// an encoder that returns its input unchanged round-trips perfectly and still
+// lets a newline forge an audit record.
+func TestAuditPathValueEncodingIsInert(t *testing.T) {
+	t.Parallel()
+	testkit.RequireEncodedFieldIsInert(t, encodeAuditPathField, auditFieldSeparators, testkit.HostileFields())
+}
+
+// FuzzAuditPathValueRoundTrip carries the two audit-field invariants past the
+// corpus: the encoded form holds no field separator, and the decoder recovers
+// the exact input bytes. The corpus seeds it, so every reviewed defect is the
+// starting point of the mutation rather than the whole of the coverage.
+func FuzzAuditPathValueRoundTrip(f *testing.F) {
+	for _, row := range testkit.HostileFields() {
+		f.Add(row.Value)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		encoded := encodeAuditPathValue(value)
+		if index := strings.IndexAny(encoded, auditFieldSeparators); index >= 0 {
+			t.Fatalf("encoded form of %q keeps the separator %q at offset %d", value, string(encoded[index]), index)
+		}
+		if decoded := decodeAuditPathValue(encoded); decoded != value {
+			t.Fatalf("round trip changed the value: encoded %q, decoded %q, want %q", encoded, decoded, value)
+		}
+	})
+}

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -199,6 +199,13 @@ var goHelperMutations = []mutationCase{
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestScanDocLanguageFlagsReviewedProse", "-count=1"),
 	},
 	{
+		relativePath: "internal/applecontainer/audit.go",
+		original:     `		if c == '%' || c <= 0x20 || c >= 0x7f {`,
+		replacement:  `		if c == '%' || c <= 0x1f || c >= 0x7f {`,
+		label:        "audit field separator encoding",
+		command:      goCmd("test", "./internal/applecontainer", "-run", "TestAuditPathValueEncodingIsInert", "-count=1"),
+	},
+	{
 		relativePath: "internal/metadatautil/portability_check.go",
 		original:     `			if rule.bashVersion && modernBash {`,
 		replacement:  `			if false && rule.bashVersion && modernBash {`,

--- a/internal/shellproto/hostilefields_test.go
+++ b/internal/shellproto/hostilefields_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package shellproto_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omkhar/workcell/internal/shellproto"
+	"github.com/omkhar/workcell/internal/testkit"
+)
+
+// The KEY=VALUE protocol answers the same corpus with rejection rather than
+// with encoding: a value that carries a record separator is refused at the
+// output boundary. Every other row must survive the bash reader's own
+// "key=${line%%=*}; value=${line#*=}" split byte for byte.
+func TestWriteFieldRoundTripsOrRejectsHostileFields(t *testing.T) {
+	t.Parallel()
+	encode := func(value string) (string, error) {
+		var line strings.Builder
+		if err := shellproto.WriteField(&line, "field", value); err != nil {
+			return "", err
+		}
+		return line.String(), nil
+	}
+	decode := func(line string) (string, error) {
+		trimmed, found := strings.CutSuffix(line, "\n")
+		if !found {
+			return "", errors.New("the record has no line terminator")
+		}
+		if strings.Contains(trimmed, "\n") {
+			return "", errors.New("the record spans more than one line")
+		}
+		_, value, found := strings.Cut(trimmed, "=")
+		if !found {
+			return "", errors.New("the record has no key separator")
+		}
+		return value, nil
+	}
+	testkit.RequireRoundTripOrReject(t, encode, decode, testkit.HostileFields())
+}

--- a/internal/testkit/hostilefields.go
+++ b/internal/testkit/hostilefields.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"strings"
+	"testing"
+)
+
+// HostileField is one untrusted value that a structured record has to carry
+// without losing it and without letting it forge a second record.
+//
+// Why names the reviewed defect the row reproduces, so a row cannot be
+// dropped without stating which finding stops being covered.
+type HostileField struct {
+	Name  string
+	Value string
+	Why   string
+}
+
+// HostileFields returns the shared corpus of untrusted field values.
+//
+// Every row is a defect the reviewer found in a Workcell encoder or decoder
+// before pull request 600: a newline that forges a record, a separator inside
+// a value, a quoted or escaped value, an octal or ANSI-C escape, a non-UTF-8
+// path byte, a value that is the prefix of a sentinel, and an unmapped key.
+// The corpus is exported so that every package with a structured record
+// format reads the same table instead of inventing its own decoy string.
+func HostileFields() []HostileField {
+	return []HostileField{
+		{"embedded newline", "a\nb", "a newline forges a second record on a line-delimited format"},
+		{"embedded carriage return", "a\rb", "a carriage return spoofs an overwritten line in a captured terminal"},
+		{"embedded NUL", "a\x00b", "a NUL truncates the bash read loop that consumes the record"},
+		{"trailing newline", "a\n", "a trailing newline appends an empty record"},
+		{"separator inside the value", "path=/tmp/x", "an equals sign inside a value splits one field into two"},
+		{"event sentinel inside the value", "/tmp/x/event=session_started", "a value that spells a sentinel satisfies an event assertion (audit_test.go)"},
+		{"sentinel prefix", "complete_partial", "a value that is the prefix of a sentinel satisfies an exact-match rule"},
+		{"space inside the value", "/tmp/a b/c", "a space injects a stray token into a whitespace-delimited record"},
+		{"tab inside the value", "/tmp/a\tb", "a tab is field-separating whitespace for the reader"},
+		{"comma inside the value", "/tmp/a,b", "a comma splits a mount record"},
+		{"double-quoted value", `"quoted"`, "a quoted value is unquoted once too often by a naive reader"},
+		{"single-quoted value", `'quoted'`, "the single-quoted form of the same defect"},
+		{"escaped double quote", `a\"b`, "a backslash-escaped quote ends the value early"},
+		{"literal backslash", `C:\path\to`, "a literal backslash in a legal path is misread as an escape"},
+		{"octal escape", `a\0101b`, "an octal escape is expanded by a reader that unescapes"},
+		{"ANSI-C escape", `a$'\cX'b`, "an ANSI-C quoted escape is expanded by the shell reader"},
+		{"percent sign", "100%done", "a percent sign is the encoder's own escape byte"},
+		{"percent escape sequence", "%41%42", "an already-encoded value must not decode twice"},
+		{"non-UTF-8 byte", "/tmp/\xff\xfe", "a non-UTF-8 path byte collapses to U+FFFD in a rune loop"},
+		{"high byte and DEL", "/tmp/\x7f\x80", "DEL and the high bytes are not printable ASCII"},
+		{"leading dash", "--flag", "a value that spells an option is read as one"},
+		{"empty value", "", "an empty value must survive as an empty value, not as an absent field"},
+		{"only whitespace", "   ", "a whitespace-only value collapses when the reader trims"},
+		{"unmapped key name", "workspace_repo_mcp", "an unmapped key must be hard-redacted, not passed through"},
+		{"long value", strings.Repeat("a", 4096), "a long value must not truncate silently"},
+	}
+}
+
+// RequireRoundTripOrReject requires every corpus row to survive an encode and
+// decode pair byte for byte, or to be rejected by the encoder.
+//
+// Silent mangling is the defect this driver exists for: an encoder that drops
+// a byte, expands an escape, or truncates at a separator returns a value that
+// reads as clean while the evidence it carried is gone. Rejection is an
+// acceptable answer, and so is an exact round trip. Nothing else is.
+func RequireRoundTripOrReject(t *testing.T, encode func(string) (string, error), decode func(string) (string, error), corpus []HostileField) {
+	t.Helper()
+
+	if len(corpus) == 0 {
+		t.Fatal("hostile-field corpus is empty; refusing a vacuous pass")
+	}
+	for _, row := range corpus {
+		t.Run(row.Name, func(t *testing.T) {
+			encoded, err := encode(row.Value)
+			if err != nil {
+				return // rejection is a correct answer
+			}
+			decoded, err := decode(encoded)
+			if err != nil {
+				t.Fatalf("the encoder accepted %q but the decoder rejected %q: %v (%s)", row.Value, encoded, err, row.Why)
+			}
+			if decoded != row.Value {
+				t.Fatalf("round trip changed the value: encoded %q, decoded %q, want %q (%s)",
+					encoded, decoded, row.Value, row.Why)
+			}
+		})
+	}
+}
+
+// RequireEncodedFieldIsInert requires the encoded form of every corpus row to
+// carry none of the bytes that separate one record or one field from the next.
+//
+// A round trip alone does not prove this: an encoder that emits the value
+// unchanged round-trips perfectly and still lets a newline forge a record.
+func RequireEncodedFieldIsInert(t *testing.T, encode func(string) (string, error), separators string, corpus []HostileField) {
+	t.Helper()
+
+	if separators == "" {
+		t.Fatal("no separator was named; refusing a vacuous pass")
+	}
+	for _, row := range corpus {
+		t.Run(row.Name, func(t *testing.T) {
+			encoded, err := encode(row.Value)
+			if err != nil {
+				return // rejection is a correct answer
+			}
+			if index := strings.IndexAny(encoded, separators); index >= 0 {
+				t.Fatalf("the encoded form of %q keeps the separator %q at offset %d (%s)",
+					row.Value, string(encoded[index]), index, row.Why)
+			}
+		})
+	}
+}

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 28
+  "expected_mutants": 29
 }

--- a/scripts/ci/run-fuzz-in-validator.sh
+++ b/scripts/ci/run-fuzz-in-validator.sh
@@ -79,6 +79,7 @@ workcell_ci_docker run --rm \
       "./internal/tomlsubset/ FuzzParse"
       "./internal/injection/ FuzzIsAllowedSystemSymlink"
       "./internal/injection/ FuzzParseSSHDirective"
+      "./internal/applecontainer/ FuzzAuditPathValueRoundTrip"
     )
     for entry in "${targets[@]}"; do
       pkg="${entry%% *}"


### PR DESCRIPTION
## Summary

Adds `internal/testkit/hostilefields.go`: one exported table of untrusted
field values, plus two drivers over it, plus a fuzz target over the audit
path encoder.

Codex review history shows 38 accepted findings of untrusted-field encoding
into structured records across 20 pull requests, all accepted, none rebutted.
Coverage before this change was one decoy string per package, for example
`internal/applecontainer/audit_test.go:90`.

## The corpus

25 rows, each recording the defect it reproduces: an embedded newline,
carriage return or NUL; a separator inside a value; an event sentinel spelled
inside a path; a value that is the prefix of a sentinel; a space, tab or comma;
a double-quoted, single-quoted or backslash-escaped value; a literal
backslash; an octal escape; an ANSI-C escape; a bare and an already-encoded
percent sign; a non-UTF-8 byte; DEL and a high byte; a value that spells an
option; an empty and a whitespace-only value; an unmapped key name; and a long
value.

## The drivers

- `RequireRoundTripOrReject(t, encode, decode, corpus)`. Each row must survive
  the pair byte for byte, or be rejected by the encoder. Silent mangling
  fails, because a value that reads as clean while its evidence is gone is the
  defect.
- `RequireEncodedFieldIsInert(t, encode, separators, corpus)`. The encoded
  form must hold no field separator. A round trip alone does not prove this:
  an encoder that returns its input unchanged round-trips perfectly and still
  lets a newline forge a record.

## Two answers, one table

| Package | Subject | Answer |
|---|---|---|
| `internal/applecontainer` | `encodeAuditPathValue` and `decodeAuditPathValue` | encodes every row and recovers it exactly |
| `internal/shellproto` | `WriteField` and the bash reader's own split | rejects the record separators, round-trips the rest |

Both answers are correct under the contract, which is why the driver accepts
either.

## Fuzz target

`FuzzAuditPathValueRoundTrip` carries both audit-field invariants past the
corpus and seeds itself from it. Registered in
`scripts/ci/run-fuzz-in-validator.sh` and in `docs/fuzzing.md`.

A 25-second local run reached 3.4 million executions with no failure, from 25
seeds to 53 interesting inputs.

## Mutation row

`internal/mutation/runner.go` gains one row that narrows the encoder from
`c <= 0x20` to `c <= 0x1f`, which stops encoding a space and leaves a field
separator in the encoded value. `TestAuditPathValueEncodingIsInert` kills it.
`policy/mutation-score-policy.json` rises from 28 to 29 mutants.

## Evidence

- `WORKCELL_VALIDATE_REPO_PROFILE=repo-core ./scripts/validate-repo.sh` passes,
  including the mutation lane at 29 of 29 killed.
- `go test ./internal/applecontainer -fuzz FuzzAuditPathValueRoundTrip
  -fuzztime=25s` passes.
- `./scripts/check-doc-language.sh`, `./scripts/check-shell-portability.sh`,
  `./scripts/check-generated-artifacts.sh`,
  `./scripts/check-validator-anchoring.sh` and
  `./scripts/check-doc-links.sh` pass.
- `./scripts/check-pr-shape.sh`: files=7 lines=226 areas=4.

Review loop deferred.