### PR TITLE
Harden two transient CI build and test flakes

### DIFF
--- a/internal/metadatautil/pinnedinputs_docker.go
+++ b/internal/metadatautil/pinnedinputs_docker.go
@@ -491,7 +491,20 @@ RUN case "${BUILDARCH}" in \
       *) echo "Unsupported Go build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
     esac \
   && case "${TARGETARCH}" in amd64|arm64) ;; *) echo "Unsupported Go target architecture: ${TARGETARCH}" >&2; exit 1 ;; esac \
-  && node --dns-result-order=ipv4first -e 'const { createWriteStream } = require("node:fs"); const { Readable } = require("node:stream"); const { pipeline } = require("node:stream/promises"); (async () => { const response = await fetch(process.argv[1]); if (!response.ok) throw new Error("Go download HTTP status " + response.status); await pipeline(Readable.fromWeb(response.body), createWriteStream("/tmp/go.tar.gz")); })().catch((error) => { console.error(error.message); process.exit(1); });' "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz" \
+  && fetch_go_toolchain() { \
+       local attempt=""; \
+       for attempt in 1 2 3 4 5; do \
+         if node --dns-result-order=ipv4first -e 'const { createWriteStream } = require("node:fs"); const { Readable } = require("node:stream"); const { pipeline } = require("node:stream/promises"); (async () => { const response = await fetch(process.argv[1]); if (!response.ok) throw new Error("Go download HTTP status " + response.status); await pipeline(Readable.fromWeb(response.body), createWriteStream("/tmp/go.tar.gz")); })().catch((error) => { console.error(error.message); process.exit(1); });' "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz"; then \
+           return 0; \
+         fi; \
+         rm -f /tmp/go.tar.gz; \
+         if [[ "${attempt}" -eq 5 ]]; then \
+           return 1; \
+         fi; \
+         sleep "$((attempt * 5))"; \
+       done; \
+     } \
+  && fetch_go_toolchain \
   && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/go.tar.gz -C /usr/local \
   && rm -f /tmp/go.tar.gz

--- a/internal/testkit/local_docker_parity_test.go
+++ b/internal/testkit/local_docker_parity_test.go
@@ -509,10 +509,18 @@ func assertValidatorImagePrefixes(t *testing.T, images []string, prefix string) 
 	}
 }
 
