### PR TITLE
Make the session-commands scenario filter survive a hostile TMPDIR

### DIFF
--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -103,7 +103,7 @@ EOF
 chmod +x "${WORKSPACE_A}/textconv.sh"
 cat >"${WORKSPACE_A}/filter.sh" <<EOF
 #!/bin/sh
-touch "${FILTER_MARKER}"
+touch '${FILTER_MARKER}'
 cat
 EOF
 chmod +x "${WORKSPACE_A}/filter.sh"
@@ -111,7 +111,7 @@ git -C "${WORKSPACE_A}" config diff.workcell.textconv "${WORKSPACE_A}/textconv.s
 git -C "${WORKSPACE_A}" config extensions.worktreeConfig true
 cat >"${FILTER_CONFIG}" <<EOF
 [filter "workcell-test"]
-	clean = ${WORKSPACE_A}/filter.sh
+	clean = '${WORKSPACE_A}/filter.sh'
 	smudge = cat
 EOF
 git -C "${WORKSPACE_A}" config --worktree include.path "${FILTER_CONFIG}"


### PR DESCRIPTION
## Summary

The advisory hostile-env CI lane's tmpdir axis fails `shared/session-commands` with:

```
error: external filter '.../workspace-a/filter.sh' failed 127
```

Root cause: the scenario registers a real git external clean filter as `clean = <absolute path to filter.sh>` in a git include file, with the path built from `TMPDIR`. Git runs external filter commands through `sh -c`, so any shell metacharacter in an unquoted path is reinterpreted by the shell instead of being treated as a literal filename. The tmpdir hostile-env axis composes `TMPDIR` with a space, a literal `$HOME`, a backtick command substitution, and padding (`scripts/ci/run-validate-in-validator.sh:~83-91`). Against that path, the unquoted filter command word-splits on the space, expands `$HOME`, and runs the backtick as a command substitution — so the shell can no longer find `filter.sh`, producing the observed `failed 127`.

This is not a noexec problem: the validator container that runs this scenario does not mount `/tmp` noexec (only workcell's own spawned session containers do that, via `container-smoke.sh`'s `--tmpfs /tmp:...noexec`). A local, byte-for-byte reproduction of the scenario's own git setup under a matching hostile `TMPDIR` reproduces the identical `failed 127` text purely from shell word-splitting/command-substitution, with no noexec mount involved.

## Fix

Single-quote the filter path in the `clean =` config line, so the value git hands to `sh -c` is one literal argument immune to `$`/backtick/space reinterpretation. The same class of bug existed one line above: `filter.sh`'s own body embedded the marker path inside a double-quoted `touch "..."`, which still lets `sh` expand `$HOME`/backticks when `filter.sh` itself runs; single-quoting that argument closes it too.

The scenario's intent is unchanged: it still exercises a real external git clean filter, and the existing assertions that `workcell session diff` must not trigger that filter are untouched.

## Verification

- Reproduced the CI-reported `error: external filter '...' failed 127` message character-for-character by extracting and running the scenario's exact git setup (`git init` / `git config .../filter.sh` / `git add`) under a hostile `TMPDIR` matching the CI axis composition (space, `$HOME`, backtick, padding).
- Confirmed the quoted form invokes `filter.sh` successfully with zero filter/touch errors under the same hostile path, both in isolation and via the real fixture lines (1-353) extracted verbatim from the scenario file, before and after the fix.
- `bash -n` and `shellcheck` clean on the touched file.
- Not verified locally: the full scenario's overall exit code inside the real validator container + Colima. This host (real Apple Silicon macOS) takes workcell's actual launch code path past this fixture, where CI's non-macOS validator container takes the lighter "launch not supported" branch instead — a divergence unrelated to this fix, present identically before and after it, and confirmable only in CI.

## Test plan

- [ ] CI tmpdir hostile-env axis reports `shared/session-commands` as PASS
- [x] `bash -n` and `shellcheck` clean locally
- [x] `scripts/check-pr-shape.sh` passes