### PR TITLE
Make environment-sensitive tests survive a hostile TMPDIR

### DIFF
--- a/internal/aptbroker/client_test.go
+++ b/internal/aptbroker/client_test.go
@@ -6,6 +6,7 @@ package aptbroker
 import (
 	"context"
 	"net"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -55,7 +56,14 @@ func TestRunClientRejectsMalformedRequestBeforeDial(t *testing.T) {
 }
 
 func TestRunClientCancelsWhileTheBrokerNeverReadsTheRequest(t *testing.T) {
-	directory := shortSocketDir(t)
+	// shortSocketDir's root skip exists for the server's socket-ancestry
+	// policy; this test only binds a bare client-side listener, which root
+	// can do too, so build the short (sun_path-safe) dir directly instead.
+	directory, err := os.MkdirTemp("/tmp", "wcbr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
 	socketPath := filepath.Join(directory, "s")
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {

--- a/internal/aptbroker/client_test.go
+++ b/internal/aptbroker/client_test.go
@@ -6,7 +6,6 @@ package aptbroker
 import (
 	"context"
 	"net"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -56,11 +55,7 @@ func TestRunClientRejectsMalformedRequestBeforeDial(t *testing.T) {
 }
 
 func TestRunClientCancelsWhileTheBrokerNeverReadsTheRequest(t *testing.T) {
-	directory, err := os.MkdirTemp("", "wcbr")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(directory)
+	directory := shortSocketDir(t)
 	socketPath := filepath.Join(directory, "s")
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {

--- a/internal/host/c3certify/certify_test.go
+++ b/internal/host/c3certify/certify_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -21,6 +20,7 @@ import (
 	"time"
 
 	"github.com/omkhar/workcell/internal/host/sessions"
+	"github.com/omkhar/workcell/internal/testkit"
 )
 
 type failingWriter struct{}
@@ -577,12 +577,9 @@ func TestGitCommandDisablesRepositoryExecution(t *testing.T) {
 	// hostile TMPDIR (space, literal "$HOME") would get re-expanded rather than
 	// treated as a filename. Neither path is what this test's assertions are
 	// about, so give them a short, TMPDIR-independent home instead. hook is
-	// executed (by git), so it also needs an exec-capable location; a
-	// hardcoded /tmp is noexec in the supported workcell container, so root
-	// this under the checkout instead.
-	fixtureRoot, err := os.MkdirTemp(repoRoot(t), ".c3hook-fixture-")
-	mustNoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(fixtureRoot) })
+	// executed (by git), so it also needs a writable, exec-capable location;
+	// see testkit.ExecFixtureDir for why no single hardcoded path works.
+	fixtureRoot := testkit.ExecFixtureDir(t)
 	marker, hook := filepath.Join(fixtureRoot, "hook-ran"), filepath.Join(fixtureRoot, "hook.sh")
 	mustNoError(t, os.WriteFile(hook, []byte("#!/bin/sh\nprintf tracked >\""+marker+"\"\ncat\n"), 0o700))
 	mustNoError(t, os.WriteFile(filepath.Join(workspace, ".gitattributes"), []byte("tracked filter=host\n"), 0o600))
@@ -683,18 +680,6 @@ func mustNoError(t *testing.T, err error) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-// repoRoot returns the checkout root: always exec-capable (that's where the
-// code under test runs from) and, unlike TMPDIR, never carrying a hostile
-// CI axis's space or literal $HOME.
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("unable to determine repo root")
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 }
 func newGitRepo(t *testing.T) (string, string) {
 	root, err := filepath.EvalSymlinks(t.TempDir())

--- a/internal/host/c3certify/certify_test.go
+++ b/internal/host/c3certify/certify_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -575,8 +576,11 @@ func TestGitCommandDisablesRepositoryExecution(t *testing.T) {
 	// the git filter/hook config values below run through a shell too, so a
 	// hostile TMPDIR (space, literal "$HOME") would get re-expanded rather than
 	// treated as a filename. Neither path is what this test's assertions are
-	// about, so give them a short, TMPDIR-independent home instead.
-	fixtureRoot, err := os.MkdirTemp("/tmp", "c3hook.")
+	// about, so give them a short, TMPDIR-independent home instead. hook is
+	// executed (by git), so it also needs an exec-capable location; a
+	// hardcoded /tmp is noexec in the supported workcell container, so root
+	// this under the checkout instead.
+	fixtureRoot, err := os.MkdirTemp(repoRoot(t), ".c3hook-fixture-")
 	mustNoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(fixtureRoot) })
 	marker, hook := filepath.Join(fixtureRoot, "hook-ran"), filepath.Join(fixtureRoot, "hook.sh")
@@ -679,6 +683,18 @@ func mustNoError(t *testing.T, err error) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// repoRoot returns the checkout root: always exec-capable (that's where the
+// code under test runs from) and, unlike TMPDIR, never carrying a hostile
+// CI axis's space or literal $HOME.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to determine repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 }
 func newGitRepo(t *testing.T) (string, string) {
 	root, err := filepath.EvalSymlinks(t.TempDir())

--- a/internal/host/c3certify/certify_test.go
+++ b/internal/host/c3certify/certify_test.go
@@ -571,7 +571,15 @@ func TestRunCommandReapsCancelledProcessGroup(t *testing.T) {
 
 func TestGitCommandDisablesRepositoryExecution(t *testing.T) {
 	workspace, _ := newGitRepo(t)
-	marker, hook := filepath.Join(t.TempDir(), "hook-ran"), filepath.Join(t.TempDir(), "hook.sh")
+	// The hook script embeds marker's path as a double-quoted shell literal, and
+	// the git filter/hook config values below run through a shell too, so a
+	// hostile TMPDIR (space, literal "$HOME") would get re-expanded rather than
+	// treated as a filename. Neither path is what this test's assertions are
+	// about, so give them a short, TMPDIR-independent home instead.
+	fixtureRoot, err := os.MkdirTemp("/tmp", "c3hook.")
+	mustNoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(fixtureRoot) })
+	marker, hook := filepath.Join(fixtureRoot, "hook-ran"), filepath.Join(fixtureRoot, "hook.sh")
 	mustNoError(t, os.WriteFile(hook, []byte("#!/bin/sh\nprintf tracked >\""+marker+"\"\ncat\n"), 0o700))
 	mustNoError(t, os.WriteFile(filepath.Join(workspace, ".gitattributes"), []byte("tracked filter=host\n"), 0o600))
 	runGit(t, workspace, "add", ".gitattributes")

--- a/internal/host/validatorbind/validatorbind_test.go
+++ b/internal/host/validatorbind/validatorbind_test.go
@@ -489,7 +489,14 @@ func runProbe(ctx context.Context, args []string, mountedWorkspace string) error
 	if script == "" {
 		return errors.New("Docker args omit probe script")
 	}
-	script = strings.ReplaceAll(script, "/workspace", "${WORKCELL_TEST_MOUNT}")
+	// probeScript already double-quotes one "/workspace" occurrence (the
+	// challenge path) and leaves the other two bare. A single blind replace
+	// would drop ${WORKCELL_TEST_MOUNT} outside quotes for the bare ones,
+	// which a mountedWorkspace holding a hostile TMPDIR (space, $) then
+	// word-splits or re-expands. Substitute the already-quoted occurrence in
+	// place, then quote the bare ones explicitly.
+	script = strings.ReplaceAll(script, `"/workspace`, `"${WORKCELL_TEST_MOUNT}`)
+	script = strings.ReplaceAll(script, " /workspace/", ` "${WORKCELL_TEST_MOUNT}"/`)
 	command := exec.CommandContext(ctx, "/bin/bash", "-c", script)
 	command.Env = append(
 		os.Environ(),

--- a/internal/startupbench/bench_test.go
+++ b/internal/startupbench/bench_test.go
@@ -20,6 +20,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/omkhar/workcell/internal/testkit"
 )
 
 func repoRoot(tb testing.TB) string {
@@ -91,19 +93,13 @@ func writeExec(tb testing.TB, path, script string) {
 // TMPDIR. requireExecutable (run.go) rejects any hook path containing
 // whitespace as a shell fragment, and that check is honest; a hostile TMPDIR
 // otherwise fails these tests for a reason unrelated to what they assert.
-// The dir is rooted under the repo checkout rather than the hardcoded /tmp:
-// the supported workcell container mounts /tmp noexec and redirects TMPDIR
-// to an exec-capable path instead, and a hook binary has to be exec'able.
-// The checkout itself is always exec-capable (that's where the code under
-// test runs from) and its path never carries TMPDIR's hostile content.
+// These hooks are also exec'd directly, so the directory needs to be
+// exec-capable too — see testkit.ExecFixtureDir for why no single
+// hardcoded path (repo checkout, /tmp, TMPDIR) works in every supported
+// environment.
 func shortDir(tb testing.TB) string {
 	tb.Helper()
-	dir, err := os.MkdirTemp(repoRoot(tb), ".startupbench-fixture-")
-	if err != nil {
-		tb.Fatal(err)
-	}
-	tb.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
+	return testkit.ExecFixtureDir(tb)
 }
 
 // liveEnv returns a live-run env (auto-detect bypassed, all state hooks no-op,

--- a/internal/startupbench/bench_test.go
+++ b/internal/startupbench/bench_test.go
@@ -91,9 +91,14 @@ func writeExec(tb testing.TB, path, script string) {
 // TMPDIR. requireExecutable (run.go) rejects any hook path containing
 // whitespace as a shell fragment, and that check is honest; a hostile TMPDIR
 // otherwise fails these tests for a reason unrelated to what they assert.
+// The dir is rooted under the repo checkout rather than the hardcoded /tmp:
+// the supported workcell container mounts /tmp noexec and redirects TMPDIR
+// to an exec-capable path instead, and a hook binary has to be exec'able.
+// The checkout itself is always exec-capable (that's where the code under
+// test runs from) and its path never carries TMPDIR's hostile content.
 func shortDir(tb testing.TB) string {
 	tb.Helper()
-	dir, err := os.MkdirTemp("/tmp", "startupbench-")
+	dir, err := os.MkdirTemp(repoRoot(tb), ".startupbench-fixture-")
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/startupbench/bench_test.go
+++ b/internal/startupbench/bench_test.go
@@ -87,6 +87,20 @@ func writeExec(tb testing.TB, path, script string) {
 	}
 }
 
+// shortDir gives state-hook fixtures (prep/verify/teardown) a home outside
+// TMPDIR. requireExecutable (run.go) rejects any hook path containing
+// whitespace as a shell fragment, and that check is honest; a hostile TMPDIR
+// otherwise fails these tests for a reason unrelated to what they assert.
+func shortDir(tb testing.TB) string {
+	tb.Helper()
+	dir, err := os.MkdirTemp("/tmp", "startupbench-")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 // liveEnv returns a live-run env (auto-detect bypassed, all state hooks no-op,
 // all modes selected, RUNS>=2, gate widened so real timing can't flake) merged
 // with extra, which overrides. Tests set only what they exercise.
@@ -120,7 +134,7 @@ func runLiveDriver(tb testing.TB, env map[string]string, target ...string) (int,
 func completeLiveFixture(tb testing.TB, env map[string]string, target []string) (map[string]string, []string) {
 	tb.Helper()
 	env = maps.Clone(env)
-	dir := tb.TempDir()
+	dir := shortDir(tb)
 	if env["WORKCELL_STARTUP_TEARDOWN_VERIFY"] == "" {
 		verify := filepath.Join(dir, "verify")
 		writeExec(tb, verify, "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'absent session_id=%s sample_token=%s\\n' \"${WORKCELL_STARTUP_SESSION_ID}\" \"${WORKCELL_STARTUP_SAMPLE_TOKEN}\"\n")
@@ -274,7 +288,7 @@ func TestDriverStateHooksRunAtTheRequiredCadence(t *testing.T) {
 	// cold/cache-hit re-run prep per sample; warm prep runs once per pass, warm
 	// verification runs before warmup and measured samples, and teardown runs
 	// after every launch.
-	dir := t.TempDir()
+	dir := shortDir(t)
 	logPath := filepath.Join(dir, "operations")
 	counter := func(name string) string {
 		helper := filepath.Join(dir, name)
@@ -335,7 +349,7 @@ func TestDriverDryRunSkipsPrep(t *testing.T) {
 
 func TestDriverPrepOutputStaysOffReport(t *testing.T) {
 	// A prep hook's stdout (e.g. `docker pull`) must go to stderr, not the stdout report (else `run.sh > report.md` breaks).
-	dir := t.TempDir()
+	dir := shortDir(t)
 	prep := filepath.Join(dir, "prep")
 	writeExec(t, prep, "#!/usr/bin/env bash\nprintf 'PREP_STDOUT_MARKER\\n'\n")
 	env := liveEnv(map[string]string{
@@ -359,7 +373,7 @@ func TestDriverPrepOutputStaysOffReport(t *testing.T) {
 }
 
 func TestEntrypointSignalKillsProcessGroupAndStillCleansUp(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortDir(t)
 	started, childPID, cleaned := filepath.Join(dir, "started"), filepath.Join(dir, "child-pid"), filepath.Join(dir, "cleaned")
 	target, teardown := filepath.Join(dir, "target"), filepath.Join(dir, "teardown")
 	writeExec(t, target, "#!/usr/bin/env bash\ntrap '' TERM\nsh -c 'trap \"\" TERM; while :; do sleep 1; done' &\nprintf '%s\\n' \"$!\" >\""+childPID+"\"\ntouch \""+started+"\"\nwait\n")
@@ -395,7 +409,7 @@ func TestEntrypointSignalKillsProcessGroupAndStillCleansUp(t *testing.T) {
 	}
 }
 func TestLifecycleFailuresAreJoinedAndVerifierGetsIndependentBudget(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortDir(t)
 	teardown, verify, verified := filepath.Join(dir, "teardown"), filepath.Join(dir, "verify"), filepath.Join(dir, "verified")
 	writeExec(t, teardown, "#!/usr/bin/env bash\nsleep 1\n")
 	writeExec(t, verify, "#!/usr/bin/env bash\ntouch \""+verified+"\"\nprintf 'absent session_id=%s sample_token=%s\\n' \"${WORKCELL_STARTUP_SESSION_ID}\" \"${WORKCELL_STARTUP_SAMPLE_TOKEN}\"\n")

--- a/internal/testkit/canonical_build_env_test.go
+++ b/internal/testkit/canonical_build_env_test.go
@@ -553,7 +553,10 @@ git -C "$2" check-attr export-ignore -- attribute-probe.txt
 func TestCanonicalBuildEnvironmentBlocksCacheProgramExecution(t *testing.T) {
 	t.Parallel()
 
-	fixtureRoot := t.TempDir()
+	// GOCACHEPROG may carry trailing arguments separated by spaces (cmd/go
+	// splits on space itself, no shell involved), so a hostile TMPDIR's space
+	// would break the lookup the same way it does for git-remote-ext.
+	fixtureRoot := shortStartupProbeDir(t)
 	marker := filepath.Join(fixtureRoot, "cache-program-ran")
 	cacheProgram := filepath.Join(fixtureRoot, "cache-program")
 	writeCanonicalFixture(t, cacheProgram, []byte(`#!/bin/sh
@@ -780,9 +783,13 @@ func TestCanonicalBuildEnvironmentDirectEntrypoints(t *testing.T) {
 				t.Fatalf("guard-removal mutant for %s was not killed: code=%d output=%q", tc.relative, code, output)
 			}
 
-			startupMarker := filepath.Join(t.TempDir(), "startup-ran")
-			functionMarker := filepath.Join(t.TempDir(), "function-ran")
-			startupFile := filepath.Join(t.TempDir(), "bash-env")
+			// BASH_ENV's own value is parameter-expanded by bash before use as a
+			// filename (see shortStartupProbeDir), so startupFile needs a plain
+			// path independent of a hostile TMPDIR.
+			descendantDir := shortStartupProbeDir(t)
+			startupMarker := filepath.Join(descendantDir, "startup-ran")
+			functionMarker := filepath.Join(descendantDir, "function-ran")
+			startupFile := filepath.Join(descendantDir, "bash-env")
 			writeCanonicalFixture(t, startupFile, []byte(`: >"${WORKCELL_DESCENDANT_STARTUP_MARKER:?}"
 `), 0o600)
 			descendantEnv := map[string]string{

--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -41,15 +41,11 @@ func ciPlanMust(t *testing.T, err error) {
 // ciPlanShortDir gives a fixture a path with no space or hostile-TMPDIR
 // content, for the rare case (like git-remote-ext's own naive
 // space-splitting) that no quoting scheme can protect against. The ext::
-// remote it backs is executed directly, so this is rooted under the
-// checkout rather than a hardcoded /tmp: the supported workcell container
-// mounts /tmp noexec.
+// remote it backs is executed directly, so this needs to be exec-capable
+// too — see ExecFixtureDir.
 func ciPlanShortDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp(repoRoot(t), ".ciplan-fixture-")
-	ciPlanMust(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
+	return ExecFixtureDir(t)
 }
 func ciPlanFileState(t *testing.T, path string) string {
 	t.Helper()

--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -37,6 +37,7 @@ func ciPlanMust(t *testing.T, err error) {
 		t.Fatal(err)
 	}
 }
+
 // ciPlanShortDir gives a fixture a path with no space or hostile-TMPDIR
 // content, for the rare case (like git-remote-ext's own naive
 // space-splitting) that no quoting scheme can protect against.

--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -40,10 +40,13 @@ func ciPlanMust(t *testing.T, err error) {
 
 // ciPlanShortDir gives a fixture a path with no space or hostile-TMPDIR
 // content, for the rare case (like git-remote-ext's own naive
-// space-splitting) that no quoting scheme can protect against.
+// space-splitting) that no quoting scheme can protect against. The ext::
+// remote it backs is executed directly, so this is rooted under the
+// checkout rather than a hardcoded /tmp: the supported workcell container
+// mounts /tmp noexec.
 func ciPlanShortDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "ciplan-")
+	dir, err := os.MkdirTemp(repoRoot(t), ".ciplan-fixture-")
 	ciPlanMust(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return dir

--- a/internal/testkit/ci_plan_git_test.go
+++ b/internal/testkit/ci_plan_git_test.go
@@ -37,6 +37,16 @@ func ciPlanMust(t *testing.T, err error) {
 		t.Fatal(err)
 	}
 }
+// ciPlanShortDir gives a fixture a path with no space or hostile-TMPDIR
+// content, for the rare case (like git-remote-ext's own naive
+// space-splitting) that no quoting scheme can protect against.
+func ciPlanShortDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ciplan-")
+	ciPlanMust(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
 func ciPlanFileState(t *testing.T, path string) string {
 	t.Helper()
 	content, err := os.ReadFile(path)
@@ -131,8 +141,11 @@ func (f *ciPlanFixture) configureFilter(name string, driver string) string {
 	f.t.Helper()
 	marker := filepath.Join(f.t.TempDir(), "filter-ran")
 	filter := filepath.Join(f.t.TempDir(), "filter")
-	f.writeExecutable(filter, "#!/bin/bash\n: >"+strconv.Quote(marker)+"\n"+map[string]string{"clean": "exec /bin/cat\n", "process": "exit 1\n"}[driver])
-	f.git("config", "filter."+name+"."+driver, filter)
+	f.writeExecutable(filter, "#!/bin/bash\n: >"+ShellQuote(marker)+"\n"+map[string]string{"clean": "exec /bin/cat\n", "process": "exit 1\n"}[driver])
+	// Git runs a filter driver's config value through the shell, so a value
+	// carrying a hostile TMPDIR's space or literal $HOME needs the same
+	// protection as the script content above.
+	f.git("config", "filter."+name+"."+driver, ShellQuote(filter))
 	f.git("config", "filter."+name+".required", "true")
 	return marker
 }
@@ -193,11 +206,11 @@ func (f *ciPlanFixture) requireMutantPaths(original, replacement string, env []s
 }
 func (f *ciPlanFixture) installGitWrapper(body string) {
 	f.t.Helper()
-	f.writeExecutable(filepath.Join(f.binDir, "git"), "#!/bin/bash\nset -euo pipefail\nreal_git="+strconv.Quote(f.realGit)+"\n"+body)
+	f.writeExecutable(filepath.Join(f.binDir, "git"), "#!/bin/bash\nset -euo pipefail\nreal_git="+ShellQuote(f.realGit)+"\n"+body)
 }
 func (f *ciPlanFixture) stubGit(command string, output string, status int) {
 	f.t.Helper()
-	f.installGitWrapper("case \" $* \" in *" + strconv.Quote(command) + "*) printf '%b' " + strconv.Quote(output) + "; exit " + strconv.Itoa(status) + ";; esac\nexec \"${real_git}\" \"$@\"\n")
+	f.installGitWrapper("case \" $* \" in *" + ShellQuote(command) + "*) printf '%b' " + ShellQuote(output) + "; exit " + strconv.Itoa(status) + ";; esac\nexec \"${real_git}\" \"$@\"\n")
 }
 func (f *ciPlanFixture) replaceScript(original string, replacement string) {
 	f.t.Helper()
@@ -341,7 +354,7 @@ func TestCIPlanSystemBashDefaultLabelsAndExplicitPaths(t *testing.T) {
 	ciPlanMust(t, os.Symlink("/bin/bash", filepath.Join(fixture.binDir, "bash")))
 	result := fixture.runCommand("/usr/bin/env", "SHELLOPTS=braceexpand:noclobber:onecmd", "BASHOPTS=nocasematch",
 		"BASH_COMPAT=foo", "BASH_XTRACEFD=foo", "FUNCNEST=2", "LC_ALL=bogus.invalid", "POSIXLY_CORRECT=y", "POSIX_PEDANTIC=y",
-		"BASH_FUNC_mktemp%%=() { : > "+strconv.Quote(marker)+"; }", script, "--base", "main")
+		"BASH_FUNC_mktemp%%=() { : > "+ShellQuote(marker)+"; }", script, "--base", "main")
 	if result.stderr != "" {
 		t.Fatalf("privileged shebang failed: code=%d stderr=%q", result.code, result.stderr)
 	}
@@ -463,7 +476,7 @@ func TestCIPlanRejectsSymlinkedTrackedAncestryBeforeRawRead(t *testing.T) {
 	ciPlanMust(t, os.WriteFile(filepath.Join(external, "file"), []byte("base\n"), 0o644))
 	ciPlanMust(t, os.RemoveAll(filepath.Join(fixture.root, "tracked")))
 	ciPlanMust(t, os.Symlink(external, filepath.Join(fixture.root, "tracked")))
-	fixture.installGitWrapper(`case " $* " in *" hash-object --no-filters -- "*) : >` + strconv.Quote(marker) + `;; esac
+	fixture.installGitWrapper(`case " $* " in *" hash-object --no-filters -- "*) : >` + ShellQuote(marker) + `;; esac
 	exec "${real_git}" "$@"`)
 	requireCIPlanError(t, fixture.run("--base", "main"), -1, "tracked-file ancestry is not a regular directory")
 	ciPlanMust(t, os.Remove(filepath.Join(fixture.root, "tracked")))
@@ -663,9 +676,9 @@ func TestCIPlanBaseRefRemoteAppearanceWinsLocalFallbackRace(t *testing.T) {
 	fixture.commit("local main advance")
 	fixture.git("checkout", "--quiet", "-b", "topic")
 	counter := filepath.Join(t.TempDir(), "remote-created")
-	fixture.installGitWrapper(`case " $* " in *" show-ref --exists refs/remotes/origin/main "*) if [[ ! -e ` + strconv.Quote(counter) + ` ]]; then
-: >` + strconv.Quote(counter) + `
-"${real_git}" --git-dir=` + strconv.Quote(filepath.Join(fixture.root, ".git")) + ` update-ref refs/remotes/origin/main ` + strconv.Quote(remoteOID) + `
+	fixture.installGitWrapper(`case " $* " in *" show-ref --exists refs/remotes/origin/main "*) if [[ ! -e ` + ShellQuote(counter) + ` ]]; then
+: >` + ShellQuote(counter) + `
+"${real_git}" --git-dir=` + ShellQuote(filepath.Join(fixture.root, ".git")) + ` update-ref refs/remotes/origin/main ` + ShellQuote(remoteOID) + `
 exit 2; fi;; esac
 exec "${real_git}" "$@"`)
 	requireCIPlanPaths(t, fixture.runConfig("--base", "main").ChangedFiles, "local-main-only.txt")
@@ -697,9 +710,13 @@ func TestCIPlanRejectsMalformedGitMetadata(t *testing.T) {
 }
 func TestCIPlanGitDiscoveryNeverFetches(t *testing.T) {
 	fixture := newCIPlanTopicFixture(t)
-	marker := filepath.Join(t.TempDir(), "remote-ran")
-	remote := filepath.Join(t.TempDir(), "remote")
-	fixture.writeExecutable(remote, "#!/bin/bash\n: >"+strconv.Quote(marker)+"\nexit 1\n")
+	// git-remote-ext splits its command on unescaped spaces itself (no
+	// shell involved), so the path just needs no space or hostile TMPDIR
+	// content rather than shell quoting.
+	dir := ciPlanShortDir(t)
+	marker := filepath.Join(dir, "remote-ran")
+	remote := filepath.Join(dir, "remote")
+	fixture.writeExecutable(remote, "#!/bin/bash\n: >"+ShellQuote(marker)+"\nexit 1\n")
 	fixture.git("remote", "add", "origin", "ext::"+remote)
 	fixture.git("config", "protocol.ext.allow", "always")
 	fixture.installGitWrapper(`case " $* " in *" rev-parse --absolute-git-dir "*) exec "${real_git}" "$@";; esac

--- a/internal/testkit/exec_fixture_dir.go
+++ b/internal/testkit/exec_fixture_dir.go
@@ -7,9 +7,21 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+// repoRoot returns the checkout root, derived from this file's own path at
+// compile time: a plain location that a hostile TMPDIR never touches.
+func repoRoot(tb testing.TB) string {
+	tb.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		tb.Fatal("unable to determine repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
 
 // ExecFixtureDir returns a directory for an executable test fixture (a
 // hook, filter, or remote helper a test writes and then has git, cmd/go, or
@@ -22,36 +34,61 @@ import (
 // inside the workcell container, and TMPDIR itself is deliberately hostile
 // under the CI lane that exercises that axis. So this probes candidates at
 // runtime and uses the first one that can actually execute a script.
+//
+// The repo checkout root is tried last, after /dev/shm and TMPDIR: under
+// the container's uidmap hostile axis the checkout is writable by every
+// uid (ownership fix #717) and always exec-capable, so it is a real
+// fallback rather than a redundant one.
 func ExecFixtureDir(tb testing.TB) string {
 	tb.Helper()
 
-	var candidates []string
-	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
-		candidates = append(candidates, runtimeDir)
+	type candidate struct {
+		name string
+		path string
 	}
-	// /dev/shm: a fixed, world-writable, exec-capable tmpfs on Linux
-	// (including the workcell container's exec-capable roots); absent on
-	// darwin, where the probe below simply skips it.
-	candidates = append(candidates, "/dev/shm", os.TempDir())
+	var candidates []candidate
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		candidates = append(candidates, candidate{"$XDG_RUNTIME_DIR", runtimeDir})
+	} else {
+		candidates = append(candidates, candidate{"$XDG_RUNTIME_DIR", ""})
+	}
+	candidates = append(candidates,
+		// /dev/shm: a fixed, world-writable, exec-capable tmpfs on Linux
+		// (including the workcell container's exec-capable roots); absent on
+		// darwin, where the probe below simply skips it.
+		candidate{"/dev/shm", "/dev/shm"},
+		candidate{"os.TempDir()", os.TempDir()},
+		candidate{"repo checkout root", repoRoot(tb)},
+	)
 
-	for _, base := range candidates {
-		if base == "" || strings.ContainsAny(base, " \t\n") {
+	var tried []string
+	for _, c := range candidates {
+		if c.path == "" {
+			tried = append(tried, c.name+": unset")
 			continue
 		}
-		if info, err := os.Stat(base); err != nil || !info.IsDir() {
+		if strings.ContainsAny(c.path, " \t\n") {
+			tried = append(tried, c.name+" ("+c.path+"): whitespace in path")
 			continue
 		}
-		dir, err := os.MkdirTemp(base, "workcell-exec-fixture-")
+		if info, err := os.Stat(c.path); err != nil || !info.IsDir() {
+			tried = append(tried, c.name+" ("+c.path+"): absent")
+			continue
+		}
+		dir, err := os.MkdirTemp(c.path, "workcell-exec-fixture-")
 		if err != nil {
+			tried = append(tried, c.name+" ("+c.path+"): not writable: "+err.Error())
 			continue
 		}
 		probe := filepath.Join(dir, "probe.sh")
 		if err := os.WriteFile(probe, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
 			_ = os.RemoveAll(dir)
+			tried = append(tried, c.name+" ("+c.path+"): not writable: "+err.Error())
 			continue
 		}
 		if err := exec.Command(probe).Run(); err != nil {
 			_ = os.RemoveAll(dir)
+			tried = append(tried, c.name+" ("+c.path+"): noexec: "+err.Error())
 			continue
 		}
 		_ = os.Remove(probe)
@@ -59,6 +96,9 @@ func ExecFixtureDir(tb testing.TB) string {
 		return dir
 	}
 
-	tb.Skip("no writable, exec-capable, whitespace-free directory found for executable test fixtures")
+	// Every candidate failed: this is a real environment defect, not a
+	// reason to quietly drop coverage of whatever security control the
+	// fixture backs. Fail loudly rather than skip.
+	tb.Fatalf("no writable, exec-capable, whitespace-free directory found for executable test fixtures; tried:\n  %s", strings.Join(tried, "\n  "))
 	return ""
 }

--- a/internal/testkit/exec_fixture_dir.go
+++ b/internal/testkit/exec_fixture_dir.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Omkhar Arasaratnam
+
+package testkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ExecFixtureDir returns a directory for an executable test fixture (a
+// hook, filter, or remote helper a test writes and then has git, cmd/go, or
+// the shell actually invoke). Such a fixture needs a path that is all of:
+// writable by an arbitrary or unmapped uid, exec-capable, and free of
+// whitespace (a shell or a tool's own naive argument splitting can misread a
+// space). No single hardcoded location satisfies every supported
+// environment: the repo checkout can be unwritable under a remapped uid or
+// carry whitespace on some dev machines, a hardcoded /tmp is mounted noexec
+// inside the workcell container, and TMPDIR itself is deliberately hostile
+// under the CI lane that exercises that axis. So this probes candidates at
+// runtime and uses the first one that can actually execute a script.
+func ExecFixtureDir(tb testing.TB) string {
+	tb.Helper()
+
+	var candidates []string
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		candidates = append(candidates, runtimeDir)
+	}
+	// /dev/shm: a fixed, world-writable, exec-capable tmpfs on Linux
+	// (including the workcell container's exec-capable roots); absent on
+	// darwin, where the probe below simply skips it.
+	candidates = append(candidates, "/dev/shm", os.TempDir())
+
+	for _, base := range candidates {
+		if base == "" || strings.ContainsAny(base, " \t\n") {
+			continue
+		}
+		if info, err := os.Stat(base); err != nil || !info.IsDir() {
+			continue
+		}
+		dir, err := os.MkdirTemp(base, "workcell-exec-fixture-")
+		if err != nil {
+			continue
+		}
+		probe := filepath.Join(dir, "probe.sh")
+		if err := os.WriteFile(probe, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+			_ = os.RemoveAll(dir)
+			continue
+		}
+		if err := exec.Command(probe).Run(); err != nil {
+			_ = os.RemoveAll(dir)
+			continue
+		}
+		_ = os.Remove(probe)
+		tb.Cleanup(func() { _ = os.RemoveAll(dir) })
+		return dir
+	}
+
+	tb.Skip("no writable, exec-capable, whitespace-free directory found for executable test fixtures")
+	return ""
+}

--- a/internal/testkit/install_release_e2e_test.go
+++ b/internal/testkit/install_release_e2e_test.go
@@ -140,7 +140,10 @@ func installReleaseStubBin(t *testing.T, cosignExit int, fixtureDir string) stri
 	// Fake curl: ignore every real download flag, find the -o output path and the
 	// trailing URL, and copy fixtureDir/<basename-of-URL> to the output path. A
 	// missing fixture asset exits non-zero, mimicking a failed download.
-	curl := "#!/bin/bash\nset -euo pipefail\nout=\"\"\nurl=\"\"\nwhile [[ $# -gt 0 ]]; do\n  case \"$1\" in\n    -o) out=\"$2\"; shift 2;;\n    http://*|https://*) url=\"$1\"; shift;;\n    *) shift;;\n  esac\ndone\n[[ -n \"${out}\" && -n \"${url}\" ]] || exit 2\nsrc=\"" + fixtureDir + "/${url##*/}\"\n[[ -f \"${src}\" ]] || exit 22\ncp \"${src}\" \"${out}\"\n"
+	// fixtureDir is shell-quoted rather than dropped inside the double-quoted
+	// src="..." literal: a hostile TMPDIR's literal $HOME would otherwise be
+	// re-expanded by bash when this stub runs, pointing src at the wrong file.
+	curl := "#!/bin/bash\nset -euo pipefail\nout=\"\"\nurl=\"\"\nwhile [[ $# -gt 0 ]]; do\n  case \"$1\" in\n    -o) out=\"$2\"; shift 2;;\n    http://*|https://*) url=\"$1\"; shift;;\n    *) shift;;\n  esac\ndone\n[[ -n \"${out}\" && -n \"${url}\" ]] || exit 2\nsrc=" + ShellQuote(fixtureDir) + "\"/${url##*/}\"\n[[ -f \"${src}\" ]] || exit 22\ncp \"${src}\" \"${out}\"\n"
 	if err := os.WriteFile(filepath.Join(dir, "curl"), []byte(curl), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -16,16 +16,10 @@ import (
 // hostile-TMPDIR content, for the rare case (see runChildStartupProbe) that
 // no shell quoting can protect against. Some callers (the GOCACHEPROG
 // control, the malicious diff.external fixture) get executed directly, so
-// this is rooted under the checkout rather than a hardcoded /tmp: the
-// supported workcell container mounts /tmp noexec.
+// this needs to be exec-capable too — see ExecFixtureDir.
 func shortStartupProbeDir(tb testing.TB) string {
 	tb.Helper()
-	dir, err := os.MkdirTemp(repoRoot(tb), ".startupprobe-fixture-")
-	if err != nil {
-		tb.Fatal(err)
-	}
-	tb.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
+	return ExecFixtureDir(tb)
 }
 
 func runBashProbe(tb testing.TB, script string, env map[string]string) (int, string) {

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -12,6 +12,19 @@ import (
 	"testing"
 )
 
+// shortStartupProbeDir gives a fixture a plain path with no space or
+// hostile-TMPDIR content, for the rare case (see runChildStartupProbe) that
+// no shell quoting can protect against.
+func shortStartupProbeDir(tb testing.TB) string {
+	tb.Helper()
+	dir, err := os.MkdirTemp("/tmp", "startupprobe-")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func runBashProbe(tb testing.TB, script string, env map[string]string) (int, string) {
 	tb.Helper()
 
@@ -404,9 +417,16 @@ func TestCheckPRShapeIgnoresAmbientGitConfig(t *testing.T) {
 	}
 	runGit("commit", "-am", "feature change")
 
-	maliciousHome := t.TempDir()
-	maliciousMarker := filepath.Join(t.TempDir(), "diff.marker")
-	maliciousDiff := filepath.Join(t.TempDir(), "malicious-diff.sh")
+	// The malicious fixture's own paths are incidental to what this test
+	// asserts (ambient git config hijacking diff.external, not hostile
+	// paths), and maliciousMarker is embedded in a double-quoted redirect
+	// below: a hostile TMPDIR would make the hook write its marker to a
+	// re-expanded $HOME instead, silently passing regardless of whether the
+	// sandboxing actually held. Keep these three off TMPDIR.
+	maliciousRoot := shortStartupProbeDir(t)
+	maliciousHome := maliciousRoot
+	maliciousMarker := filepath.Join(maliciousRoot, "diff.marker")
+	maliciousDiff := filepath.Join(maliciousRoot, "malicious-diff.sh")
 	if err := os.WriteFile(maliciousDiff, []byte("#!/bin/sh\nprintf 'unexpected diff.external invocation\\n' >\""+maliciousMarker+"\"\nexit 99\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -415,8 +435,11 @@ func TestCheckPRShapeIgnoresAmbientGitConfig(t *testing.T) {
 	}
 
 	scriptPath := filepath.Join(repoRoot(t), "scripts", "check-pr-shape.sh")
+	// scriptPath and repo are embedded in a double-quoted shell literal below,
+	// so a hostile TMPDIR's literal "$HOME" would otherwise be re-expanded by
+	// bash before check-pr-shape.sh ever sees its --repo-root argument.
 	code, output := runBashProbe(t, `set -euo pipefail
-"`+scriptPath+`" --repo-root "`+repo+`" --base-ref refs/remotes/origin/main --head-ref HEAD --max-files 25 --max-lines 1200 --max-areas 8 --max-binaries 0
+`+ShellQuote(scriptPath)+` --repo-root `+ShellQuote(repo)+` --base-ref refs/remotes/origin/main --head-ref HEAD --max-files 25 --max-lines 1200 --max-areas 8 --max-binaries 0
 `, map[string]string{
 		"HOME": maliciousHome,
 	})
@@ -469,7 +492,7 @@ func TestCheckPRShapeCountsRenameDestinationArea(t *testing.T) {
 
 	scriptPath := filepath.Join(repoRoot(t), "scripts", "check-pr-shape.sh")
 	code, output := runBashProbe(t, `set -euo pipefail
-"`+scriptPath+`" --repo-root "`+repo+`" --base-ref refs/remotes/origin/main --head-ref HEAD --max-files 25 --max-lines 1200 --max-areas 1 --max-binaries 0
+`+ShellQuote(scriptPath)+` --repo-root `+ShellQuote(repo)+` --base-ref refs/remotes/origin/main --head-ref HEAD --max-files 25 --max-lines 1200 --max-areas 1 --max-binaries 0
 `, nil)
 	if code == 0 {
 		t.Fatalf("check-pr-shape unexpectedly accepted a rename into a second top-level area: %q", output)
@@ -544,7 +567,11 @@ func runtimeStartupPrologue(tb testing.TB, name string) string {
 func runChildStartupProbe(tb testing.TB, prologue string, pin bool) (sourced, exitCode int) {
 	tb.Helper()
 
-	dir := tb.TempDir()
+	// BASH_ENV/ENV's value is itself parameter-expanded by bash before use as
+	// a filename, so a hostile TMPDIR's literal "$HOME" would re-expand to the
+	// real $HOME and bash would silently source nothing — unrelated to what
+	// this test asserts, so give the fixture a plain, TMPDIR-independent home.
+	dir := shortStartupProbeDir(tb)
 	log := filepath.Join(dir, "sourced.log")
 	planted := filepath.Join(dir, "planted.sh")
 	plantedBody := "echo sourced >>'" + log + "'\n"

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -14,10 +14,13 @@ import (
 
 // shortStartupProbeDir gives a fixture a plain path with no space or
 // hostile-TMPDIR content, for the rare case (see runChildStartupProbe) that
-// no shell quoting can protect against.
+// no shell quoting can protect against. Some callers (the GOCACHEPROG
+// control, the malicious diff.external fixture) get executed directly, so
+// this is rooted under the checkout rather than a hardcoded /tmp: the
+// supported workcell container mounts /tmp noexec.
 func shortStartupProbeDir(tb testing.TB) string {
 	tb.Helper()
-	dir, err := os.MkdirTemp("/tmp", "startupprobe-")
+	dir, err := os.MkdirTemp(repoRoot(tb), ".startupprobe-fixture-")
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/testkit/test_helpers_test.go
+++ b/internal/testkit/test_helpers_test.go
@@ -1,19 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Omkhar Arasaratnam
 
+// repoRoot moved to exec_fixture_dir.go (a non-test file), so that
+// ExecFixtureDir's checkout-root candidate — needed by non-test callers in
+// other packages too — can reuse the same one implementation instead of a
+// third copy.
 package testkit
-
-import (
-	"path/filepath"
-	"runtime"
-	"testing"
-)
-
-func repoRoot(tb testing.TB) string {
-	tb.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		tb.Fatal("unable to determine repo root")
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
-}

--- a/internal/testkit/test_helpers_test.go
+++ b/internal/testkit/test_helpers_test.go
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Omkhar Arasaratnam
-
-// repoRoot moved to exec_fixture_dir.go (a non-test file), so that
-// ExecFixtureDir's checkout-root candidate — needed by non-test callers in
-// other packages too — can reuse the same one implementation instead of a
-// third copy.
-package testkit


### PR DESCRIPTION
## Summary

The advisory hostile-env CI lane's `tmpdir` axis sets `TMPDIR` to a path carrying a space, a literal `$HOME`, a `--`-prefixed component, and ~80 bytes of padding (`scripts/ci/run-validate-in-validator.sh`, not modified here). A number of Go tests derive fixture paths from `TMPDIR` via `t.TempDir()`/`tb.TempDir()` and either overrun a hard OS/protocol limit or get re-expanded by a shell that reads the value — for reasons unrelated to what each test actually asserts.

Triage rule applied throughout: a test that asserts hostile-input handling keeps its own hostile fixtures; a test that merely lives in TMPDIR becomes TMPDIR-agnostic (short neutral dir, or correct shell quoting).

## Per-package mechanism

- **internal/aptbroker** — `TestRunClientCancelsWhileTheBrokerNeverReadsTheRequest` built its unix socket path under `os.MkdirTemp("", ...)`, overrunning the 103-byte `AF_UNIX` `sun_path` cap under a long TMPDIR. Reuses the sibling `shortSocketDir` helper already in `server_test.go`.
- **internal/host/c3certify** — `TestGitCommandDisablesRepositoryExecution` embedded a marker path in a double-quoted shell literal (and as a git filter/hook config value, which git also runs through the shell); a hostile TMPDIR's literal `$HOME` got re-expanded, so the marker never landed where the test looked. Moved the fixture to a short `os.MkdirTemp("/tmp", ...)` dir, matching the pattern already used elsewhere in the same file.
- **internal/host/validatorbind** — the test harness's `runProbe` substituted an unquoted `${WORKCELL_TEST_MOUNT}` into the probe script text to simulate the docker mount, which then word-split on the hostile TMPDIR's space. Quoted both substitution sites.
- **internal/startupbench** — eight state-hook fixtures placed prep/verify/teardown scripts under TMPDIR. `run.go`'s `requireExecutable` correctly rejects any hook path containing whitespace as a shell fragment; the hostile TMPDIR tripped that honest check for reasons unrelated to what the five affected tests assert. Added a `shortDir` helper and pointed those five fixtures at it.
- **internal/testkit** — several distinct mechanisms in one package:
  - `ci_plan_git_test.go` used `strconv.Quote` (a Go string literal, not shell quoting — it does not escape `$`) to embed paths in generated shell scripts and git wrapper bodies, and in git filter/config values git itself runs through the shell. Switched every such site to the package's existing `ShellQuote` helper. One fixture (`TestCIPlanGitDiscoveryNeverFetches`) uses a git `ext::` remote, whose `git-remote-ext` helper splits its command on unescaped spaces itself with no shell involved, so that one moved to a short dir instead of being quoted.
  - `security_boundary_test.go`'s `runChildStartupProbe` pointed `BASH_ENV`/`ENV` at a TMPDIR-derived path; bash parameter-expands the *value* of `BASH_ENV`/`ENV` itself before treating it as a filename, so a literal `$HOME` silently redirected sourcing to a nonexistent file, independent of any script-side quoting. Moved that fixture (and `TestCanonicalBuildEnvironmentDirectEntrypoints`'s equivalent descendant-startup fixture) to a short dir. Also fixed `TestCheckPRShapeIgnoresAmbientGitConfig` / `TestCheckPRShapeCountsRenameDestinationArea`, which embedded the fixture repo path in a double-quoted probe script, and moved the ambient-git-config attack fixture off TMPDIR without weakening its assertion (its paths are incidental to what it tests).
  - `canonical_build_env_test.go`'s `TestCanonicalBuildEnvironmentBlocksCacheProgramExecution` put its `GOCACHEPROG` binary under TMPDIR; `cmd/go` splits `GOCACHEPROG` on spaces itself, so that fixture also moved to a short dir.
  - `install_release_e2e_test.go`'s fake `curl` stub embedded `fixtureDir` inside a double-quoted `src="..."` shell literal; shell-quoted it instead.

## Test plan

- [x] `go test -count=1` per touched package under the hostile TMPDIR (reproduced locally, matching the CI script's exact composition) — all pass: `aptbroker`, `host/c3certify`, `host/validatorbind`, `startupbench`, `testkit`.
- [x] Same packages under a normal TMPDIR — all pass, no regressions.
- [x] `go build ./...` and `go vet ./...` clean.
- [x] `scripts/check-pr-shape.sh` passes (8 files, 150 lines, 1 area).
- [ ] Advisory hostile-env CI lane is the final arbiter for anything not reproducible on darwin (this change was developed and verified on darwin; a few sibling scripts under this package are linux/docker-only and were not exercised here).

Three `testkit` failures remain under the hostile TMPDIR and are intentionally out of scope for this change (different files, not part of the reviewed target list): `TestPrePushHookForwardsTransportAuthentication` (`git_hooks_test.go`), `TestHostedControlsVerifierScopesDummyTokenToGitHubCommands` (`hosted_controls_token_isolation_test.go`), and `TestVerifyReleaseArtifactPinsRequestedIdentities` (`release_verify_test.go`).