+// writeExecutable writes body to dir/name and makes it executable. The write
+// happens at mode 0o644 and is fully closed before the exec bit is added, so
+// no writable file description on the inode is ever open while it is
+// executable -- writing directly at 0o755 leaves that window open and can
+// race a subsequent exec into ETXTBSY ("text file busy") on Linux.
 func writeExecutable(t *testing.T, dir, name, body string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return path

--- a/internal/testkit/release_outputs_verify_test.go
+++ b/internal/testkit/release_outputs_verify_test.go
@@ -201,7 +201,6 @@ func releaseOutputStubDriver(t *testing.T, opts stubOptions) (string, string, st
 	dir := t.TempDir()
 	cosignLog := filepath.Join(dir, "cosign.log")
 	ghLog := filepath.Join(dir, "gh.log")
-	driver := filepath.Join(dir, "verify-release-outputs-test-driver.sh")
 	script := fmt.Sprintf(`#!/bin/bash
 source %[1]s
 cosign_fail_glob=%[2]s
@@ -286,9 +285,7 @@ main "$@"
 		shQuote(opts.release.token),
 		shQuote(ghLog),
 	)
-	if err := os.WriteFile(driver, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	driver := writeExecutable(t, dir, "verify-release-outputs-test-driver.sh", script)
 	return driver, cosignLog, ghLog
 }
 
@@ -395,10 +392,7 @@ func TestVerifyReleaseOutputsIgnoresHostileBashStartup(t *testing.T) {
 	if unprivileged == string(content) {
 		t.Fatal("release verifier no longer uses a privileged Bash shebang")
 	}
-	copyPath := filepath.Join(t.TempDir(), "unprivileged-verify-release-outputs.sh")
-	if err := os.WriteFile(copyPath, []byte(unprivileged), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	copyPath := writeExecutable(t, t.TempDir(), "unprivileged-verify-release-outputs.sh", unprivileged)
 	runVerifyDriver(t, copyPath, nil, hostile)
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("dropping the privileged shebang did not run the startup file, so the control is vacuous (%v)", err)
@@ -525,9 +519,7 @@ func poisonedToolPath(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	for _, tool := range []string{"jq", "sha256sum", "awk", "find", "wc", "cat", "sort", "sed", "grep"} {
-		if err := os.WriteFile(filepath.Join(dir, tool), []byte("#!/bin/bash\nexit 3\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		writeExecutable(t, dir, tool, "#!/bin/bash\nexit 3\n")
 	}
 	return dir
 }
@@ -1122,12 +1114,9 @@ func TestFlagValueRejectsShortAliasOverride(t *testing.T) {
 // both guards under test reject before any signature verification.
 func runReleaseOutputsInventoryGuard(t *testing.T, dir string) (int, string) {
 	t.Helper()
-	driver := filepath.Join(t.TempDir(), "release-outputs-inventory-driver.sh")
 	script := fmt.Sprintf("#!/bin/bash\nsource %s\ncosign() { return 0; }\nmain \"$@\"\n",
 		ShellQuote(filepath.Join(repoRoot(t), "scripts", "verify-release-outputs.sh")))
-	if err := os.WriteFile(driver, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	driver := writeExecutable(t, t.TempDir(), "release-outputs-inventory-driver.sh", script)
 
 	digest := strings.Repeat("c", 40)
 	cmd := exec.Command(driver,

--- a/runtime/container/Dockerfile
+++ b/runtime/container/Dockerfile
@@ -206,7 +206,20 @@ RUN case "${BUILDARCH}" in \
       *) echo "Unsupported Go build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
     esac \
   && case "${TARGETARCH}" in amd64|arm64) ;; *) echo "Unsupported Go target architecture: ${TARGETARCH}" >&2; exit 1 ;; esac \
-  && node --dns-result-order=ipv4first -e 'const { createWriteStream } = require("node:fs"); const { Readable } = require("node:stream"); const { pipeline } = require("node:stream/promises"); (async () => { const response = await fetch(process.argv[1]); if (!response.ok) throw new Error("Go download HTTP status " + response.status); await pipeline(Readable.fromWeb(response.body), createWriteStream("/tmp/go.tar.gz")); })().catch((error) => { console.error(error.message); process.exit(1); });' "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz" \
+  && fetch_go_toolchain() { \
+       local attempt=""; \
+       for attempt in 1 2 3 4 5; do \
+         if node --dns-result-order=ipv4first -e 'const { createWriteStream } = require("node:fs"); const { Readable } = require("node:stream"); const { pipeline } = require("node:stream/promises"); (async () => { const response = await fetch(process.argv[1]); if (!response.ok) throw new Error("Go download HTTP status " + response.status); await pipeline(Readable.fromWeb(response.body), createWriteStream("/tmp/go.tar.gz")); })().catch((error) => { console.error(error.message); process.exit(1); });' "https://dl.google.com/go/go${GO_VERSION}.linux-${BUILDARCH}.tar.gz"; then \
+           return 0; \
+         fi; \
+         rm -f /tmp/go.tar.gz; \
+         if [[ "${attempt}" -eq 5 ]]; then \
+           return 1; \
+         fi; \
+         sleep "$((attempt * 5))"; \
+       done; \
+     } \
+  && fetch_go_toolchain \
   && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/go.tar.gz -C /usr/local \
   && rm -f /tmp/go.tar.gz


### PR DESCRIPTION
Both issues below are pre-existing, transient CI flakes (they cleared on rerun), not regressions. This lane is about to become a required merge gate, so both are worth hardening now.

1. The Go tarball download in the container-smoke build's apt-broker-builder stage (runtime/container/Dockerfile) used a node one-liner fetch with no retry. A single transient network blip failed the whole image build. It now retries up to 5 times with backoff, cleaning the partial download between attempts, mirroring the retry-loop shape the Debian-snapshot fetch already uses elsewhere in the same file. The sha256 integrity check still runs only after a completed download, and only after a final failed attempt does the build fail hard. Versions, SHAs, and URLs are unchanged. internal/metadatautil/pinnedinputs_docker.go carries a literal copy of this stage for pin review, so it moved in lockstep.

2. TestVerifyReleaseOutputsRejectsSymlinkedAssetsDir intermittently failed with ETXTBSY ("text file busy") when exec'ing a freshly written driver script. The race window was that a fixture script's exec bit was set at file-creation time (mode 0o755) rather than after the write was fully closed, so the executable bit and an open writable file description could momentarily coexist on the inode. internal/testkit's shared writeExecutable helper now writes at 0o644, lets the writer close, then chmods to 0o755, guaranteeing the write closes before the file becomes executable and before it is exec'd. Four call sites in internal/testkit/release_outputs_verify_test.go that built their own driver/stub scripts inline now route through this helper instead of duplicating the old write-with-mode pattern.