### PR TITLE
Quote the textconv fixture path in the session-commands scenario

### DIFF
--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -97,7 +97,7 @@ WORKSPACE_B="$(cd "${WORKSPACE_B}" && pwd -P)"
 git -C "${WORKSPACE_A}" init >/dev/null
 cat >"${WORKSPACE_A}/textconv.sh" <<EOF
 #!/bin/sh
-touch "${TEXTCONV_MARKER}"
+touch '${TEXTCONV_MARKER}'
 cat "\$1"
 EOF
 chmod +x "${WORKSPACE_A}/textconv.sh"
@@ -107,7 +107,7 @@ touch '${FILTER_MARKER}'
 cat
 EOF
 chmod +x "${WORKSPACE_A}/filter.sh"
-git -C "${WORKSPACE_A}" config diff.workcell.textconv "${WORKSPACE_A}/textconv.sh"
+git -C "${WORKSPACE_A}" config diff.workcell.textconv "'${WORKSPACE_A}/textconv.sh'"
 git -C "${WORKSPACE_A}" config extensions.worktreeConfig true
 cat >"${FILTER_CONFIG}" <<EOF
 [filter "workcell-test"]


### PR DESCRIPTION
The tmpdir hostile-environment axis roots the scenario workspace under a TMPDIR that contains a space, a literal $HOME, and a backtick command substitution. PR #724 fixed the git external clean filter for this axis but left the sibling diff textconv fixture with the same defect, so the tmpdir axis still failed on shared/session-commands.

Git runs a textconv command through a shell. The scenario registered diff.workcell.textconv with an unquoted absolute path and wrote textconv.sh with a double-quoted marker path. Under the hostile TMPDIR the shell word-splits the path and runs the backtick as a command, so the textconv invocation fails.

This quotes both sites, mirroring the filter fix in #724: the textconv.sh marker touch now uses single quotes, and the diff.workcell.textconv value stores a single-quoted path. Scenario intent is unchanged.

Verified: bash -n and shellcheck clean. The full scenario runs only in the container tmpdir axis; the other three axes already pass.