### PR TITLE
Add the hardened filesystem helpers (S11, part 2)

### DIFF
--- a/internal/applecontainer/conformance.go
+++ b/internal/applecontainer/conformance.go
@@ -18,29 +18,21 @@ import (
 
 	"github.com/omkhar/workcell/internal/host/sessions"
 	"github.com/omkhar/workcell/internal/providerid"
+	"github.com/omkhar/workcell/internal/rootio"
 )
 
-// requireNoSymlink verifies path (under stateRoot) is reached without traversing any symlink and
-// is the expected kind (regular file, or directory when wantDir), via the production no-follow
-// stat (statPathSafe: parents O_NOFOLLOW, leaf Fstatat AT_SYMLINK_NOFOLLOW). A regular leaf also
-// requires Nlink==1 (mirroring readFileSafe), so a symlink OR a hardlink to a decoy outside
-// StateRoot is rejected before any content is read.
-func requireNoSymlink(stateRoot, path, label string, wantDir bool) error {
+// requireSingleLinkedRegular verifies path (under stateRoot) is reached without traversing any
+// symlink and is a single-linked regular file, via the production no-follow stat (statPathSafe:
+// parents O_NOFOLLOW, leaf Fstatat AT_SYMLINK_NOFOLLOW). The type and link-count rule itself is
+// rootio.RequireSingleLinkedRegular, which the hardened readers apply to every leaf they open, so
+// a symlink, a FIFO or a hardlink to a decoy outside StateRoot is rejected by one rule rather than
+// by a copy of it.
+func requireSingleLinkedRegular(stateRoot, path, label string) error {
 	st, err := statPathSafe(stateRoot, path)
 	if err != nil {
 		return fmt.Errorf("%s %q: %w", label, path, err)
 	}
-	want := unix.S_IFREG
-	if wantDir {
-		want = unix.S_IFDIR
-	}
-	if int(st.Mode)&unix.S_IFMT != want {
-		return fmt.Errorf("%s %q is not the expected file type (mode %#o) — a symlink/decoy is rejected", label, path, st.Mode&unix.S_IFMT)
-	}
-	if !wantDir && st.Nlink != 1 {
-		return fmt.Errorf("%s %q is multiply linked (%d links) — a hardlink to a decoy is rejected", label, path, st.Nlink)
-	}
-	return nil
+	return rootio.RequireSingleLinkedRegular(&st, label, path)
 }
 
 // canonicalLayout is the set of on-disk paths derived purely from the state root + contract + case
@@ -229,7 +221,7 @@ func RunConformance(ctx context.Context, target ConformanceTarget, contract Cont
 	}
 	// The export reads the audit log by FOLLOWING record.AuditLogPath (== layout.auditLog); reject a
 	// symlink/hardlink there first, else a decoy log outside StateRoot could be exported.
-	if err := requireNoSymlink(c.StateRoot, layout.auditLog, "audit log", false); err != nil {
+	if err := requireSingleLinkedRegular(c.StateRoot, layout.auditLog, "audit log"); err != nil {
 		return ConformanceResult{}, err
 	}
 	exported, err := sessions.ExportSessionRecordInRoots([]string{c.StateRoot}, c.SessionID)

--- a/internal/applecontainer/conformance.go
+++ b/internal/applecontainer/conformance.go
@@ -24,9 +24,11 @@ import (
 // requireSingleLinkedRegular verifies path (under stateRoot) is reached without traversing any
 // symlink and is a single-linked regular file, via the production no-follow stat (statPathSafe:
 // parents O_NOFOLLOW, leaf Fstatat AT_SYMLINK_NOFOLLOW). The type and link-count rule itself is
-// rootio.RequireSingleLinkedRegular, which the hardened readers apply to every leaf they open, so
-// a symlink, a FIFO or a hardlink to a decoy outside StateRoot is rejected by one rule rather than
-// by a copy of it.
+// rootio.RequireSingleLinkedRegular, so a symlink, a FIFO or a hardlink to a decoy outside
+// StateRoot is rejected by one rule rather than by a copy of it. The rule is not applied by the
+// hardened readers: ReadFileAtNoFollow checks the file type only, because a hard-linked bundle
+// manifest is read on purpose elsewhere and protected by the atomic replace instead. A caller that
+// needs the link-count guarantee calls this rule itself.
 func requireSingleLinkedRegular(stateRoot, path, label string) error {
 	st, err := statPathSafe(stateRoot, path)
 	if err != nil {

--- a/internal/mutation/runner.go
+++ b/internal/mutation/runner.go
@@ -199,6 +199,27 @@ var goHelperMutations = []mutationCase{
 		command:      goCmd("test", "./internal/metadatautil", "-run", "TestScanDocLanguageFlagsReviewedProse", "-count=1"),
 	},
 	{
+		relativePath: "internal/rootio/hardened.go",
+		original:     `	if info.Nlink != 1 {`,
+		replacement:  `	if false && info.Nlink != 1 {`,
+		label:        "hardened leaf single-link requirement",
+		command:      goCmd("test", "./internal/rootio", "-run", "TestRequireSingleLinkedRegular", "-count=1"),
+	},
+	{
+		relativePath: "internal/rootio/hardened.go",
+		original:     `		next, err := unix.Openat(current, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)`,
+		replacement:  `		next, err := unix.Openat(current, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)`,
+		label:        "synced directory creation refuses a symlinked component",
+		command:      goCmd("test", "./internal/rootio", "-run", "TestMkdirAllSyncedAtRejectsASymlinkedComponent", "-count=1"),
+	},
+	{
+		relativePath: "internal/rootio/hardened.go",
+		original:     `	if !createOnce {`,
+		replacement:  `	if true || !createOnce {`,
+		label:        "staged publication create-once semantics",
+		command:      goCmd("test", "./internal/rootio", "-run", "TestStageAndCreateAtRefusesAnExistingName", "-count=1"),
+	},
+	{
 		relativePath: "internal/metadatautil/hardenedfs_check.go",
 		original:     `	return found && strings.TrimSpace(reason) != ""`,
 		replacement:  `	return found || strings.TrimSpace(reason) != ""`,

--- a/internal/rootio/hardened.go
+++ b/internal/rootio/hardened.go
@@ -15,6 +15,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// errStagedSiblingLeft marks a publication that succeeded while the staged
+// sibling could not be removed. The caller must not unlink again: the name is
+// already published, and the removal is the step that just failed.
+var errStagedSiblingLeft = errors.New("the staged sibling was left in place")
+
 // RequireSingleLinkedRegular rejects a leaf that is not a single-linked regular
 // file.
 //
@@ -57,7 +62,10 @@ func MkdirAllSyncedAt(parent *os.File, relative string, mode os.FileMode) error 
 	if err != nil {
 		return err
 	}
-	current, err := unix.Dup(int(parent.Fd()))
+	// F_DUPFD_CLOEXEC rather than dup: dup clears FD_CLOEXEC, so a child
+	// started while this descriptor is open would inherit a handle on a
+	// trusted directory.
+	current, err := unix.FcntlInt(parent.Fd(), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
 		return err
 	}
@@ -93,10 +101,9 @@ func StageAndPublishAt(parent *os.File, name string, data []byte, mode os.FileMo
 // StageAndCreateAt writes data to name under parent and fails when name
 // already exists.
 //
-// Publication uses linkat rather than renameat, because renameat replaces a
-// name that appeared after any earlier absence check and linkat refuses it.
-// Two callers that both find the name absent therefore cannot both report
-// success.
+// The kernel refuses the existing name in the same step that publishes, so two
+// callers that both find the name absent cannot both report success. A plain
+// renameat would replace a name that appeared after the absence check.
 func StageAndCreateAt(parent *os.File, name string, data []byte, mode os.FileMode, tempPrefix string) error {
 	return stageAndPublish(parent, name, data, mode, tempPrefix, true)
 }
@@ -139,7 +146,13 @@ func stageAndPublish(parent *os.File, name string, data []byte, mode os.FileMode
 			return err
 		}
 		if err := publishStagedFile(parentFD, temporary, name, createOnce); err != nil {
-			_ = unix.Unlinkat(parentFD, temporary, 0)
+			// The staged sibling is removed only when nothing was published;
+			// linkStagedFile reports its own removal failure after the name
+			// exists, and unlinking again there would be a second attempt at
+			// the step that just failed.
+			if !errors.Is(err, errStagedSiblingLeft) {
+				_ = unix.Unlinkat(parentFD, temporary, 0)
+			}
 			return err
 		}
 		// The published entry is only durable once the directory that gained
@@ -187,24 +200,50 @@ func writeStagedFile(parentFD, fd int, temporary, path string, data []byte, mode
 
 // publishStagedFile moves the staged name onto its final name.
 //
-// ponytail: the create-once path links and then unlinks, so the staged file is
-// a second link to the same inode for that window, and a concurrent reader
-// that runs RequireSingleLinkedRegular during it sees two links and refuses a
-// file that is in fact intact. Linux renameat2 with RENAME_NOREPLACE would
-// publish create-once in one step; macOS has no equivalent, and macOS is the
-// host baseline, so the window stays. Replace this with renameat2 if the
-// baseline ever becomes Linux-only, or have the reader retry once.
+// The create-once form asks the kernel to refuse an existing name in the same
+// step that publishes, so no window exists in which both names are links to
+// one inode. Darwin spells that renameatx_np with RENAME_EXCL and Linux spells
+// it renameat2 with RENAME_NOREPLACE.
 func publishStagedFile(parentFD int, temporary, name string, createOnce bool) error {
 	if !createOnce {
 		return unix.Renameat(parentFD, temporary, parentFD, name)
 	}
+	switch err := renameNoReplaceAt(parentFD, temporary, name); {
+	case err == nil:
+		return nil
+	case errors.Is(err, unix.EEXIST):
+		return fmt.Errorf("%s already exists", name)
+	case errors.Is(err, unix.ENOTSUP), errors.Is(err, unix.ENOSYS), errors.Is(err, unix.EINVAL):
+		return linkStagedFile(parentFD, temporary, name)
+	default:
+		return err
+	}
+}
+
+// linkStagedFile is the create-once publication for a filesystem whose kernel
+// refuses the one-step form. link refuses an existing name, so create-once
+// still holds.
+//
+// ponytail: link leaves the staged name as a second link to the inode until
+// the unlink returns, and a concurrent RequireSingleLinkedRegular during that
+// window refuses a file that is in fact intact. The one-step form above has no
+// such window, so this path runs only where the kernel or the filesystem
+// rejects it, such as an older Darwin volume. Delete this fallback when the
+// supported filesystems all carry the one-step form.
+func linkStagedFile(parentFD int, temporary, name string) error {
 	if err := unix.Linkat(parentFD, temporary, parentFD, name, 0); err != nil {
 		if errors.Is(err, unix.EEXIST) {
 			return fmt.Errorf("%s already exists", name)
 		}
 		return err
 	}
-	return unix.Unlinkat(parentFD, temporary, 0)
+	// The published name exists from here on, so a failure to remove the
+	// staged sibling is reported without unpublishing it, and the caller still
+	// syncs the parent.
+	if err := unix.Unlinkat(parentFD, temporary, 0); err != nil {
+		return fmt.Errorf("%w: remove the staged sibling of %s: %w", errStagedSiblingLeft, name, err)
+	}
+	return nil
 }
 
 // relativeComponents splits a relative path into the names to create, and

--- a/internal/rootio/hardened.go
+++ b/internal/rootio/hardened.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package rootio
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// RequireSingleLinkedRegular rejects a leaf that is not a single-linked regular
+// file.
+//
+// A symlink, a FIFO, a socket and a device node all pass a bare existence
+// check, and a hard link to a file outside the trusted root passes a file-type
+// check as well: the link count is the only thing that separates the intended
+// inode from an attacker's copy of it. The caller supplies a stat taken
+// without following symlinks, which is the only stat this rule is sound over.
+func RequireSingleLinkedRegular(info *unix.Stat_t, label, name string) error {
+	if info == nil {
+		return fmt.Errorf("%s %q has no stat to check", label, name)
+	}
+	if info.Mode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("%s %q is not a regular file (mode %#o); a symlink, FIFO, socket or device is rejected",
+			label, name, info.Mode&unix.S_IFMT)
+	}
+	if info.Nlink != 1 {
+		return fmt.Errorf("%s %q is multiply linked (%d links); a hard link to a file outside the trusted root is rejected",
+			label, name, info.Nlink)
+	}
+	return nil
+}
+
+// MkdirAllSyncedAt creates relative under parent and makes every new directory
+// entry durable.
+//
+// It differs from os.MkdirAll in two ways the review corpus demands. Each
+// component is opened relative to the previous descriptor with O_NOFOLLOW, so
+// a symlink swapped into the middle of the path is refused rather than
+// followed. And the directory that gains each entry is fsynced, not only the
+// parent of the last one, so a crash cannot lose an ancestor that the call
+// reported as created.
+//
+// The fsync runs whether this call created the component or found it present.
+// A racing creator can return from its own mkdir before its fsync completes,
+// or fail that fsync, so the loser of the race cannot treat an existing
+// directory as already durable.
+func MkdirAllSyncedAt(parent *os.File, relative string, mode os.FileMode) error {
+	components, err := relativeComponents(relative)
+	if err != nil {
+		return err
+	}
+	current, err := unix.Dup(int(parent.Fd()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(current) }()
+
+	for _, component := range components {
+		if err := unix.Mkdirat(current, component, uint32(mode.Perm())); err != nil && !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("create %s under %s: %w", component, parent.Name(), err)
+		}
+		next, err := unix.Openat(current, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return fmt.Errorf("open %s under %s: %w", component, parent.Name(), err)
+		}
+		if err := unix.Fsync(current); err != nil {
+			_ = unix.Close(next)
+			return fmt.Errorf("sync the directory that gained %s: %w", component, err)
+		}
+		_ = unix.Close(current)
+		current = next
+	}
+	return nil
+}
+
+// StageAndPublishAt writes data to name under parent, replacing any file
+// already there.
+//
+// StageAndCreateAt publishes the same way but refuses to replace an existing
+// name.
+func StageAndPublishAt(parent *os.File, name string, data []byte, mode os.FileMode, tempPrefix string) error {
+	return stageAndPublish(parent, name, data, mode, tempPrefix, false)
+}
+
+// StageAndCreateAt writes data to name under parent and fails when name
+// already exists.
+//
+// Publication uses linkat rather than renameat, because renameat replaces a
+// name that appeared after any earlier absence check and linkat refuses it.
+// Two callers that both find the name absent therefore cannot both report
+// success.
+func StageAndCreateAt(parent *os.File, name string, data []byte, mode os.FileMode, tempPrefix string) error {
+	return stageAndPublish(parent, name, data, mode, tempPrefix, true)
+}
+
+// stageAndPublish writes a uniquely named sibling with O_EXCL, sets its mode,
+// syncs its contents, publishes it under name, and syncs the parent directory.
+//
+// Every step answers a defect the reviewer found. The temporary name is random
+// so a crash-left file or one an attacker pre-created cannot block the write,
+// and an O_EXCL collision retries with a fresh name. The mode is set through
+// the descriptor so a restrictive umask cannot publish an unreadable file. The
+// contents are synced before publication and the parent is synced after it, so
+// a crash cannot leave a name that points at unwritten bytes.
+func stageAndPublish(parent *os.File, name string, data []byte, mode os.FileMode, tempPrefix string, createOnce bool) error {
+	if err := validateLeafName(name); err != nil {
+		return err
+	}
+	if tempPrefix == "" {
+		tempPrefix = ".workcell-tmp-"
+	}
+	if strings.Contains(tempPrefix, string(filepath.Separator)) {
+		return fmt.Errorf("temporary-file prefix must not contain a path separator: %s", tempPrefix)
+	}
+	parentFD := int(parent.Fd())
+	for attempt := 0; attempt < 32; attempt++ {
+		suffix, err := randomSuffix()
+		if err != nil {
+			return err
+		}
+		temporary := tempPrefix + suffix + ".tmp"
+		fd, err := unix.Openat(parentFD, temporary,
+			unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode.Perm()))
+		if errors.Is(err, unix.EEXIST) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if err := writeStagedFile(parentFD, fd, temporary, filepath.Join(parent.Name(), temporary), data, mode); err != nil {
+			return err
+		}
+		if err := publishStagedFile(parentFD, temporary, name, createOnce); err != nil {
+			_ = unix.Unlinkat(parentFD, temporary, 0)
+			return err
+		}
+		// The published entry is only durable once the directory that gained
+		// it is synced. A crash before this returns can otherwise lose the
+		// name while the caller has already been told the write succeeded.
+		if err := unix.Fsync(parentFD); err != nil {
+			return fmt.Errorf("sync the directory that gained %s: %w", name, err)
+		}
+		return nil
+	}
+	return fmt.Errorf("unable to allocate temporary file under %s", parent.Name())
+}
+
+// writeStagedFile fills, chmods, syncs and closes the staged descriptor,
+// unlinking it on any failure so a partial file is never left behind.
+func writeStagedFile(parentFD, fd int, temporary, path string, data []byte, mode os.FileMode) error {
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		_ = unix.Unlinkat(parentFD, temporary, 0)
+		return fmt.Errorf("create temporary file %s", temporary)
+	}
+	fail := func(err error) error {
+		_ = file.Close()
+		_ = unix.Unlinkat(parentFD, temporary, 0)
+		return err
+	}
+	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+		return fail(err)
+	}
+	// O_CREAT applies the umask, so a restrictive one would publish a file the
+	// owner cannot read. Set the mode through the descriptor instead.
+	if err := unix.Fchmod(fd, uint32(mode.Perm())); err != nil {
+		return fail(err)
+	}
+	if err := file.Sync(); err != nil {
+		return fail(err)
+	}
+	if err := file.Close(); err != nil {
+		_ = unix.Unlinkat(parentFD, temporary, 0)
+		return err
+	}
+	return nil
+}
+
+// publishStagedFile moves the staged name onto its final name.
+//
+// ponytail: the create-once path links and then unlinks, so the staged file is
+// a second link to the same inode for that window, and a concurrent reader
+// that runs RequireSingleLinkedRegular during it sees two links and refuses a
+// file that is in fact intact. Linux renameat2 with RENAME_NOREPLACE would
+// publish create-once in one step; macOS has no equivalent, and macOS is the
+// host baseline, so the window stays. Replace this with renameat2 if the
+// baseline ever becomes Linux-only, or have the reader retry once.
+func publishStagedFile(parentFD int, temporary, name string, createOnce bool) error {
+	if !createOnce {
+		return unix.Renameat(parentFD, temporary, parentFD, name)
+	}
+	if err := unix.Linkat(parentFD, temporary, parentFD, name, 0); err != nil {
+		if errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("%s already exists", name)
+		}
+		return err
+	}
+	return unix.Unlinkat(parentFD, temporary, 0)
+}
+
+// relativeComponents splits a relative path into the names to create, and
+// refuses any spelling that would leave the opened parent.
+func relativeComponents(relative string) ([]string, error) {
+	if relative == "" || filepath.IsAbs(relative) {
+		return nil, fmt.Errorf("path must be relative to the opened parent: %q", relative)
+	}
+	var components []string
+	for _, component := range strings.Split(filepath.Clean(relative), string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		if component == ".." {
+			return nil, fmt.Errorf("path must stay within the opened parent: %q", relative)
+		}
+		components = append(components, component)
+	}
+	if len(components) == 0 {
+		return nil, fmt.Errorf("path names no directory to create: %q", relative)
+	}
+	return components, nil
+}

--- a/internal/rootio/hardened_test.go
+++ b/internal/rootio/hardened_test.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package rootio_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/omkhar/workcell/internal/rootio"
+)
+
+// Each row is a leaf shape the reviewer found accepted by a check that read
+// only the file type, or only the name.
+func TestRequireSingleLinkedRegular(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	regular := filepath.Join(root, "regular")
+	if err := os.WriteFile(regular, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write the regular file: %v", err)
+	}
+	// A hard link raises the link count of both names, so the clean case needs
+	// a file that nothing links to.
+	shared := filepath.Join(root, "shared")
+	if err := os.WriteFile(shared, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write the shared file: %v", err)
+	}
+	linked := filepath.Join(root, "linked")
+	if err := os.Link(shared, linked); err != nil {
+		t.Fatalf("create the hard link: %v", err)
+	}
+	symlink := filepath.Join(root, "symlink")
+	if err := os.Symlink(regular, symlink); err != nil {
+		t.Fatalf("create the symlink: %v", err)
+	}
+	fifo := filepath.Join(root, "fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("create the FIFO: %v", err)
+	}
+	directory := filepath.Join(root, "directory")
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatalf("create the directory: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{name: "a single-linked regular file", path: regular},
+		{name: "a hard link", path: linked, wantErr: "multiply linked"},
+		{name: "a symlink", path: symlink, wantErr: "not a regular file"},
+		{name: "a FIFO", path: fifo, wantErr: "not a regular file"},
+		{name: "a directory", path: directory, wantErr: "not a regular file"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			var info unix.Stat_t
+			if err := unix.Lstat(testCase.path, &info); err != nil {
+				t.Fatalf("stat the fixture: %v", err)
+			}
+			err := rootio.RequireSingleLinkedRegular(&info, "fixture", testCase.path)
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected a clean result, found %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("expected an error containing %q, found %v", testCase.wantErr, err)
+			}
+		})
+	}
+	// A missing stat is an error, not a pass: a caller that forgot to stat
+	// would otherwise take the clean branch.
+	if err := rootio.RequireSingleLinkedRegular(nil, "fixture", "missing"); err == nil {
+		t.Fatal("expected a missing stat to fail")
+	}
+}
+
+func TestMkdirAllSyncedAt(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		relative string
+		wantErr  string
+	}{
+		{name: "one component", relative: "one"},
+		{name: "nested components", relative: "one/two/three"},
+		{name: "an existing tree", relative: "one/two/three"},
+		{name: "an absolute path", relative: "/one", wantErr: "must be relative"},
+		{name: "a parent escape", relative: "one/../../two", wantErr: "must stay within"},
+		{name: "an empty path", relative: "", wantErr: "must be relative"},
+		{name: "a bare dot", relative: ".", wantErr: "names no directory"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			parent := openDirectory(t, root)
+			defer parent.Close() //nolint:errcheck // test fixture
+			if testCase.name == "an existing tree" {
+				if err := os.MkdirAll(filepath.Join(root, testCase.relative), 0o700); err != nil {
+					t.Fatalf("pre-create the tree: %v", err)
+				}
+			}
+			err := rootio.MkdirAllSyncedAt(parent, testCase.relative, 0o700)
+			if testCase.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+					t.Fatalf("expected an error containing %q, found %v", testCase.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected a clean result, found %v", err)
+			}
+			info, statErr := os.Stat(filepath.Join(root, testCase.relative))
+			if statErr != nil || !info.IsDir() {
+				t.Fatalf("expected a directory at %s, found %v", testCase.relative, statErr)
+			}
+		})
+	}
+}
+
+// A symlink in the middle of the path is refused rather than followed, so the
+// tree cannot be redirected outside the opened parent.
+func TestMkdirAllSyncedAtRejectsASymlinkedComponent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	outside := filepath.Join(root, "outside")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatalf("create the outside directory: %v", err)
+	}
+	inside := filepath.Join(root, "inside")
+	if err := os.Mkdir(inside, 0o700); err != nil {
+		t.Fatalf("create the inside directory: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(inside, "link")); err != nil {
+		t.Fatalf("create the symlinked component: %v", err)
+	}
+	parent := openDirectory(t, inside)
+	defer parent.Close() //nolint:errcheck // test fixture
+
+	if err := rootio.MkdirAllSyncedAt(parent, "link/below", 0o700); err == nil {
+		t.Fatal("expected a symlinked component to fail")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "below")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("the call created a directory through the symlink")
+	}
+}
+
+func TestStageAndPublishAt(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	parent := openDirectory(t, root)
+	defer parent.Close() //nolint:errcheck // test fixture
+
+	if err := rootio.StageAndPublishAt(parent, "record", []byte("first"), 0o600, ""); err != nil {
+		t.Fatalf("publish the first record: %v", err)
+	}
+	// Publication replaces, so the second write wins.
+	if err := rootio.StageAndPublishAt(parent, "record", []byte("second"), 0o600, ""); err != nil {
+		t.Fatalf("replace the record: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "record"))
+	if err != nil || string(content) != "second" {
+		t.Fatalf("expected the replacement content, found %q %v", content, err)
+	}
+	// The mode is set through the descriptor, so a restrictive umask cannot
+	// publish an unreadable file.
+	info, err := os.Stat(filepath.Join(root, "record"))
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected mode 0600, found %v %v", info.Mode().Perm(), err)
+	}
+	// Only the published name is left; every staged sibling is gone.
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 1 || entries[0].Name() != "record" {
+		t.Fatalf("expected only the published record, found %v %v", entries, err)
+	}
+}
+
+func TestStageAndCreateAtRefusesAnExistingName(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	parent := openDirectory(t, root)
+	defer parent.Close() //nolint:errcheck // test fixture
+
+	if err := rootio.StageAndCreateAt(parent, "record", []byte("first"), 0o600, ""); err != nil {
+		t.Fatalf("create the record: %v", err)
+	}
+	err := rootio.StageAndCreateAt(parent, "record", []byte("second"), 0o600, "")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected the second create to fail, found %v", err)
+	}
+	content, readErr := os.ReadFile(filepath.Join(root, "record"))
+	if readErr != nil || string(content) != "first" {
+		t.Fatalf("expected the first record to survive, found %q %v", content, readErr)
+	}
+	// The refused create leaves no staged sibling behind.
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected only the published record, found %v %v", entries, err)
+	}
+}
+
+// The published file is a single-linked regular file, so the hardened readers
+// accept what the publisher wrote.
+func TestStageAndPublishAtLeavesOneLink(t *testing.T) {
+	t.Parallel()
+	for _, publish := range []struct {
+		name  string
+		write func(*os.File, string, []byte, os.FileMode, string) error
+	}{
+		{"replace", rootio.StageAndPublishAt},
+		{"create", rootio.StageAndCreateAt},
+	} {
+		t.Run(publish.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			parent := openDirectory(t, root)
+			defer parent.Close() //nolint:errcheck // test fixture
+			if err := publish.write(parent, "record", []byte("x"), 0o600, ""); err != nil {
+				t.Fatalf("publish the record: %v", err)
+			}
+			var info unix.Stat_t
+			if err := unix.Lstat(filepath.Join(root, "record"), &info); err != nil {
+				t.Fatalf("stat the record: %v", err)
+			}
+			if err := rootio.RequireSingleLinkedRegular(&info, "record", "record"); err != nil {
+				t.Fatalf("the published record fails the reader's own rule: %v", err)
+			}
+		})
+	}
+}
+
+func TestStageAndPublishAtRejectsAnUnsafeName(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	parent := openDirectory(t, root)
+	defer parent.Close() //nolint:errcheck // test fixture
+
+	for _, testCase := range []struct{ name, leaf, prefix string }{
+		{"a path in the name", "sub/record", ""},
+		{"a parent escape in the name", "..", ""},
+		{"a path in the prefix", "record", "sub/tmp-"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if err := rootio.StageAndPublishAt(parent, testCase.leaf, []byte("x"), 0o600, testCase.prefix); err == nil {
+				t.Fatal("expected the unsafe name to fail")
+			}
+		})
+	}
+}
+
+func openDirectory(t *testing.T, path string) *os.File {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open the directory: %v", err)
+	}
+	return file
+}

