### PR TITLE
Document the descriptor path a snapshotted script sees as $0

### DIFF
--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -225,6 +225,14 @@ this layer does not inspect. The container and VM boundaries stay in force. Use
 [Expected Controls](../verify/invariants/expected-controls.md) for the exact
 enforcement scope.
 
+On the strict path, the guard runs a script from a sealed copy of its bytes.
+The kernel gives the interpreter the name of that copy. Thus a script in
+`/workspace`, `/state`, or `/tmp` sees `$0` as `/dev/fd/<number>` or
+`/proc/self/fd/<number>`. A script that finds a sibling file from `$0` does not
+find it. Give the script an absolute path or an explicit argument for a
+sibling file. The guard does not copy a file under an immutable path such as
+`/usr/local/bin`.
+
 ## Detached Sessions
 
 The host owns detached session state. The operator can start, attach, send

--- a/docs/workcell-system-design.md
+++ b/docs/workcell-system-design.md
@@ -227,11 +227,14 @@ enforcement scope.
 
 On the strict path, the guard runs a script from a sealed copy of its bytes.
 The kernel gives the interpreter the name of that copy. Thus a script in
-`/workspace`, `/state`, or `/tmp` sees `$0` as `/dev/fd/<number>` or
+`/workspace` or `/state` sees `$0` as `/dev/fd/<number>` or
 `/proc/self/fd/<number>`. A script that finds a sibling file from `$0` does not
 find it. Give the script an absolute path or an explicit argument for a
 sibling file. The guard does not copy a file under an immutable path such as
 `/usr/local/bin`.
+
+The profile mounts `/tmp` `noexec`. The guard refuses a script run directly
+from `/tmp`. The guard does not copy such a script first.
 
 ## Detached Sessions
 

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -2452,7 +2452,11 @@ fn fd_exec_path(fd: c_int) -> Option<CString> {
 }
 
 /// Executes the prepared descriptor itself, so the bytes that run are the bytes
