### PR TITLE
Give hostile root and uidmap axes a validator-owned workspace copy

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -69,6 +69,10 @@ The `Hostile environment` lanes run repository validation again on one hostile a
 - `root` runs the container as UID 0.
 - `uidmap` runs the container as a UID that owns none of the bind and has no record in the image.
 
+The `root` and `uidmap` axes validate a copy of the workspace that the container makes as its own UID.
+Git refuses a repository owned by another UID.
+`scripts/ci-plan.sh` runs Git with no configuration that could grant an exception, so the lane aligns the ownership.
+
 These shapes reproduce quoting, argument-boundary, mount-record, and `sun_path` defects before review.
 The lanes are advisory: they use `continue-on-error` and are not required checks.
 Run one axis on a host the same way the lane does, with Docker available:

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -90,6 +90,19 @@ validator_tmp="${validator_home}/.tmp"
 if [[ "${HOSTILE_ENV}" == "tmpdir" ]]; then
   validator_tmp="${validator_tmp}/hostile \$HOME --hostname/$(printf 'p%.0s' {1..80})"
 fi
+# The root and uidmap axes run as a uid that owns nothing in the bind mount,
+# and git refuses a repository owned by another uid: "detected dubious
+# ownership in repository at '/workspace'".  scripts/ci-plan.sh runs git with
+# no global and no system configuration on purpose, so safe.directory is not
+# reachable and is not the fix here; align the ownership instead.  The copy is
+# made inside the container by the validator uid itself, so it owns the result
+# with no privileged step on the host and no change to either axis: root still
+# runs as uid 0 and uidmap still runs as a uid the bind mount and the image
+# know nothing about.
+validator_workspace_copy=""
+case "${HOSTILE_ENV}" in
+  root | uidmap) validator_workspace_copy="${validator_home}/workspace" ;;
+esac
 
 setup_workcell_ci_docker
 
@@ -113,6 +126,7 @@ workcell_ci_docker run --rm \
   -e GOMODCACHE="${validator_cache}/go-mod" \
   -e CARGO_TARGET_DIR="${validator_cache}/cargo-target" \
   -e TMPDIR="${validator_tmp}" \
+  -e WORKCELL_VALIDATOR_WORKSPACE_COPY="${validator_workspace_copy}" \
   --mount "${validator_workspace_mount}" \
   --mount "${validator_passwd_mount}" \
   -w /workspace \
@@ -120,5 +134,14 @@ workcell_ci_docker run --rm \
   -lc '
     set -euo pipefail
     mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${GOCACHE}" "${GOMODCACHE}" "${CARGO_TARGET_DIR}" "${TMPDIR}"
+    if [[ -n "${WORKCELL_VALIDATOR_WORKSPACE_COPY}" ]]; then
+      # -d keeps symlinks and hard links as they are, and the mode and
+      # timestamp list omits ownership on purpose: as uid 0 a preserving copy
+      # would reproduce the bind owner and land back on the dubious-ownership
+      # refusal this copy exists to remove.
+      mkdir -p "${WORKCELL_VALIDATOR_WORKSPACE_COPY}"
+      cp -dR --preserve=mode,timestamps /workspace/. "${WORKCELL_VALIDATOR_WORKSPACE_COPY}/"
+      cd "${WORKCELL_VALIDATOR_WORKSPACE_COPY}"
+    fi
     ./scripts/validate-repo.sh
   '


### PR DESCRIPTION
The advisory hostile-environment lane runs the validator as UID 0 on the `root` axis and as an unmapped UID on the `uidmap` axis. Both run against a workspace bind that the checkout UID owns, so every Git call underneath `scripts/ci-plan.sh` stopped at "detected dubious ownership in repository at /workspace" and the two axes never reached the validation they exist to run.

The planner runs Git with no global and no system configuration on purpose, and that hardening is the point of it, so `safe.directory` is not reachable from inside the lane and is not the fix here. This aligns the ownership instead: for those two axes the container copies `/workspace` into the validator home and validates the copy, which the running UID owns because it made the copy. The copy keeps modes, timestamps, symlinks and hard links, and deliberately does not keep ownership, so the root axis does not reproduce the bind owner and land back on the same refusal.

Both axes stay faithful. Root still runs as UID 0, uidmap still runs as a UID that neither the bind mount nor the image knows, and the hostile TMPDIR composition is untouched. The `none`, `tmpdir` and `workspace` axes get an empty copy path and behave exactly as before.

Verified on a local Colima daemon against a clean clone of this branch, with the lane script driven the same way CI drives it:

- Controls in the validator image: as UID 0 and as an unowned UID, `git rev-parse --absolute-git-dir` on the bind fails with the dubious-ownership refusal for the unowned UID and succeeds for both after the copy. A separate control confirms that a copy made by root from a 1001-owned source lands root-owned, with modes and symlinks intact.
- `WORKCELL_HOSTILE_ENV=root ./scripts/ci/run-validate-in-validator.sh` with the `repo-core` profile: exit 0, "Workcell repository validation passed", no ownership error anywhere in the log.
- `WORKCELL_HOSTILE_ENV=uidmap` with the same profile: no ownership error, and the run is repeating on the final tree.
- `bash -n`, `shellcheck -x`, `shellcheck -x -o check-extra-masked-returns`, `shfmt -ln=bash -i 2 -ci`, `markdownlint`, `codespell`, `go test ./internal/metadatautil -run TestCheckDocLanguageRepositoryDocuments`, and `scripts/check-pr-shape.sh` all pass.