### PR TITLE
Make the session-commands scenario pass under the hostile tmpdir axis

### DIFF
--- a/tests/scenarios/shared/test-session-commands.sh
+++ b/tests/scenarios/shared/test-session-commands.sh
@@ -1321,9 +1321,9 @@ grep -q '^SESSION_META_TARGET_PROVIDER=docker-desktop$' <<<"${monitor_env_output
 grep -q '^SESSION_META_TARGET_ID=desktop-linux$' <<<"${monitor_env_output}"
 grep -q '^SESSION_META_TARGET_ASSURANCE_CLASS=compat$' <<<"${monitor_env_output}"
 grep -q '^SESSION_MONITOR_READY_PATH=' <<<"${monitor_env_output}"
-grep -q '^XDG_STATE_HOME='"${TMP_DIR}/monitor-xdg-state"'$' <<<"${monitor_env_output}"
-grep -q '^WORKCELL_STATE_ROOT='"${TMP_DIR}/monitor-xdg-state/workcell"'$' <<<"${monitor_env_output}"
-grep -q '^WORKCELL_TARGET_STATE_ROOT='"${TMP_DIR}/monitor-xdg-state/workcell/targets"'$' <<<"${monitor_env_output}"
+grep -qxF "XDG_STATE_HOME=$(printf '%q' "${TMP_DIR}/monitor-xdg-state")" <<<"${monitor_env_output}"
+grep -qxF "WORKCELL_STATE_ROOT=$(printf '%q' "${TMP_DIR}/monitor-xdg-state/workcell")" <<<"${monitor_env_output}"
+grep -qxF "WORKCELL_TARGET_STATE_ROOT=$(printf '%q' "${TMP_DIR}/monitor-xdg-state/workcell/targets")" <<<"${monitor_env_output}"
 
 monitor_ready_probe_output="$(
   bash -lc '
@@ -1492,16 +1492,16 @@ bash -lc '
   "workspace_control_plane": "masked"
 }
 EOF_JSON
-    cat >"${STATE_FILE}" <<EOF_STATE
-SESSION_ID=${SESSION_ID}
-COLIMA_PROFILE=${PROFILE_NAME}
-CONTAINER_NAME=${CONTAINER_NAME}
-EXECUTION_PATH=managed-tier1
-SESSION_AUDIT_DIR=${SESSION_AUDIT_DIR}
-WORKCELL_STATE_ROOT=${WORKCELL_STATE_ROOT}
-WORKCELL_TARGET_STATE_ROOT=${WORKCELL_TARGET_STATE_ROOT}
-COLIMA_STATE_ROOT=${COLIMA_STATE_ROOT}
-EOF_STATE
+    {
+      printf "SESSION_ID=%q\n" "${SESSION_ID}"
+      printf "COLIMA_PROFILE=%q\n" "${PROFILE_NAME}"
+      printf "CONTAINER_NAME=%q\n" "${CONTAINER_NAME}"
+      printf "EXECUTION_PATH=%q\n" "managed-tier1"
+      printf "SESSION_AUDIT_DIR=%q\n" "${SESSION_AUDIT_DIR}"
+      printf "WORKCELL_STATE_ROOT=%q\n" "${WORKCELL_STATE_ROOT}"
+      printf "WORKCELL_TARGET_STATE_ROOT=%q\n" "${WORKCELL_TARGET_STATE_ROOT}"
+      printf "COLIMA_STATE_ROOT=%q\n" "${COLIMA_STATE_ROOT}"
+    } >"${STATE_FILE}"
     resolve_host_tool() { printf "/usr/bin/true\n"; }
     sanitize_host_docker_env() { :; }
     capture_session_audit_state() { :; }


### PR DESCRIPTION
## Problem

`shared/session-commands` failed only on the **tmpdir** hostile-env axis (`passed=16 failed=1`). That axis points `TMPDIR` at a directory whose name carries a space, a literal `$HOME`, and a backtick `` `id` `` command substitution (`scripts/ci/run-validate-in-validator.sh:~83-91`), and the scenario roots its **entire** workspace tree under `TMPDIR` (`TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/...")`). Two earlier piecemeal fixes (#724 clean filter, #725 diff textconv) did not reach the remaining breaks because the full scenario only executes inside the Linux validator container (macOS takes a different launch path), so they were never reproduced.

## Method — reproduced in-container

Built the validator image and ran **only** this scenario inside it under the real hostile `TMPDIR` (uid 501, `HOME`/`GOCACHE`/`GOMODCACHE` mirroring the harness), iterating with `bash -x` until it ran to completion. Under `set -e`, running to completion is proof there is no remaining break.

## Hostile-path sites found and fixed (both test-side defects)

1. **Monitor env-file assertions (3 lines).** The product writes the monitor env file with `printf '%s=%q\n'` (`scripts/workcell` `write_session_monitor_env_file`). The assertions grepped the **raw** workspace path, which mismatched once `%q` escaped the hostile characters. Now match the `%q`-quoted form with `grep -qxF`.
2. **docker-desktop monitor fixture state file.** The fixture hand-wrote `session-monitor.env` with a raw-interpolated heredoc and then had the product `source` it — the unquoted hostile path broke sourcing. Now emitted with `printf "%q"`, mirroring the product's own format, so it is safe to source. (The intermediate single-quoted `printf '…\n'` was additionally nested inside a single-quoted `bash -lc` body, which collapsed the newlines into literal `n`; double-quoted formats — the existing pattern in these blocks — avoid that.)

## Why spot-quoting, not re-rooting

Sibling scenarios and this one deliberately root `TMP_DIR` under `${TMPDIR}` and pass under the axis — exercising real code under hostile paths is the axis's purpose. Re-rooting would defeat it. Both breaks were genuine test bugs that now match the product's real contract, and `%q` is a no-op on benign paths, so the normal axes are unchanged.

## Verification (in-container)

- Hostile `TMPDIR`: scenario **runs to completion, exit 0** (was the sole failure before).
- Normal `TMPDIR`: scenario exit 0 — no regression.
- `bash -n` clean; `shellcheck` (validator image) clean.
- The axis composition in `run-validate-in-validator.sh` is unchanged (space + `$` + backtick preserved).

## Why this is comprehensive

The fix was driven by an actual in-container run to completion rather than fixing the first error and guessing, so every hostile-path break the scenario can hit on this axis is covered in one pass.
