### PR TITLE
Require the hostile-environment axes as merge gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,11 @@ jobs:
     #   uidmap     the container runs as a uid that owns none of the bind and
     #              that the image has no passwd record for.
     #
-    # Advisory while the first failures are triaged: these jobs are deliberately
-    # absent from required_status_checks in policy/github-hosted-controls.toml
-    # and carry continue-on-error, so a red run reports without blocking a
-    # merge.  Gated on validate rather than pr-shape so the validator image
-    # layers are already in the shared buildx cache scope when these builds run.
-    continue-on-error: true
+    # Required merge gate: the four "Hostile environment (<axis>)" contexts are
+    # listed in required_status_checks in policy/github-hosted-controls.toml, so
+    # a red axis fails the job and blocks the merge.  Gated on validate rather
+    # than pr-shape so the validator image layers are already in the shared
+    # buildx cache scope when these builds run.
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -42,7 +42,7 @@ For an approved large adapter PR, use both required options:
 | --- | --- |
 | `bench.yml` | Measures exec-guard performance on a schedule or manual run. |
 | `ci-insights.yml` | Writes weekly flake and cost reports. See [CI reliability](ci-efficiency-and-reliability.md). |
-| `ci.yml` | Runs repository validation, smoke tests, reproducibility, install checks, PR-shape checks, and advisory hostile-environment reruns. |
+| `ci.yml` | Runs repository validation, smoke tests, reproducibility, install checks, PR-shape checks, and required hostile-environment reruns. |
 | `codeql.yml` | Scans the shipped Go, Rust, and JavaScript code. |
 | `docs.yml` | Checks spelling, links, contracts, and the man page. |
 | `fuzz.yml` | Runs extended Go and Rust fuzz tests. |
@@ -74,7 +74,7 @@ Git refuses a repository owned by another UID.
 `scripts/ci-plan.sh` runs Git with no configuration that could grant an exception, so the lane aligns the ownership.
 
 These shapes reproduce quoting, argument-boundary, mount-record, and `sun_path` defects before review.
