### PR TITLE
Add a backtick to the hostile tmpdir axis and fix the remaining env-sensitive tests

### DIFF
--- a/internal/host/c3certify/certify_test.go
+++ b/internal/host/c3certify/certify_test.go
@@ -581,7 +581,10 @@ func TestGitCommandDisablesRepositoryExecution(t *testing.T) {
 	// see testkit.ExecFixtureDir for why no single hardcoded path works.
 	fixtureRoot := testkit.ExecFixtureDir(t)
 	marker, hook := filepath.Join(fixtureRoot, "hook-ran"), filepath.Join(fixtureRoot, "hook.sh")
-	mustNoError(t, os.WriteFile(hook, []byte("#!/bin/sh\nprintf tracked >\""+marker+"\"\ncat\n"), 0o700))
+	// marker is shell-safe by construction (see ExecFixtureDir), but
+	// ShellQuote is used here as defense in depth rather than trusting a
+	// literal double-quoted splice to stay safe.
+	mustNoError(t, os.WriteFile(hook, []byte("#!/bin/sh\nprintf tracked >"+testkit.ShellQuote(marker)+"\ncat\n"), 0o700))
 	mustNoError(t, os.WriteFile(filepath.Join(workspace, ".gitattributes"), []byte("tracked filter=host\n"), 0o600))
 	runGit(t, workspace, "add", ".gitattributes")
 	runGit(t, workspace, "-c", "user.name=Workcell Test", "-c", "user.email=workcell-test@example.invalid", "commit", "--quiet", "-m", "attributes")

--- a/internal/startupbench/bench_test.go
+++ b/internal/startupbench/bench_test.go
@@ -293,9 +293,12 @@ func TestDriverStateHooksRunAtTheRequiredCadence(t *testing.T) {
 	logPath := filepath.Join(dir, "operations")
 	counter := func(name string) string {
 		helper := filepath.Join(dir, name)
+		// logPath is shell-safe by construction (see ExecFixtureDir), but
+		// ShellQuote is used here as defense in depth rather than trusting a
+		// literal double-quoted splice to stay safe.
 		writeExec(t, helper, "#!/usr/bin/env bash\n"+
 			"set -euo pipefail\n"+
-			"printf '"+name+"\\n' >> \""+logPath+"\"\n")
+			"printf '"+name+"\\n' >> "+testkit.ShellQuote(logPath)+"\n")
 		return helper
 	}
 	env := liveEnv(map[string]string{
@@ -377,8 +380,11 @@ func TestEntrypointSignalKillsProcessGroupAndStillCleansUp(t *testing.T) {
 	dir := shortDir(t)
 	started, childPID, cleaned := filepath.Join(dir, "started"), filepath.Join(dir, "child-pid"), filepath.Join(dir, "cleaned")
 	target, teardown := filepath.Join(dir, "target"), filepath.Join(dir, "teardown")
-	writeExec(t, target, "#!/usr/bin/env bash\ntrap '' TERM\nsh -c 'trap \"\" TERM; while :; do sleep 1; done' &\nprintf '%s\\n' \"$!\" >\""+childPID+"\"\ntouch \""+started+"\"\nwait\n")
-	writeExec(t, teardown, "#!/usr/bin/env bash\n[[ -n \"${WORKCELL_STARTUP_SAMPLE_TOKEN}\" && -z \"${WORKCELL_STARTUP_SESSION_ID}\" ]]\ntouch \""+cleaned+"\"\n")
+	// childPID, started, and cleaned are shell-safe by construction (see
+	// ExecFixtureDir), but ShellQuote is used here as defense in depth rather
+	// than trusting a literal double-quoted splice to stay safe.
+	writeExec(t, target, "#!/usr/bin/env bash\ntrap '' TERM\nsh -c 'trap \"\" TERM; while :; do sleep 1; done' &\nprintf '%s\\n' \"$!\" >"+testkit.ShellQuote(childPID)+"\ntouch "+testkit.ShellQuote(started)+"\nwait\n")
+	writeExec(t, teardown, "#!/usr/bin/env bash\n[[ -n \"${WORKCELL_STARTUP_SAMPLE_TOKEN}\" && -z \"${WORKCELL_STARTUP_SESSION_ID}\" ]]\ntouch "+testkit.ShellQuote(cleaned)+"\n")
 	env := liveEnv(map[string]string{"WORKCELL_STARTUP_MODES": "cold", "WORKCELL_STARTUP_ITERATIONS": "1", "WORKCELL_STARTUP_TEARDOWN": teardown})
 	env, argv := completeLiveFixture(t, env, []string{target})
 	cmd := exec.Command(filepath.Join(repoRoot(t), filepath.FromSlash(driver)), append([]string{"--"}, argv...)...)
@@ -413,7 +419,10 @@ func TestLifecycleFailuresAreJoinedAndVerifierGetsIndependentBudget(t *testing.T
 	dir := shortDir(t)
 	teardown, verify, verified := filepath.Join(dir, "teardown"), filepath.Join(dir, "verify"), filepath.Join(dir, "verified")
 	writeExec(t, teardown, "#!/usr/bin/env bash\nsleep 1\n")
-	writeExec(t, verify, "#!/usr/bin/env bash\ntouch \""+verified+"\"\nprintf 'absent session_id=%s sample_token=%s\\n' \"${WORKCELL_STARTUP_SESSION_ID}\" \"${WORKCELL_STARTUP_SAMPLE_TOKEN}\"\n")
+	// verified is shell-safe by construction (see ExecFixtureDir), but
+	// ShellQuote is used here as defense in depth rather than trusting a
+	// literal double-quoted splice to stay safe.
+	writeExec(t, verify, "#!/usr/bin/env bash\ntouch "+testkit.ShellQuote(verified)+"\nprintf 'absent session_id=%s sample_token=%s\\n' \"${WORKCELL_STARTUP_SESSION_ID}\" \"${WORKCELL_STARTUP_SAMPLE_TOKEN}\"\n")
 	cfg := config{target: []string{"false"}, teardown: teardown, cleanupCheck: verify, teardownTimeout: 50 * time.Millisecond, verifyTimeout: 2 * time.Second}
 	_, err := measureOne(context.Background(), cfg, "cold", 1, "1", io.Discard)
 	if err == nil {

--- a/internal/testkit/exec_fixture_dir.go
+++ b/internal/testkit/exec_fixture_dir.go
@@ -7,10 +7,20 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 )
+
+// shellSafePath matches a candidate base that is safe to splice as literal
+// text into generated shell script source (a double-quoted assignment, a
+// redirect target) as well as safe for a tool's own naive space-splitting.
+// This is an allowlist rather than a denylist of "$ and backtick": a
+// candidate can come from an ambient environment variable (XDG_RUNTIME_DIR)
+// that this package does not control, and a denylist only covers the
+// metacharacters someone remembered to name.
+var shellSafePath = regexp.MustCompile(`^[A-Za-z0-9_./-]+$`)
 
 // repoRoot returns the checkout root, derived from this file's own path at
 // compile time: a plain location that a hostile TMPDIR never touches.
@@ -26,14 +36,20 @@ func repoRoot(tb testing.TB) string {
 // ExecFixtureDir returns a directory for an executable test fixture (a
 // hook, filter, or remote helper a test writes and then has git, cmd/go, or
 // the shell actually invoke). Such a fixture needs a path that is all of:
-// writable by an arbitrary or unmapped uid, exec-capable, and free of
-// whitespace (a shell or a tool's own naive argument splitting can misread a
-// space). No single hardcoded location satisfies every supported
-// environment: the repo checkout can be unwritable under a remapped uid or
-// carry whitespace on some dev machines, a hardcoded /tmp is mounted noexec
-// inside the workcell container, and TMPDIR itself is deliberately hostile
-// under the CI lane that exercises that axis. So this probes candidates at
-// runtime and uses the first one that can actually execute a script.
+// writable by an arbitrary or unmapped uid, exec-capable, and shell-safe (a
+// shell's own re-interpolation, a tool's naive argument splitting, or a
+// caller that splices the returned path into generated shell script text can
+// all misread whitespace or a metacharacter such as $ or a backtick). No
+// single hardcoded location satisfies every supported environment: the repo
+// checkout can be unwritable under a remapped uid or carry whitespace on some
+// dev machines, a hardcoded /tmp is mounted noexec inside the workcell
+// container, and TMPDIR itself is deliberately hostile under the CI lane
+// that exercises that axis. So this probes candidates at runtime and uses
+// the first one that can actually execute a script.
+//
+// The returned path always matches shellSafePath, so a caller may still
+// choose to quote it (ShellQuote) as defense in depth, but does not have to
+// treat it as hostile.
 //
 // The repo checkout root is tried last, after /dev/shm and TMPDIR: under
 // the container's uidmap hostile axis the checkout is writable by every
@@ -67,8 +83,8 @@ func ExecFixtureDir(tb testing.TB) string {
 			tried = append(tried, c.name+": unset")
 			continue
 		}
-		if strings.ContainsAny(c.path, " \t\n") {
-			tried = append(tried, c.name+" ("+c.path+"): whitespace in path")
+		if !shellSafePath.MatchString(c.path) {
+			tried = append(tried, c.name+" ("+c.path+"): shell-unsafe path")
 			continue
 		}
 		if info, err := os.Stat(c.path); err != nil || !info.IsDir() {
@@ -99,6 +115,6 @@ func ExecFixtureDir(tb testing.TB) string {
 	// Every candidate failed: this is a real environment defect, not a
 	// reason to quietly drop coverage of whatever security control the
 	// fixture backs. Fail loudly rather than skip.
-	tb.Fatalf("no writable, exec-capable, whitespace-free directory found for executable test fixtures; tried:\n  %s", strings.Join(tried, "\n  "))
+	tb.Fatalf("no writable, exec-capable, shell-safe directory found for executable test fixtures; tried:\n  %s", strings.Join(tried, "\n  "))
 	return ""
 }

--- a/internal/testkit/git_hooks_test.go
+++ b/internal/testkit/git_hooks_test.go
@@ -654,7 +654,11 @@ func TestPrePushHookForwardsTransportAuthentication(t *testing.T) {
 	// The destination is reachable only through GIT_SSH_COMMAND, so the hook
 	// cannot read the advertisement without it. The walk then reaches the
 	// published unsigned base and refuses an otherwise valid new-ref push.
-	sshCommand := filepath.Join(fixture.homeDir, "fake-ssh")
+	// Git re-parses GIT_SSH_COMMAND's value as a shell command line, so the
+	// script needs a whitespace-free path rather than fixture.homeDir, which
+	// under the hostile TMPDIR axis carries a space that would otherwise
+	// split the command in two.
+	sshCommand := filepath.Join(ExecFixtureDir(t), "fake-ssh")
 	script := "#!/bin/bash\nexec /bin/sh -c \"${@: -1}\"\n"
 	if err := os.WriteFile(sshCommand, []byte(script), 0o755); err != nil {
 		t.Fatalf("write ssh command failed: %v", err)

--- a/internal/testkit/hosted_controls_token_isolation_test.go
+++ b/internal/testkit/hosted_controls_token_isolation_test.go
@@ -170,11 +170,11 @@ func prepareHostedControlCommandGraphFixture(t *testing.T, root string) {
 	copyHostedControlFixture(t, "scripts/lib/go-run-env.sh", filepath.Join(root, "scripts", "lib", "go-run-env.sh"))
 	copyHostedControlFixture(t, "go.mod", filepath.Join(root, "go.mod"))
 	// GO_BIN, GH_BIN, and JQ_BIN below are spliced as literal text into the
-	// generated shell script, not passed through a shell-quoted variable, so
-	// their path has to come from ExecFixtureDir rather than root: root is
-	// the hostile TMPDIR-derived t.TempDir() under the hostile-env lane, and
-	// a backtick spliced into that double-quoted assignment would run as a
-	// live command substitution when bash parses the script.
+	// generated shell script, so their path has to come from ExecFixtureDir
+	// rather than root: root is the hostile TMPDIR-derived t.TempDir() under
+	// the hostile-env lane. ExecFixtureDir's own path is shell-safe by
+	// construction, but the splice below still uses ShellQuote as defense in
+	// depth rather than trusting that invariant to hold forever.
 	binDir := ExecFixtureDir(t)
 	writeCanonicalFixture(t, filepath.Join(binDir, "go"), []byte(hostedControlFakeGo), 0o755)
 	writeCanonicalFixture(t, filepath.Join(binDir, "gh"), []byte(hostedControlFakeGH), 0o755)
@@ -191,9 +191,9 @@ func prepareHostedControlCommandGraphFixture(t *testing.T, root string) {
 		t.Fatal(err)
 	}
 	fixture := string(source)
-	fixture = strings.Replace(fixture, `GO_BIN="$(resolve_trusted_go_bin)"`, `GO_BIN="`+filepath.Join(binDir, "go")+`"`, 1)
-	fixture = strings.Replace(fixture, `GH_BIN="$(resolve_trusted_tool /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)"`, `GH_BIN="`+filepath.Join(binDir, "gh")+`"`, 1)
-	fixture = strings.Replace(fixture, `JQ_BIN="$(resolve_trusted_tool /opt/homebrew/bin/jq /usr/local/bin/jq /usr/bin/jq)"`, `JQ_BIN="`+filepath.Join(binDir, "jq")+`"`, 1)
+	fixture = strings.Replace(fixture, `GO_BIN="$(resolve_trusted_go_bin)"`, `GO_BIN=`+ShellQuote(filepath.Join(binDir, "go")), 1)
+	fixture = strings.Replace(fixture, `GH_BIN="$(resolve_trusted_tool /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)"`, `GH_BIN=`+ShellQuote(filepath.Join(binDir, "gh")), 1)
+	fixture = strings.Replace(fixture, `JQ_BIN="$(resolve_trusted_tool /opt/homebrew/bin/jq /usr/local/bin/jq /usr/bin/jq)"`, `JQ_BIN=`+ShellQuote(filepath.Join(binDir, "jq")), 1)
 	writeCanonicalFixture(t, filepath.Join(root, "scripts", "verify-github-hosted-controls.sh"), []byte(fixture), 0o755)
 }
 

--- a/internal/testkit/hosted_controls_token_isolation_test.go
+++ b/internal/testkit/hosted_controls_token_isolation_test.go
@@ -169,14 +169,21 @@ func prepareHostedControlCommandGraphFixture(t *testing.T, root string) {
 	copyHostedControlFixture(t, "scripts/lib/canonical-build-env.sh", filepath.Join(root, "scripts", "lib", "canonical-build-env.sh"))
 	copyHostedControlFixture(t, "scripts/lib/go-run-env.sh", filepath.Join(root, "scripts", "lib", "go-run-env.sh"))
 	copyHostedControlFixture(t, "go.mod", filepath.Join(root, "go.mod"))
-	writeCanonicalFixture(t, filepath.Join(root, "bin", "go"), []byte(hostedControlFakeGo), 0o755)
-	writeCanonicalFixture(t, filepath.Join(root, "bin", "gh"), []byte(hostedControlFakeGH), 0o755)
+	// GO_BIN, GH_BIN, and JQ_BIN below are spliced as literal text into the
+	// generated shell script, not passed through a shell-quoted variable, so
+	// their path has to come from ExecFixtureDir rather than root: root is
+	// the hostile TMPDIR-derived t.TempDir() under the hostile-env lane, and
+	// a backtick spliced into that double-quoted assignment would run as a
+	// live command substitution when bash parses the script.
+	binDir := ExecFixtureDir(t)
+	writeCanonicalFixture(t, filepath.Join(binDir, "go"), []byte(hostedControlFakeGo), 0o755)
+	writeCanonicalFixture(t, filepath.Join(binDir, "gh"), []byte(hostedControlFakeGH), 0o755)
 	jqPath, err := exec.LookPath("jq")
 	if err != nil {
 		t.Fatal(err)
 	}
 	jqFixture := strings.Replace(hostedControlFakeJQ, "@JQ_PATH@", jqPath, 1)
-	writeCanonicalFixture(t, filepath.Join(root, "bin", "jq"), []byte(jqFixture), 0o755)
+	writeCanonicalFixture(t, filepath.Join(binDir, "jq"), []byte(jqFixture), 0o755)
 	writeCanonicalFixture(t, filepath.Join(root, "citools-template"), []byte(hostedControlFakeCITools), 0o755)
 
 	source, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts", "verify-github-hosted-controls.sh"))
@@ -184,9 +191,9 @@ func prepareHostedControlCommandGraphFixture(t *testing.T, root string) {
 		t.Fatal(err)
 	}
 	fixture := string(source)
-	fixture = strings.Replace(fixture, `GO_BIN="$(resolve_trusted_go_bin)"`, `GO_BIN="`+filepath.Join(root, "bin", "go")+`"`, 1)
-	fixture = strings.Replace(fixture, `GH_BIN="$(resolve_trusted_tool /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)"`, `GH_BIN="`+filepath.Join(root, "bin", "gh")+`"`, 1)
-	fixture = strings.Replace(fixture, `JQ_BIN="$(resolve_trusted_tool /opt/homebrew/bin/jq /usr/local/bin/jq /usr/bin/jq)"`, `JQ_BIN="`+filepath.Join(root, "bin", "jq")+`"`, 1)
+	fixture = strings.Replace(fixture, `GO_BIN="$(resolve_trusted_go_bin)"`, `GO_BIN="`+filepath.Join(binDir, "go")+`"`, 1)
+	fixture = strings.Replace(fixture, `GH_BIN="$(resolve_trusted_tool /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh)"`, `GH_BIN="`+filepath.Join(binDir, "gh")+`"`, 1)
+	fixture = strings.Replace(fixture, `JQ_BIN="$(resolve_trusted_tool /opt/homebrew/bin/jq /usr/local/bin/jq /usr/bin/jq)"`, `JQ_BIN="`+filepath.Join(binDir, "jq")+`"`, 1)
 	writeCanonicalFixture(t, filepath.Join(root, "scripts", "verify-github-hosted-controls.sh"), []byte(fixture), 0o755)
 }
 

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -705,6 +705,9 @@ func TestHostileAxesKeepTheShapesThatReproducedFindings(t *testing.T) {
 	if !strings.Contains(tmpdir, "$") {
 		t.Fatalf("hostile TMPDIR %q has no unexpanded dollar sign", tmpdir)
 	}
+	if !strings.Contains(tmpdir, "`") {
+		t.Fatalf("hostile TMPDIR %q has no backtick component", tmpdir)
+	}
 	if !hasOptionToken(tmpdir) {
 		t.Fatalf("hostile TMPDIR %q has no --prefixed token", tmpdir)
 	}

--- a/internal/testkit/release_verify_test.go
+++ b/internal/testkit/release_verify_test.go
@@ -271,7 +271,11 @@ func TestVerifyReleaseArtifactPinsRequestedIdentities(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			binDir := stubBinDir(t, -1)
 			record := filepath.Join(t.TempDir(), "cosign-args")
-			cosign := "#!/bin/bash\nprintf '%s\\n' \"$@\" > " + record + "\nexit 0\n"
+			// record is unquoted shell text below, so it needs shQuote: under the
+			// hostile TMPDIR axis it can carry a space or a backtick, and an
+			// unquoted redirect target would split on the former and run the
+			// latter as a live command substitution.
+			cosign := "#!/bin/bash\nprintf '%s\\n' \"$@\" > " + shQuote(record) + "\nexit 0\n"
 			if err := os.WriteFile(filepath.Join(binDir, "cosign"), []byte(cosign), 0o755); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/testkit/security_boundary_test.go
+++ b/internal/testkit/security_boundary_test.go
@@ -424,7 +424,10 @@ func TestCheckPRShapeIgnoresAmbientGitConfig(t *testing.T) {
 	maliciousHome := maliciousRoot
 	maliciousMarker := filepath.Join(maliciousRoot, "diff.marker")
 	maliciousDiff := filepath.Join(maliciousRoot, "malicious-diff.sh")
-	if err := os.WriteFile(maliciousDiff, []byte("#!/bin/sh\nprintf 'unexpected diff.external invocation\\n' >\""+maliciousMarker+"\"\nexit 99\n"), 0o755); err != nil {
+	// maliciousMarker is shell-safe by construction (see ExecFixtureDir), but
+	// ShellQuote is used here as defense in depth rather than trusting a
+	// literal double-quoted splice to stay safe.
+	if err := os.WriteFile(maliciousDiff, []byte("#!/bin/sh\nprintf 'unexpected diff.external invocation\\n' >"+ShellQuote(maliciousMarker)+"\nexit 99\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(maliciousHome, ".gitconfig"), []byte("[diff]\n\texternal = "+maliciousDiff+"\n"), 0o644); err != nil {

--- a/scripts/ci/run-validate-in-validator.sh
+++ b/scripts/ci/run-validate-in-validator.sh
@@ -83,12 +83,16 @@ validator_cache="${validator_home}/.cache"
 validator_tmp="${validator_home}/.tmp"
 # The tmpdir axis points TMPDIR at a directory whose name carries the shapes
 # that have broken this repository under review: a space, a literal `$` that a
-# re-expanding generator would substitute, a `--`-prefixed component that a
-# substring flag check mistakes for an option, and ~80 characters of padding
-# that pushes any AF_UNIX path derived from TMPDIR past sun_path.  Three review
-# findings were first reproduced by hand this way.
+# re-expanding generator would substitute, a backtick that an unquoted
+# re-interpolation would run as a command substitution, a `--`-prefixed
+# component that a substring flag check mistakes for an option, and ~80
+# characters of padding that pushes any AF_UNIX path derived from TMPDIR past
+# sun_path.  Three review findings were first reproduced by hand this way; the
+# backtick adds a fourth shape without changing any of the others.  A
+# backtick is a legal filename character, so mkdir -p below still creates the
+# path; it is only hostile to code that re-interpolates the path unquoted.
 if [[ "${HOSTILE_ENV}" == "tmpdir" ]]; then
-  validator_tmp="${validator_tmp}/hostile \$HOME --hostname/$(printf 'p%.0s' {1..80})"
+  validator_tmp="${validator_tmp}/hostile \$HOME \`id\` --hostname/$(printf 'p%.0s' {1..80})"
 fi
 # The root and uidmap axes run as a uid that owns nothing in the bind mount,
 # and git refuses a repository owned by another uid: "detected dubious


### PR DESCRIPTION
Finishes the hostile-env lane: the tmpdir axis now includes a backtick, and the tests it exposed are fixed so all four hostile axes (tmpdir, workspace, root, uidmap) can go green.

## The backtick

`scripts/ci/run-validate-in-validator.sh` composed the tmpdir axis's TMPDIR from a space, a literal `$HOME`, a `--`-prefixed component, and ~80 padding characters, but nothing that a command-substitution-sensitive re-interpolation would run. Added a backtick to the "hostile $HOME" segment. It's a legal filename character, so `mkdir -p` still creates the path; it's only hostile to code that re-interpolates the path unquoted. The other three axes are byte-identical.

## What broke, and the fix

Reproduced locally on darwin by pointing `TMPDIR` at the exact backtick-hostile string and running `go test ./internal/... ./cmd/...`. Three tests failed — the same three flagged out-of-scope in PR #720, and (confirmed by testing without the backtick) they fail under any hostile TMPDIR shape, not specifically the backtick:

- `TestPrePushHookForwardsTransportAuthentication` (`git_hooks_test.go`): wrote a fake-ssh script under the fixture's home dir. Git re-parses `GIT_SSH_COMMAND`'s value as a shell command line, so a space in that path split it into two words. Moved the script to `testkit.ExecFixtureDir(t)`.
- `TestHostedControlsVerifierScopesDummyTokenToGitHubCommands` (`hosted_controls_token_isolation_test.go`): spliced `GO_BIN`/`GH_BIN`/`JQ_BIN` paths directly into a double-quoted assignment inside generated shell script text, so the backtick in the hostile root ran as a live command substitution when bash parsed it, corrupting `GO_BIN` and silently falling back to the real `go`. Moved just those three fixture binaries to `testkit.ExecFixtureDir(t)`.
- `TestVerifyReleaseArtifactPinsRequestedIdentities` (`release_verify_test.go`): built a shell redirect from an unquoted TempDir path. Wrapped it with the existing `shQuote` helper already used for this in `release_outputs_verify_test.go`.

Triage rule matches the merged PRs: each of these three lived in TMPDIR incidentally rather than testing hostile-input handling, so they became TMPDIR-agnostic instead of keeping a hostile fixture.

## Verification

`go test ./internal/... ./cmd/... ./tests/...` passes on darwin both under this exact backtick-hostile TMPDIR and under a normal TMPDIR. `gofmt -l ./internal` is empty, `go vet ./...` and `go build ./...` are clean.

No other test regressed from the backtick itself — the ~27 additional failures anticipated from prior analysis did not materialize in the Go suite on darwin. (One package, `internal/host/release`, does fail if TMPDIR is nested under a home directory carrying a pre-existing macOS ACL — an artifact of my local machine, unrelated to this axis or the backtick — so I validated from a `/tmp`-rooted hostile path instead, matching how the real script roots TMPDIR under `/tmp/workcell-home-<uid>`.)

The containerized Linux hostile lane itself (docker, shellcheck, the installer scripts) is not exercised here and remains CI-only — that's what the hostile-env GitHub Actions job will confirm. This PR does not change the lane's advisory `continue-on-error: true` status; promoting it to a required check is a follow-up for a separate decision.