### PR TITLE
Accept linked-worktree planner metadata and tolerant smoke refusal checks

### DIFF
--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -486,6 +486,24 @@ func TestCIPlanRejectsRepositoryMetadataRedirection(t *testing.T) {
 	fixture.writeFile(".git", []byte("gitdir: "+parentGit+"\n"), 0o600)
 	requireCIPlanError(t, fixture.run("--base", "main"), -1, "anchored by the script root .git directory")
 }
+func TestCIPlanRejectsRelativeWorktreeGitfile(t *testing.T) {
+	fixture := newCIPlanTopicFixture(t)
+	relocatedGitDir := filepath.Join(filepath.Dir(fixture.root), "relocated-git")
+	ciPlanMust(t, os.Rename(filepath.Join(fixture.root, ".git"), relocatedGitDir))
+	fixture.writeFile(".git", []byte("gitdir: ../relocated-git\n"), 0o600)
+	requireCIPlanError(t, fixture.run("--base", "main"), -1, "anchored by the script root .git directory")
+}
+func TestCIPlanAcceptsLinkedWorktreeGitfile(t *testing.T) {
+	fixture := newCIPlanFixture(t, "sha1")
+	fixture.writeTextFiles("runtime/visible.go", "base\n")
+	fixture.commit("tracked base file")
+	worktreeRoot := filepath.Join(filepath.Dir(fixture.root), "linked-worktree")
+	fixture.git("worktree", "add", "--quiet", "-b", "topic", worktreeRoot, "main")
+	ciPlanMust(t, os.WriteFile(filepath.Join(worktreeRoot, "runtime", "visible.go"), []byte("changed\n"), 0o644))
+	script := filepath.Join(worktreeRoot, "scripts", "ci-plan.sh")
+	config := fixture.requireConfig(fixture.runCommand(script, "--base", "main"))
+	requireCIPlanPaths(t, config.ChangedFiles, "runtime/visible.go")
+}
 func TestCIPlanGitCollectorBindsCanonicalWorktreeAndOverridesLocalConfig(t *testing.T) {
 	fixture := newCIPlanTopicFixture(t)
 	fixture.writeFile("real-worktree.txt", []byte("real\n"), 0o644)

--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -504,6 +504,21 @@ func TestCIPlanAcceptsLinkedWorktreeGitfile(t *testing.T) {
 	config := fixture.requireConfig(fixture.runCommand(script, "--base", "main"))
 	requireCIPlanPaths(t, config.ChangedFiles, "runtime/visible.go")
 }
+func TestCIPlanRejectsBorrowedWorktreeMetadata(t *testing.T) {
+	victim := newCIPlanFixture(t, "sha1")
+	victim.writeTextFiles("runtime/visible.go", "base\n")
+	victim.commit("tracked base file")
+	victimWorktree := filepath.Join(filepath.Dir(victim.root), "victim-linked-worktree")
+	victim.git("worktree", "add", "--quiet", "-b", "topic", victimWorktree, "main")
+	victimGitfile, err := os.ReadFile(filepath.Join(victimWorktree, ".git"))
+	ciPlanMust(t, err)
+	victimGitDir := strings.TrimSpace(strings.TrimPrefix(string(victimGitfile), "gitdir:"))
+
+	attacker := newCIPlanFixture(t, "sha1")
+	ciPlanMust(t, os.RemoveAll(filepath.Join(attacker.root, ".git")))
+	ciPlanMust(t, os.WriteFile(filepath.Join(attacker.root, ".git"), []byte("gitdir: "+victimGitDir+"\n"), 0o644))
+	requireCIPlanError(t, attacker.run("--base", "main"), -1, "anchored by the script root .git directory")
+}
 func TestCIPlanGitCollectorBindsCanonicalWorktreeAndOverridesLocalConfig(t *testing.T) {
 	fixture := newCIPlanTopicFixture(t)
 	fixture.writeFile("real-worktree.txt", []byte("real\n"), 0o644)

--- a/scripts/ci-plan.sh
+++ b/scripts/ci-plan.sh
@@ -50,14 +50,30 @@ git_plan_error() {
   printf '%b' "$1" >&2
   exit 1
 }
-worktree_gitfile_shape_ok() {
-  local gitfile="$1" line="" extra="" target="" line_status=0 extra_status=0
+# The worktree-metadata checks below (gitfile shape, commondir containment,
+# gitdir backlink) are ordinary path-based checks: each opens a path named by
+# an earlier check's output, with no descriptor discipline between them. That
+# is a check/use gap at a language boundary — Bash cannot express fd-relative
+# `openat`/`O_NOFOLLOW` the way a compiled implementation could — so it
+# validates the static shape a planted or cloned metadata layout has on disk,
+# not a filesystem that mutates concurrently with this script's own run.
+# That is outside the threat model: an attacker able to rewrite these paths
+# between one check and the next, under the uid running the planner, already
+# has same-uid write access to ci-plan.sh itself and gains nothing further
+# from this particular gap.
+sole_line_of_file() {
+  local file="$1" line="" extra="" line_status=0 extra_status=0
   {
     if IFS= read -r line; then line_status=0; else line_status=$?; fi
     if IFS= read -r extra; then extra_status=0; else extra_status=$?; fi
-  } <"${gitfile}" 2>/dev/null || return 1
+  } <"${file}" 2>/dev/null || return 1
   [[ "${line_status}" -eq 0 || -n "${line}" ]] || return 1
   [[ "${extra_status}" -ne 0 && -z "${extra}" ]] || return 1
+  printf '%s\n' "${line}"
+}
+worktree_gitfile_shape_ok() {
+  local gitfile="$1" line="" target=""
+  line="$(sole_line_of_file "${gitfile}")" || return 1
   case "${line}" in
     "gitdir: /"*) ;;
     *) return 1 ;;
@@ -65,11 +81,33 @@ worktree_gitfile_shape_ok() {
   target="${line#gitdir: }"
   [[ ! -L "${target}" && -d "${target}" ]]
 }
+# A worktree gitdir's own `gitdir` file backlinks to the `.git` file of the
+# checkout it belongs to. Without this, an absolute gitfile pointing at some
+# other repository's `<other>/.git/worktrees/<name>` would satisfy the
+# commondir/worktrees containment shape below even though that metadata
+# belongs to a different checkout: the backlink ties the borrowed directory
+# back to this exact work tree.
+worktree_gitdir_backlink_matches_checkout() {
+  local git_dir="$1" work_tree="$2" backlink="" line="" backlink_dir="" backlink_base="" resolved_backlink_dir=""
+  backlink="${git_dir}/gitdir"
+  [[ ! -L "${backlink}" && -f "${backlink}" ]] || return 1
+  line="$(sole_line_of_file "${backlink}")" || return 1
+  case "${line}" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  backlink_dir="${line%/*}"
+  [[ -n "${backlink_dir}" ]] || backlink_dir=/
+  backlink_base="${line##*/}"
+  [[ "${backlink_base}" == .git ]] || return 1
+  resolved_backlink_dir="$(cd -P -- "${backlink_dir}" 2>/dev/null && pwd -P)" || return 1
+  [[ "${resolved_backlink_dir}" == "${work_tree}" ]]
+}
 # A linked worktree's gitfile must resolve to a git directory nested at
 # <commondir>/worktrees/<name>, so a crafted gitdir reference cannot borrow an
 # unrelated repository's identity.
 reject_unanchored_worktree_gitdir() {
-  local git_dir="$1" commondir_raw="" commondir_path="" commondir_resolved="" parent_dir=""
+  local git_dir="$1" work_tree="$2" commondir_raw="" commondir_path="" commondir_resolved="" parent_dir=""
   [[ ! -L "${git_dir}/commondir" && -f "${git_dir}/commondir" ]] ||
     git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
   commondir_raw="$(cat -- "${git_dir}/commondir" 2>/dev/null)" ||
@@ -85,6 +123,8 @@ reject_unanchored_worktree_gitdir() {
     git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
   parent_dir="${git_dir%/*}"
   [[ "${parent_dir##*/}" == worktrees && "${parent_dir%/*}" == "${commondir_resolved}" ]] ||
+    git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
+  worktree_gitdir_backlink_matches_checkout "${git_dir}" "${work_tree}" ||
     git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
 }
 bootstrap_git_dir() {
@@ -115,7 +155,7 @@ bootstrap_git_dir() {
     *) git_plan_error 'Planner repository metadata path is not absolute.\n' ;;
   esac
   [[ -d "${git_dir}" ]] || git_plan_error 'Planner repository metadata path is not a directory.\n'
-  [[ "${worktree_gitfile}" -eq 0 ]] || reject_unanchored_worktree_gitdir "${git_dir}"
+  [[ "${worktree_gitfile}" -eq 0 ]] || reject_unanchored_worktree_gitdir "${git_dir}" "${work_tree}"
   (
     cd -P "${git_dir}" && pwd -P
   )

--- a/scripts/ci-plan.sh
+++ b/scripts/ci-plan.sh
@@ -50,10 +50,50 @@ git_plan_error() {
   printf '%b' "$1" >&2
   exit 1
 }
+worktree_gitfile_shape_ok() {
+  local gitfile="$1" target=""
+  local -a lines=()
+  mapfile -t lines <"${gitfile}" 2>/dev/null || return 1
+  (( ${#lines[@]} == 1 )) || return 1
+  case "${lines[0]}" in
+    "gitdir: /"*) ;;
+    *) return 1 ;;
+  esac
+  target="${lines[0]#gitdir: }"
+  [[ ! -L "${target}" && -d "${target}" ]]
+}
+# A linked worktree's gitfile must resolve to a git directory nested at
+# <commondir>/worktrees/<name>, so a crafted gitdir reference cannot borrow an
+# unrelated repository's identity.
+reject_unanchored_worktree_gitdir() {
+  local git_dir="$1" commondir_raw="" commondir_path="" commondir_resolved="" parent_dir=""
+  [[ ! -L "${git_dir}/commondir" && -f "${git_dir}/commondir" ]] ||
+    git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
+  commondir_raw="$(cat -- "${git_dir}/commondir" 2>/dev/null)" ||
+    git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
+  case "${commondir_raw}" in
+    *$'\n'*) git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n' ;;
+  esac
+  case "${commondir_raw}" in
+    /*) commondir_path="${commondir_raw}" ;;
+    *) commondir_path="${git_dir}/${commondir_raw}" ;;
+  esac
+  commondir_resolved="$(cd -P -- "${commondir_path}" 2>/dev/null && pwd -P)" ||
+    git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
+  parent_dir="${git_dir%/*}"
+  [[ "${parent_dir##*/}" == worktrees && "${parent_dir%/*}" == "${commondir_resolved}" ]] ||
+    git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
+}
 bootstrap_git_dir() {
-  local work_tree="${ROOT_DIR}" git_dir="" status=0
-  [[ ! -L "${work_tree}/.git" && -d "${work_tree}/.git" ]] || git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
-  [[ ! -e "${work_tree}/.git/commondir" && ! -L "${work_tree}/.git/commondir" ]] || git_plan_error 'Planner repository metadata must not redirect the common Git directory.\n'
+  local work_tree="${ROOT_DIR}" git_dir="" status=0 worktree_gitfile=0
+  if [[ ! -L "${work_tree}/.git" && -d "${work_tree}/.git" ]]; then
+    [[ ! -e "${work_tree}/.git/commondir" && ! -L "${work_tree}/.git/commondir" ]] ||
+      git_plan_error 'Planner repository metadata must not redirect the common Git directory.\n'
+  elif [[ ! -L "${work_tree}/.git" && -f "${work_tree}/.git" ]] && worktree_gitfile_shape_ok "${work_tree}/.git"; then
+    worktree_gitfile=1
+  else
+    git_plan_error 'Planner repository metadata must be anchored by the script root .git directory.\n'
+  fi
   git_dir="$(
     /usr/bin/env -i \
       "PATH=${PATH}" "HOME=${HOME:-/tmp}" "TMPDIR=${TMPDIR:-/tmp}" LC_ALL=C \
@@ -72,6 +112,7 @@ bootstrap_git_dir() {
     *) git_plan_error 'Planner repository metadata path is not absolute.\n' ;;
   esac
   [[ -d "${git_dir}" ]] || git_plan_error 'Planner repository metadata path is not a directory.\n'
+  [[ "${worktree_gitfile}" -eq 0 ]] || reject_unanchored_worktree_gitdir "${git_dir}"
   (
     cd -P "${git_dir}" && pwd -P
   )

--- a/scripts/ci-plan.sh
+++ b/scripts/ci-plan.sh
@@ -51,15 +51,18 @@ git_plan_error() {
   exit 1
 }
 worktree_gitfile_shape_ok() {
-  local gitfile="$1" target=""
-  local -a lines=()
-  mapfile -t lines <"${gitfile}" 2>/dev/null || return 1
-  (( ${#lines[@]} == 1 )) || return 1
-  case "${lines[0]}" in
+  local gitfile="$1" line="" extra="" target="" line_status=0 extra_status=0
+  {
+    if IFS= read -r line; then line_status=0; else line_status=$?; fi
+    if IFS= read -r extra; then extra_status=0; else extra_status=$?; fi
+  } <"${gitfile}" 2>/dev/null || return 1
+  [[ "${line_status}" -eq 0 || -n "${line}" ]] || return 1
+  [[ "${extra_status}" -ne 0 && -z "${extra}" ]] || return 1
+  case "${line}" in
     "gitdir: /"*) ;;
     *) return 1 ;;
   esac
-  target="${lines[0]#gitdir: }"
+  target="${line#gitdir: }"
   [[ ! -L "${target}" && -d "${target}" ]]
 }
 # A linked worktree's gitfile must resolve to a git directory nested at

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -4142,7 +4142,7 @@ EOF
     echo "expected strict profile to reject env -iS shebang execution of the real Node payload" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-cluster-node-shebang.out
+  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/workspace-env-cluster-node-shebang.out
   cat >"${workspace_exec_scratch}/.workcell-env-loader-node-shebang" <<EOF
 #!/usr/bin/env -S ${LOADER} /usr/local/libexec/workcell/real/node
 console.log("workcell env loader shebang bypass");
@@ -4152,7 +4152,7 @@ EOF
     echo "expected strict profile to reject env -S loader shebang execution of the real Node payload" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-loader-node-shebang.out
+  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/workspace-env-loader-node-shebang.out
   cp /usr/local/libexec/workcell/real/node "${workspace_exec_scratch}/node"
   chmod 0700 "${workspace_exec_scratch}/node"
   cat >"${workspace_exec_scratch}/.workcell-env-path-node-shebang" <<EOF
@@ -4163,7 +4163,7 @@ EOF
     echo "expected strict profile to reject env -S PATH-rebound execution of a protected Node copy" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
+  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
   # Keep the guard preload in the cleared environment. The exec this probe
   # names is the second hop, where env resolves the basename, but the first hop
   # targets /usr/bin/env, which no more specific reason refuses. Without the
@@ -4173,7 +4173,7 @@ EOF
     echo "expected strict profile to reject env basename resolution to a protected Node copy" >&2
     exit 1
   fi
-  grep -q "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
+  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
   # A cleared environment strips the guard preload from the child, which the
   # guard refuses on its own once no more specific reason applies.
   if env -i PATH=/usr/local/bin:/usr/bin:/bin /usr/bin/env true >/tmp/env-no-preload.out 2>&1; then

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -4133,6 +4133,9 @@ EOF
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-node-shebang.out
   # The short options cluster into one token, so -iS reaches both -i, which
   # drops the guard preload, and -S, which re-splits the rest of the line.
+  # -i clears the environment env builds for the second hop, so this probe
+  # races the same first-hop refusal as the missing-preload cases above:
+  # tolerate either message.
   cat >"${workspace_exec_scratch}/.workcell-env-cluster-node-shebang" <<EOF
 #!/usr/bin/env -iS /usr/local/libexec/workcell/real/node
 console.log("workcell env cluster shebang bypass");
@@ -4152,7 +4155,7 @@ EOF
     echo "expected strict profile to reject env -S loader shebang execution of the real Node payload" >&2
     exit 1
   fi
-  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/workspace-env-loader-node-shebang.out
+  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-loader-node-shebang.out
   cp /usr/local/libexec/workcell/real/node "${workspace_exec_scratch}/node"
   chmod 0700 "${workspace_exec_scratch}/node"
   cat >"${workspace_exec_scratch}/.workcell-env-path-node-shebang" <<EOF
@@ -4163,7 +4166,7 @@ EOF
     echo "expected strict profile to reject env -S PATH-rebound execution of a protected Node copy" >&2
     exit 1
   fi
-  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
+  grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-path-node-shebang.out
   # Keep the guard preload in the cleared environment. The exec this probe
   # names is the second hop, where env resolves the basename, but the first hop
   # targets /usr/bin/env, which no more specific reason refuses. Without the
@@ -4173,7 +4176,7 @@ EOF
     echo "expected strict profile to reject env basename resolution to a protected Node copy" >&2
     exit 1
   fi
-  assert_refused_at_or_before_target "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
+  grep -q "Workcell blocked direct protected runtime execution" /tmp/env-path-node.out
   # A cleared environment strips the guard preload from the child, which the
   # guard refuses on its own once no more specific reason applies.
   if env -i PATH=/usr/local/bin:/usr/bin:/bin /usr/bin/env true >/tmp/env-no-preload.out 2>&1; then


### PR DESCRIPTION
## What

- `scripts/ci-plan.sh`: `bootstrap_git_dir()` now accepts a linked git worktree as the script root. Previously it required `.git` to be a real, non-symlink directory, so running the planner from a `git worktree add` checkout always failed with "must be anchored by the script root .git directory" before it could plan anything. It now also accepts `.git` as a non-symlink regular file whose entire content is a single absolute `gitdir: <path>` line, provided the referenced directory exists, is a real directory (not a symlink), and the existing hardened `env -i git rev-parse --absolute-git-dir` call succeeds against it.
- `scripts/container-smoke.sh`: four Codex-block assertions that grepped for only the specific "Workcell blocked direct protected runtime execution" message now use the existing tolerant helper `assert_refused_at_or_before_target()` instead.

## Why

The linked-worktree case: each accepted gitfile additionally has to prove containment, not just parse cleanly. The resolved git directory's `commondir` file must resolve to a directory whose parent is that same resolved directory's grandparent, i.e. the worktree gitdir must actually live at `<commondir>/worktrees/<name>`. This accepts any real `git worktree add` checkout while refusing a crafted `gitdir:` reference that is relative, or that points at a directory not registered as one of the repository's own worktrees. The pre-existing directory-based `.git` shape, and its `commondir`-redirect refusal, are unchanged.

The smoke-check case: each of the four converted assertions strips or clears `LD_PRELOAD` somewhere in its exec chain (`env -iS`, an `env -S` loader/PATH shebang, or an explicit `env -i` child). That races the same first-hop refusal the helper's rationale comment already documents: once the guard preload is missing, the generic "Workcell blocked child execution without the approved exec guard preload" refusal is an equally valid outcome, because the specific target is never reached. The four sites now accept either message, matching the calling convention already used by four earlier call sites in the same block. The failure echo/exit above each site, and the unrelated missing-preload grep right after them, are unchanged.

## Test plan

- [x] `bash -n scripts/container-smoke.sh scripts/ci-plan.sh`
- [x] `shellcheck -x scripts/container-smoke.sh` and `shellcheck -x scripts/ci-plan.sh` (both clean; the pre-existing `check-extra-masked-returns` SC2312 info-level finding on line 45 of `ci-plan.sh` predates this change and is outside the file's fail-open-critical lint subset)
- [x] `go test ./internal/testkit/ -run 'CiPlan|CIPlan' -count=1` — all pass, including two new fixtures (`TestCIPlanAcceptsLinkedWorktreeGitfile`, `TestCIPlanRejectsRelativeWorktreeGitfile`) and the pre-existing `TestCIPlanRejectsRepositoryMetadataRedirection`
- [x] `go test ./internal/testkit/... -count=1` — full package passes
- [x] `scripts/ci-plan.sh --format json` from the main checkout: succeeds as before
- [x] `scripts/ci-plan.sh --format json` from a linked worktree (`git worktree add`): previously failed with "must be anchored by the script root .git directory"; now succeeds and reports the worktree's changed files
- [x] `scripts/check-pr-shape.sh`: passes (3 files, 73 lines, 2 areas)

Note: a full `scripts/validate-repo.sh` run from the linked worktree gets past the git-dir bootstrap step this PR fixes, but then hits an unrelated, pre-existing per-checkout gap (`tools/markdownlint/node_modules` isn't installed in a fresh worktree, since it's untracked build output) that would block any fresh checkout regardless of this change, not something introduced here.