-The lanes are advisory: they use `continue-on-error` and are not required checks.
+The lanes are required merge gates: each axis is a required status check, so a red axis blocks the merge.
 Run one axis on a host the same way the lane does, with Docker available:
 
 ```bash

--- a/internal/metadatautil/workflow_validation_test.go
+++ b/internal/metadatautil/workflow_validation_test.go
@@ -620,6 +620,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: true
+
+  hostile-env:
+    name: Hostile environment (${{ matrix.axis }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - axis: tmpdir
+          - axis: workspace
+          - axis: root
+          - axis: uidmap
+    steps:
+      - run: true
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(ci.yml) error = %v", err)
 	}
@@ -672,6 +685,10 @@ contexts = [
   "Reproducible build",
   "GitHub Actions lint",
   "GitHub Actions security analysis",
+  "Hostile environment (tmpdir)",
+  "Hostile environment (workspace)",
+  "Hostile environment (root)",
+  "Hostile environment (uidmap)",
 ]
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(policy.toml) error = %v", err)

--- a/internal/metadatautil/workflows.go
+++ b/internal/metadatautil/workflows.go
@@ -42,8 +42,9 @@ type workflowJob struct {
 	Environment struct {
 		Name string `yaml:"name"`
 	} `yaml:"environment"`
-	Permissions map[string]string `yaml:"permissions"`
-	Steps       []workflowStep    `yaml:"steps"`
+	Permissions map[string]string          `yaml:"permissions"`
+	Steps       []workflowStep             `yaml:"steps"`
+	Strategy    workflowLaneRawJobStrategy `yaml:"strategy"`
 }
 
 type workflowStep struct {
@@ -73,7 +74,15 @@ func CollectWorkflowJobNames(content []byte) ([]string, error) {
 		if name == "" {
 			continue
 		}
-		names = append(names, name)
+		// A matrix job's name: is a template such as "Hostile environment
+		// (${{ matrix.axis }})", and GitHub reports one check context per
+		// matrix leg.  Expand the template against matrix.include so every
+		// concrete leg name (e.g. "Hostile environment (tmpdir)") can match a
+		// required status-check context.  Non-matrix jobs expand to the single
+		// unchanged name.
+		for _, matrix := range workflowLaneExpandMatrix(job.Strategy.Matrix.Include) {
+			names = append(names, workflowLaneRenderJobName(name, matrix))
+		}
 	}
 	return names, nil
 }

--- a/policy/github-hosted-controls.toml
+++ b/policy/github-hosted-controls.toml
@@ -49,6 +49,10 @@ contexts = [
   "Dependency review",
   "GitHub Actions lint",
   "GitHub Actions security analysis",
+  "Hostile environment (tmpdir)",
+  "Hostile environment (workspace)",
+  "Hostile environment (root)",
+  "Hostile environment (uidmap)",
 ]
 
 [actions_policy]

--- a/policy/workflow-lane-policy.json
+++ b/policy/workflow-lane-policy.json
@@ -26,22 +26,22 @@
     "ci.yml/hostile-env[axis=root]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=root, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=root, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/hostile-env[axis=tmpdir]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=tmpdir, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=tmpdir, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/hostile-env[axis=uidmap]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=uidmap, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=uidmap, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/hostile-env[axis=workspace]": {
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=workspace, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=workspace, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]": {
       "profiles": ["pr-parity"],

--- a/policy/workflow-lanes.json
+++ b/policy/workflow-lanes.json
@@ -81,7 +81,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=root, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a container running as uid 0, where a chmod assertion and a write-only read assertion stop holding; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=root, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/hostile-env[axis=tmpdir]",
@@ -99,7 +99,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=tmpdir, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a TMPDIR whose name holds a space, a literal dollar sign, a --prefixed token and 80 characters of padding; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=tmpdir, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/hostile-env[axis=uidmap]",
@@ -117,7 +117,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=uidmap, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a container running as a uid that owns none of the bind and that the image has no passwd record for; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=uidmap, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/hostile-env[axis=workspace]",
@@ -135,7 +135,7 @@
       ],
       "authority": "github-only",
       "local_mode": "none",
-      "github_only_reason": "advisory rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it carries continue-on-error and is absent from required_status_checks while its first failures are triaged, so it never gates a PR or release and is not part of any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=workspace, which builds the validator image and selects the repo-core profile the hosted job uses"
+      "github_only_reason": "required rerun of repository validation under a bind source whose name holds a space and a comma, which the CSV --mount record has to survive; it is a required merge gate in required_status_checks that runs only on GitHub, with no local mirror and no place in any local profile plan; docs/github-workflows.md carries the local reproduction sequence for WORKCELL_HOSTILE_ENV=workspace, which builds the validator image and selects the repo-core profile the hosted job uses"
     },
     {
       "id": "ci.yml/install-verification[runner=macos-15,runner_label=macos-15]",


### PR DESCRIPTION
## What changed

Promotes the four hostile-environment CI axes from an advisory lane to **required merge gates**. PR #727 reduced the flakes that could trip them and all four axes have proven green together (tmpdir/workspace/root/uidmap).

- **`.github/workflows/ci.yml`** — removed `continue-on-error: true` from the `hostile-env` job so a red axis fails the job; rewrote the job comment to say the four contexts are now required. `max-parallel: 1` and everything else unchanged.
- **`policy/github-hosted-controls.toml`** — added the four contexts to `[required_status_checks].contexts`: `Hostile environment (tmpdir)`, `Hostile environment (workspace)`, `Hostile environment (root)`, `Hostile environment (uidmap)`.
- **`internal/metadatautil/workflows.go`** — validator mapping update (see below).
- **`internal/metadatautil/workflow_validation_test.go`** — added a matrix-job fixture to `TestCheckWorkflowsRecognizesRequiredJobNames` proving the four expanded leg contexts map through `CheckWorkflows`.
- **`policy/workflow-lane-policy.json` / `policy/workflow-lanes.json` / `docs/github-workflows.md`** — corrected the now-false "advisory / continue-on-error / not a required check" language to reflect the required gate (manifest regenerated from the source policy; `authority`/`local_mode` unchanged — both remain accurate).

## Matrix-mapping approach

`CheckWorkflows` requires each context string to match a collected workflow job name literally. The `hostile-env` job's `name:` is the template `Hostile environment (${{ matrix.axis }})`, which does not literally equal the four leg contexts — so a naive add would have failed the PR's own `Validate repository` check.

Following the repo's existing handling of matrix lanes, `CollectWorkflowJobNames` now expands a matrix job's `name:` template against `matrix.include`, reusing the existing `workflowLaneExpandMatrix` / `workflowLaneRenderJobName` helpers. Non-matrix jobs expand to their single unchanged name (no behavior change for the existing nine contexts). This yields exactly the four concrete leg names as matchable required contexts.

## Live ruleset

The live default-branch ruleset (`main-status-checks`) must add the same four contexts to its `required_status_checks` rule **before** the post-merge push-to-main hosted-controls run, which cross-checks live against this TOML. That update is applied **separately at merge time** — it is not part of this PR, and the PR's own required checks pass without it (the live cross-check does not run on PRs).