--- a/internal/rootio/nofollow.go
+++ b/internal/rootio/nofollow.go
@@ -4,7 +4,6 @@
 package rootio
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -149,59 +148,12 @@ func MarshalCompactJSON(value any, label string, limit int64) ([]byte, error) {
 }
 
 // WriteFileAtomicAtNoFollow replaces name from an already trusted parent.
-// It writes a unique sibling with O_EXCL, sets mode before publication, then
-// uses renameat. renameat replaces a swapped leaf symlink instead of following it.
+//
+// It is StageAndPublishAt under its original name: one staged sibling created
+// with O_EXCL under a random name, its mode set through the descriptor, its
+// contents synced, published with renameat, and the parent directory synced.
 func WriteFileAtomicAtNoFollow(parent *os.File, name string, data []byte, mode os.FileMode, tempPrefix string) error {
-	if err := validateLeafName(name); err != nil {
-		return err
-	}
-	if tempPrefix == "" {
-		tempPrefix = ".workcell-tmp-"
-	}
-	if strings.Contains(tempPrefix, string(filepath.Separator)) {
-		return fmt.Errorf("temporary-file prefix must not contain a path separator: %s", tempPrefix)
-	}
-	parentFD := int(parent.Fd())
-	for attempt := 0; attempt < 32; attempt++ {
-		suffix, err := randomSuffix()
-		if err != nil {
-			return err
-		}
-		temporaryName := tempPrefix + suffix + ".tmp"
-		fd, err := unix.Openat(parentFD, temporaryName, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode.Perm()))
-		if errors.Is(err, unix.EEXIST) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		file := os.NewFile(uintptr(fd), filepath.Join(parent.Name(), temporaryName))
-		if file == nil {
-			_ = unix.Close(fd)
-			_ = unix.Unlinkat(parentFD, temporaryName, 0)
-			return fmt.Errorf("create temporary file for %s", name)
-		}
-		if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
-			_ = file.Close()
-			_ = unix.Unlinkat(parentFD, temporaryName, 0)
-			return err
-		}
-		if err := unix.Fchmod(fd, uint32(mode.Perm())); err != nil {
-			_ = file.Close()
-			_ = unix.Unlinkat(parentFD, temporaryName, 0)
-			return err
-		}
-		if err := file.Close(); err != nil {
-			_ = unix.Unlinkat(parentFD, temporaryName, 0)
-			return err
-		}
-		if err := unix.Renameat(parentFD, temporaryName, parentFD, name); err != nil {
-			_ = unix.Unlinkat(parentFD, temporaryName, 0)
-			return err
-		}
-		return nil
-	}
-	return fmt.Errorf("unable to allocate temporary file under %s", parent.Name())
+	return StageAndPublishAt(parent, name, data, mode, tempPrefix)
 }
 
 func validateLeafName(name string) error {

--- a/internal/rootio/rename_darwin.go
+++ b/internal/rootio/rename_darwin.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build darwin
+
+package rootio
+
+import "golang.org/x/sys/unix"
+
+// renameNoReplaceAt publishes from onto to in one step and refuses to replace
+// an existing name. Darwin spells the flag RENAME_EXCL.
+func renameNoReplaceAt(parentFD int, from, to string) error {
+	return unix.RenameatxNp(parentFD, from, parentFD, to, unix.RENAME_EXCL)
+}

--- a/internal/rootio/rename_linux.go
+++ b/internal/rootio/rename_linux.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build linux
+
+package rootio
+
+import "golang.org/x/sys/unix"
+
+// renameNoReplaceAt publishes from onto to in one step and refuses to replace
+// an existing name. Linux spells the flag RENAME_NOREPLACE.
+func renameNoReplaceAt(parentFD int, from, to string) error {
+	return unix.Renameat2(parentFD, from, parentFD, to, unix.RENAME_NOREPLACE)
+}

--- a/internal/rootio/rename_other.go
+++ b/internal/rootio/rename_other.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+//go:build !darwin && !linux
+
+package rootio
+
+import "golang.org/x/sys/unix"
+
+// renameNoReplaceAt has no one-step spelling on this platform, so the caller
+// falls back to the link-and-unlink publication.
+func renameNoReplaceAt(int, string, string) error {
+	return unix.ENOTSUP
+}

--- a/policy/mutation-score-policy.json
+++ b/policy/mutation-score-policy.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "baseline_score": 100.0,
-  "expected_mutants": 30
+  "expected_mutants": 33
 }