-/// the guard classified.
+/// the guard classified. The kernel names the descriptor, not the original
+/// path, to a shebang interpreter, so the script observes that /dev/fd or
+/// /proc/self/fd name as $0; re-exposing the original pathname would hand the
+/// interpreter a name to resolve a second time, reopening the exec-time race
+/// the snapshot closes.
 #[cfg(target_os = "linux")]
 fn execute_snapshot_execveat(
     fd: c_int,
@@ -2487,7 +2491,9 @@ fn execute_snapshot_execveat(
 /// The `execvp` family form. glibc answers `ENOEXEC` by running `/bin/sh` on
 /// the target, from inside libc and without re-entering this guard, so the
 /// guard has to perform that fallback itself once it is executing a descriptor
-/// rather than a name.
+/// rather than a name. The shell's argv[1] is built from that same descriptor's
+/// proc path, so a shebang script run through this fallback likewise observes
+/// its /proc/self/fd name as $0, not the path the guard classified.
 #[cfg(target_os = "linux")]
 fn execute_snapshot_execveat_with_shell_fallback(
     fd: c_int,
@@ -5212,6 +5218,89 @@ mod tests {
                 &[]
             ),
             None
+        );
+
+        fs::remove_dir_all(&dir).expect("cleanup temp test dir");
+    }
+
+    /// Documents the consequence in `execute_prepared_spawn`: the descriptor
+    /// is served under its `/proc/self/fd` name, so the kernel's own shebang
+    /// handling hands that name to the interpreter as the script's `$0`. Gated
+    /// on `current_mode_blocks_mutable_native_exec`, which fails closed to
+    /// true off-container, so this runs on the ordinary test lane.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_snapshotted_script_sees_its_descriptor_path_as_argv_zero() {
+        if !current_mode_blocks_mutable_native_exec() {
+            println!("skipping: this lane does not block mutable native exec");
+            return;
+        }
+        if !Path::new("/bin/sh").exists() {
+            println!("skipping: this runtime has no /bin/sh");
+            return;
+        }
+
+        let dir = create_temp_test_dir("argv0-descriptor-path");
+        let script = dir.join("script");
+        let output = dir.join("output");
+        fs::write(
+            &script,
+            format!("#!/bin/sh\nprintf '%s' \"$0\" >{}\n", output.display()),
+        )
+        .expect("write script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("chmod script");
+
+        let arg0 = CString::new(script.as_os_str().as_bytes()).expect("script path");
+        let argv: [*const c_char; 2] = [arg0.as_ptr(), std::ptr::null()];
+        let envp: [*const c_char; 1] = [std::ptr::null()];
+
+        let mut pid: pid_t = 0;
+        let result = execute_prepared_spawn(
+            script.to_str().expect("script path"),
+            &mut pid,
+            std::ptr::null(),
+            std::ptr::null(),
+            argv.as_ptr(),
+            envp.as_ptr(),
+            &[],
+        );
+        assert_eq!(
+            result,
+            Some(0),
+            "posix_spawn must accept the snapshotted script"
+        );
+
+        let mut status: c_int = 0;
+        // SAFETY: pid names the child execute_prepared_spawn just spawned, and status is a valid out-param for this thread's own waitpid call.
+        let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
+        assert_eq!(waited, pid, "must wait on the spawned child");
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "the script must run to completion"
+        );
+
+        let observed = fs::read_to_string(&output).expect("read recorded argv0");
+        let real_path = script.to_str().expect("script path");
+
+        // (a) The security assertion: the descriptor path is not the script's
+        // real path, so a script cannot recover the pathname the guard
+        // resolved at classification time from its own $0.
+        assert_ne!(
+            observed, real_path,
+            "the recorded $0 must not equal the script's real path"
+        );
+
+        // (b) The documented-property assertion: $0 has the descriptor shape
+        // the guard promises, covering both the execveat (/dev/fd) and the
+        // execve (/proc/self/fd) forms.
+        let is_descriptor_path = ["/proc/self/fd/", "/dev/fd/"].iter().any(|prefix| {
+            observed
+                .strip_prefix(prefix)
+                .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+        });
+        assert!(
+            is_descriptor_path,
+            "$0 must be a /proc/self/fd or /dev/fd descriptor path, got {observed:?}"
         );
 
         fs::remove_dir_all(&dir).expect("cleanup temp test dir");

--- a/runtime/container/rust/src/lib.rs
+++ b/runtime/container/rust/src/lib.rs
@@ -2491,9 +2491,9 @@ fn execute_snapshot_execveat(
 /// The `execvp` family form. glibc answers `ENOEXEC` by running `/bin/sh` on
 /// the target, from inside libc and without re-entering this guard, so the
 /// guard has to perform that fallback itself once it is executing a descriptor
-/// rather than a name. The shell's argv[1] is built from that same descriptor's
-/// proc path, so a shebang script run through this fallback likewise observes
-/// its /proc/self/fd name as $0, not the path the guard classified.
+/// rather than a name. For a script with no shebang line, the guard runs
+/// `/bin/sh` on that same descriptor, so this script also observes the
+/// /proc/self/fd name as $0, not the path the guard classified.
 #[cfg(target_os = "linux")]
 fn execute_snapshot_execveat_with_shell_fallback(
     fd: c_int,
@@ -5243,15 +5243,16 @@ mod tests {
         let dir = create_temp_test_dir("argv0-descriptor-path");
         let script = dir.join("script");
         let output = dir.join("output");
-        fs::write(
-            &script,
-            format!("#!/bin/sh\nprintf '%s' \"$0\" >{}\n", output.display()),
-        )
-        .expect("write script");
+        // The output path travels as argv[1] rather than baked into the
+        // script text, so a TMPDIR containing spaces or shell metacharacters
+        // cannot break the redirect: "$1" is a single shell word regardless
+        // of what it contains.
+        fs::write(&script, "#!/bin/sh\nprintf '%s' \"$0\" > \"$1\"\n").expect("write script");
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("chmod script");
 
         let arg0 = CString::new(script.as_os_str().as_bytes()).expect("script path");
-        let argv: [*const c_char; 2] = [arg0.as_ptr(), std::ptr::null()];
+        let output_arg = CString::new(output.as_os_str().as_bytes()).expect("output path");
+        let argv: [*const c_char; 3] = [arg0.as_ptr(), output_arg.as_ptr(), std::ptr::null()];
         let envp: [*const c_char; 1] = [std::ptr::null()];
 
         let mut pid: pid_t = 0;

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -4232,11 +4232,24 @@ EOF
     exit 1
   fi
   grep -q "Workcell blocked direct protected runtime execution" /tmp/workspace-env-shell-node-shebang.out
+  # The only positive workspace-shebang control in this block: every other row
+  # here asserts a refusal, this one asserts the guard actually runs the
+  # script, and that the script sees its snapshot's descriptor path rather
+  # than its own pathname as $0. The alternation covers both the execveat
+  # descriptor form (/dev/fd) and the ENOENT execve fallback (/proc/self/fd).
+  cat >"${workspace_exec_scratch}/.workcell-argv0-probe" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$0"
+EOF
+  chmod 0700 "${workspace_exec_scratch}/.workcell-argv0-probe"
+  "${workspace_exec_scratch}/.workcell-argv0-probe" >/tmp/workspace-argv0-probe.out 2>&1
+  grep -Eq '^(/proc/self/fd|/dev/fd)/[0-9]+$' /tmp/workspace-argv0-probe.out
   rm -f "${workspace_exec_scratch}/.workcell-node-shebang" "${workspace_exec_scratch}/.workcell-loader-node-shebang"
   rm -f "${workspace_exec_scratch}/.workcell-env-node-shebang" "${workspace_exec_scratch}/.workcell-env-loader-node-shebang" "${workspace_exec_scratch}/.workcell-env-path-node-shebang" "${workspace_exec_scratch}/.workcell-env-shell-node-shebang"
   rm -f "${workspace_exec_scratch}/shebang-bypass" "${workspace_exec_scratch}/workcell-child-envp-bypass.js"
   rm -f "${workspace_exec_scratch}/node"
   rm -f "${workspace_exec_scratch}/.workcell-native-helper"
+  rm -f "${workspace_exec_scratch}/.workcell-argv0-probe"
 		cp /usr/local/libexec/workcell/real/node "$EXEC_TMP/workcell-node-real-copy"
 	chmod 0700 "$EXEC_TMP/workcell-node-real-copy"
 	if "$EXEC_TMP/workcell-node-real-copy" --version >/tmp/node-real-copy.out 2>&1; then


### PR DESCRIPTION
## Summary

This is a zero-functional-change PR. It documents an already-shipped behavior of the strict-profile exec guard and locks it with tests; it does not alter behavior.

**The behavior.** On the strict path, the exec guard runs a mutable-path script (`/workspace`, `/state`, `/tmp`) from a sealed memfd copy and executes it by descriptor (`execute_snapshot_execveat` via `execveat(fd, "", AT_EMPTY_PATH)`, with an `execve("/proc/self/fd/N")` fallback; `execute_prepared_spawn`'s `posix_spawn` names the same `/proc/self/fd/N` path). Because the kernel's shebang handling names the interpreter's argv from the descriptor rather than the script's own path, a shebang script under a mutable exec root observes `$0` as `/dev/fd/<n>` or `/proc/self/fd/<n>`, not its real path. A script that locates a sibling file relative to `$0` will not find it; callers need an absolute path or an explicit argument instead.

**Why the real path isn't re-exposed.** Handing the interpreter the script's original pathname would give it a name to resolve a second time, after the guard already classified and sealed the bytes behind the descriptor. That reopens the exec-time TOCTOU the snapshot exists to close. Immutable-path scripts (e.g. under `/usr/local/bin`) are never copied and keep their real `$0`.

## Changes

- `runtime/container/rust/src/lib.rs`: two doc-comment sentences, above `execute_snapshot_execveat` and `execute_snapshot_execveat_with_shell_fallback`, naming this consequence at the two call sites that build the descriptor-named argv. No code change.
- `runtime/container/rust/src/lib.rs`: a new unit test, `a_snapshotted_script_sees_its_descriptor_path_as_argv_zero`. It writes a real `#!/bin/sh` fixture under a temp dir (a mutable exec root), drives it through `execute_prepared_spawn`, waits on the child, and asserts (a) the recorded `$0` is not the script's real path (the security property) and (b) it matches `^(/proc/self/fd|/dev/fd)/[0-9]+$` (the documented property). Gated on `current_mode_blocks_mutable_native_exec`, which fails closed to `true` off-container, so it runs on the ordinary test lane.
- `scripts/container-smoke.sh`: one positive workspace-shebang row. Every other row in that block asserts a refusal; this is the one row that expects the script to run successfully, and checks that its `$0` has the descriptor shape.
- `docs/workcell-system-design.md`: one paragraph appended to the `## Exec Guard` section describing the property and the workaround.

`runtime/container/rust/tests/loader_forms.rs` is untouched — `PENDING_FORMS` stays 3. That lane can only observe refusals from the loader-invocation matrix; it has no way to host a test that needs a successful exec's `$0`, which is what this property is about.

## Verification

Local (darwin):
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked --offline` all pass. The new test and its Linux-gated siblings are `#[cfg(target_os = "linux")]` and do not compile on darwin, so this only confirms the rest of the suite (29 tests) and that the crate still builds clean.
- `bash -n scripts/container-smoke.sh` and `shellcheck scripts/container-smoke.sh` are clean.
- `scripts/check-doc-language.sh` exits 0 with no new findings and no new `policy/doc-language-baseline.tsv` rows.
- `scripts/check-pr-shape.sh` passes (3 files, 114 lines, 3 areas).

Additionally verified for real on Linux, since the new test's assertions only execute there: ran `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --locked --offline` inside a `rust:1.97.1` container (matching `rust-toolchain.toml`). All 49 tests pass, including `a_snapshotted_script_sees_its_descriptor_path_as_argv_zero`, which actually snapshots and execs the fixture script and observes the descriptor path — and the pre-existing deterministic check/use tests (`a_replaced_pathname_no_longer_matches_its_descriptor` and siblings) still pass unchanged.

## Test plan

- [x] `cargo fmt --check` (darwin and Linux)
- [x] `cargo clippy --all-targets -- -D warnings` (darwin and Linux)
- [x] `cargo test --locked --offline` (darwin: 29 tests pass; Linux: 49 tests pass, including the new test)
- [x] `bash -n` and `shellcheck` on `scripts/container-smoke.sh`
- [x] `scripts/check-doc-language.sh` exits 0
- [x] `scripts/check-pr-shape.sh` passes