--- a/scripts/generate-control-plane-manifest.sh
+++ b/scripts/generate-control-plane-manifest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -p
-# generated-artifact: none (release artifact under dist/; scripts/verify-control-plane-manifest.sh proves determinism)
+# generated-artifact: runtime/container/control-plane-manifest.json
 # shellcheck source=scripts/lib/trusted-entrypoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/trusted-entrypoint.sh"
 


### PR DESCRIPTION
## Summary

Pull request 711 added the ratchet that forbids new raw `os` pathname
references in eleven trust-boundary packages. This adds the three
`internal/rootio` helpers the review corpus asks for, so the 196 baselined
references have somewhere to go.

## The helpers

**`RequireSingleLinkedRegular(info *unix.Stat_t, label, name string) error`**
Rejects a leaf that is not a single-linked regular file. A symlink, a FIFO, a
socket and a device node all pass a bare existence check, and a hard link to a
file outside the trusted root passes a file-type check as well, so the link
count is the only thing that separates the intended inode from a copy of it.
Findings: 436 ("Reject non-regular audit log leaves", "Reject hard-linked
audit logs"), 447 ("Require single-linked audit logs before export").

**Dedupe.** `internal/applecontainer/conformance.go` held the only copy of
this rule; `requireNoSymlink` becomes `requireSingleLinkedRegular` and calls
the helper. The `wantDir` parameter went with it: its single caller always
passed `false`.

**`MkdirAllSyncedAt(parent *os.File, relative string, mode os.FileMode) error`**
Opens each component relative to the previous descriptor with `O_NOFOLLOW`, so
a symlink swapped into the middle of the path is refused rather than followed,
and fsyncs the directory that gained each entry rather than only the parent of
the last one. Findings: 474 ("Fsync every ancestor created by MkdirAll",
"Fsync nested ancestors on existing-dir races", "Fsync the parent when
creating the signing dir").

The fsync runs whether this call created the component or found it present,
which is what "Fsync nested ancestors on existing-dir races" asks for: a
racing creator can return from its own mkdir before its fsync completes, or
fail it, so the loser cannot treat an existing directory as already durable.

**`StageAndPublishAt` and `StageAndCreateAt`**
One staged sibling created with `O_EXCL` under a random name, mode set through
the descriptor, contents synced, published, parent directory synced. Findings:
437 ("Sync rewritten records before renaming", "Stage records before
publishing the final path", "Randomize rewrite temp names and retry
collisions", "Preserve create-once semantics during publish", "Chmod staged
session records before rename").

`WriteFileAtomicAtNoFollow` is now the replace form under its original name,
so one implementation serves both rather than a near-identical twin. Its
fourteen existing call sites gain the content sync and the parent sync, which
is the durability half of finding 437.

The create-once form publishes with `linkat`, which refuses a name that
appeared after an absence check where `renameat` would silently replace it.
Its link-and-unlink window leaves two links for an instant, which a concurrent
`RequireSingleLinkedRegular` would refuse; that is recorded in a `ponytail:`
comment naming `renameat2` with `RENAME_NOREPLACE` as the upgrade and macOS as
the reason it is not used.

## Two reverts worth reading

I first made `ReadFileAtNoFollow` apply `RequireSingleLinkedRegular` to every
leaf it opens. Two existing tests failed and showed the change was wrong:
`internal/runtimeutil` asserts that `RewriteBundleCredentialOverride`
**succeeds** on a hard-linked bundle manifest and that the atomic replace
leaves the outside inode untouched. Hard links are accepted there by design;
the protection is the atomic replace, not rejection. I reverted it.

I also first routed the `sessions dir entry` check in `conformance.go` through
the helper, which would have added a link-count rule to a deliberately
type-only check. Reverted for the same reason. The dedupe is now exactly the
one rule that was duplicated, with no behaviour change to either site.

## Follow-up folded in

`scripts/generate-control-plane-manifest.sh` declared
`# generated-artifact: none` while it also writes the tracked
`runtime/container/control-plane-manifest.json`. It now names that file, so
the freshness gate from pull request 707 regenerates and byte-compares it on
every validate lane instead of skipping it.

## Tests and mutation

`internal/rootio/hardened_test.go` covers the five leaf shapes (regular, hard
link, symlink, FIFO, directory) and a nil stat; `MkdirAllSyncedAt` over one
component, nested components, an existing tree, an absolute path, a parent
escape, an empty path, a bare dot, and a symlinked component that must not be
followed; publication for replace, create-once refusal, mode, staged-sibling
cleanup, unsafe names, and that every published file passes the reader's own
single-link rule.

Three `internal/mutation/runner.go` rows, one per helper:
the link-count requirement, the `O_NOFOLLOW` on directory components, and the
create-once branch. `policy/mutation-score-policy.json` rises from 30 to 33.

## Evidence

- `WORKCELL_VALIDATE_REPO_PROFILE=repo-core ./scripts/validate-repo.sh` passes,
  including the mutation lane at 33 of 33.
- `./scripts/check-hardened-fs.sh`, `./scripts/check-generated-artifacts.sh`,
  `./scripts/check-doc-language.sh`, `./scripts/check-shell-portability.sh`,
  `./scripts/check-validator-anchoring.sh` and
  `./verify/invariants/control-plane-lockstep.sh` pass.
- `./scripts/check-pr-shape.sh`: files=7 lines=610 areas=3.